### PR TITLE
Added POSIX_TIMERS alternative for eval timer

### DIFF
--- a/src/GNUmakefile.in
+++ b/src/GNUmakefile.in
@@ -58,7 +58,8 @@ SRC=grammar.tab.c lex.c main.c rc.c interpret.c simulate.c file.c object.c \
   socket_efuns.c socket_ctrl.c qsort.c eoperators.c socket_err.c md.c \
   disassembler.c uvalarm.c $(STRFUNCS) \
   replace_program.c master.c function.c \
-  debug.c crypt.c applies_table.c add_action.c eval.c fliconv.c console.c
+  debug.c crypt.c applies_table.c add_action.c eval.c fliconv.c console.c \
+  posix_timers.c
 
 all: $(OBJDIR) cc.h main_build
 main_build2: $(DRIVER_BIN) addr_server portbind

--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -61,7 +61,8 @@ SRC=grammar.tab.c lex.c main.c rc.c interpret.c simulate.c file.c object.c \
   socket_efuns.c socket_ctrl.c qsort.c eoperators.c socket_err.c md.c \
   disassembler.c uvalarm.c $(STRFUNCS) \
   replace_program.c master.c function.c \
-  debug.c crypt.c add_action.c eval.c fliconv.c console.c applies_table.c
+  debug.c crypt.c add_action.c eval.c fliconv.c console.c applies_table.c \
+  posix_timers.c
 
 all: cc.h files main_build
 main_build2: $(DRIVER_BIN) addr_server portbind
@@ -82,7 +83,8 @@ OBJ=grammar.tab.o lex.o main.o rc.o interpret.o simulate.o file.o object.o \
   socket_efuns.o socket_ctrl.o qsort.o eoperators.o socket_err.o md.o \
   disassembler.o uvalarm.o $(STRFUNCS) \
   replace_program.o master.o function.o \
-  debug.o crypt.o add_action.o eval.o fliconv.o console.o applies_table.o
+  debug.o crypt.o add_action.o eval.o fliconv.o console.o applies_table.o \
+  posix_timers.o
 
 .c.o:
 	$(CC) $(CFLAGS) $(OPTIMIZE) -c $*.c

--- a/src/edit_source.c
+++ b/src/edit_source.c
@@ -1672,6 +1672,8 @@ static void handle_configure() {
         check_library("-lssl");
     if (lookup_define("PACKAGE_PCRE"))
         check_library("-lpcre");
+    if (lookup_define("POSIX_TIMERS"))
+        check_library("-lrt");
     fprintf(stderr, "Checking for flaky Linux systems ...\n");
     check_linux_libc();
 

--- a/src/eval.c
+++ b/src/eval.c
@@ -4,6 +4,7 @@
 #include "uvalarm.h"
 #include <time.h>
 #include "backend.h"
+#include "posix_timers.h"
 
 int outoftime = 0;
 struct timeval tv;
@@ -11,31 +12,38 @@ int lasttime;
 
 void set_eval(int etime){
 #ifndef WIN32
-  long diff;
-  gettimeofday(&tv, NULL);
-  if((diff = tv.tv_sec-current_time) > 1){
-	  diff *= 1000000;
-	  if(diff > max_cost*100L){
-		  //put some hard limit to eval times
-      debug(d_flag, ("difft:%ld, max_cost:%d", diff, max_cost));
-		  outoftime = 1;
-		  return;
-	  }
-  }
-  signal(SIGVTALRM, sigalrm_handler);
-  uvalarm(etime, 0);
+    long diff;
+    gettimeofday(&tv, NULL);
+    if((diff = tv.tv_sec-current_time) > 1){
+	diff *= 1000000;
+	if(diff > max_cost*100L){
+	    //put some hard limit to eval times
+	    debug(d_flag, ("difft:%ld, max_cost:%d", diff, max_cost));
+	    outoftime = 1;
+	    return;
+	}
+    }
+#ifdef POSIX_TIMERS
+    posix_eval_timer_set(etime);
+#else
+    signal(SIGVTALRM, sigalrm_handler);
+    uvalarm(etime, 0);
 #endif
-  outoftime = 0;
-
+#endif
+    outoftime = 0;
 }
 
 int get_eval(){
 #ifndef WIN32
-  struct timeval now;
-  gettimeofday(&now, NULL);
-  return max_cost - (1000000*(now.tv_sec - tv.tv_sec))-(now.tv_usec - tv.tv_usec);
+#ifdef POSIX_TIMERS
+    return posix_eval_timer_get();
 #else
-  return 100;
+    struct timeval now;
+    gettimeofday(&now, NULL);
+    return max_cost - (1000000*(now.tv_sec - tv.tv_sec))-(now.tv_usec - tv.tv_usec);
+#endif
+#else
+    return 100;
 #endif
 }
 

--- a/src/main.c
+++ b/src/main.c
@@ -14,6 +14,7 @@
 #include "socket_efuns.h"
 #include "master.h"
 #include "eval.h"
+#include "posix_timers.h"
 
 port_def_t external_port[5];
 
@@ -174,6 +175,13 @@ int main (int argc, char ** argv)
 	 * Initialize the microsecond clock.
 	 */
 	init_usec_clock();
+
+#ifdef POSIX_TIMERS
+	/*
+	 * Initialize the POSIX timers.
+	 */
+	init_posix_timers();
+#endif
 
 	/* read in the configuration file */
 

--- a/src/options.h
+++ b/src/options.h
@@ -910,5 +910,8 @@
 
 /* use struct keyword for lpc structs */
 #define STRUCT_STRUCT
+
+/* use POSIX timers for eval_cost */
+#define POSIX_TIMERS
 #endif
 

--- a/src/packages/GNUmakefile
+++ b/src/packages/GNUmakefile
@@ -1,6 +1,6 @@
 
-SRC=uids.c db.c compress.c math.c develop.c external.c contrib.c sockets.c async.c dwlib.c 
-OBJ=uids.$(O) db.$(O) compress.$(O) math.$(O) develop.$(O) external.$(O) contrib.$(O) sockets.$(O) async.$(O) dwlib.$(O) 
+SRC=dslib.c math.c develop.c matrix.c parser.c contrib.c sockets.c mudlib_stats.c 
+OBJ=dslib.$(O) math.$(O) develop.$(O) matrix.$(O) parser.$(O) contrib.$(O) sockets.$(O) mudlib_stats.$(O) 
 
 OBJ=$(addprefix $(OBJDIR)/,$(subst .c,.o,$(SRC)))
 

--- a/src/packages/Makefile
+++ b/src/packages/Makefile
@@ -1,6 +1,6 @@
 
-SRC=uids.c db.c compress.c math.c develop.c external.c contrib.c sockets.c async.c dwlib.c 
-OBJ=uids.$(O) db.$(O) compress.$(O) math.$(O) develop.$(O) external.$(O) contrib.$(O) sockets.$(O) async.$(O) dwlib.$(O) 
+SRC=dslib.c math.c develop.c matrix.c parser.c contrib.c sockets.c mudlib_stats.c 
+OBJ=dslib.$(O) math.$(O) develop.$(O) matrix.$(O) parser.$(O) contrib.$(O) sockets.$(O) mudlib_stats.$(O) 
 
 .c.$(O):
 	$(CC) $(CFLAGS) -I.. -c $*.c

--- a/src/packages/packages
+++ b/src/packages/packages
@@ -1,2 +1,2 @@
-SRC=uids.c db.c compress.c math.c develop.c external.c contrib.c sockets.c async.c dwlib.c 
-OBJ=uids.$(O) db.$(O) compress.$(O) math.$(O) develop.$(O) external.$(O) contrib.$(O) sockets.$(O) async.$(O) dwlib.$(O) 
+SRC=dslib.c math.c develop.c matrix.c parser.c contrib.c sockets.c mudlib_stats.c 
+OBJ=dslib.$(O) math.$(O) develop.$(O) matrix.$(O) parser.$(O) contrib.$(O) sockets.$(O) mudlib_stats.$(O) 

--- a/src/posix_timers.c
+++ b/src/posix_timers.c
@@ -1,0 +1,67 @@
+#include "std.h"
+
+#ifdef POSIX_TIMERS
+
+#include <signal.h>
+#include <time.h>
+#include "comm.h"
+#include "posix_timers.h"
+
+static timer_t eval_timer_id;
+
+/* Called by main() to initialize all timers (currently only eval_cost) */
+void init_posix_timers(void)
+{
+    struct sigevent sev;
+    struct sigaction sa;
+    int i;
+
+    /* This mimics the behavior of setitimer in uvalarm.c */
+    sev.sigev_signo = SIGVTALRM;
+    sev.sigev_notify = SIGEV_SIGNAL;
+    sev.sigev_value.sival_int = 0;
+
+    i = timer_create(CLOCK_THREAD_CPUTIME_ID, &sev, &eval_timer_id);
+    if (i < 0) {
+	perror("init_posix_timers: timer_create");
+	exit(-1);
+    }
+
+    sa.sa_handler = sigalrm_handler;
+    sigemptyset(&sa.sa_mask);
+    sa.sa_flags = 0;
+
+    i = sigaction(SIGVTALRM, &sa, NULL);
+    if (i < 0) {
+	perror("init_posix_timers: sigaction");
+	exit(-1);
+    }
+}
+
+/* Set the eval_timer to the given number of microseconds */
+void posix_eval_timer_set(int micros)
+{
+    struct itimerspec it;
+
+    it.it_interval.tv_sec = 0;
+    it.it_interval.tv_nsec = 0;
+
+    it.it_value.tv_sec = micros / 1000000;
+    it.it_value.tv_nsec = micros % 1000000 * 1000;
+
+    timer_settime(eval_timer_id, 0, &it, NULL);
+}
+
+/* Return the number of microseconds remaining on the eval_timer */
+int posix_eval_timer_get(void)
+{
+    struct itimerspec it;
+
+    if (timer_gettime(eval_timer_id, &it) < 0) {
+	return 100;
+    }
+
+    return it.it_value.tv_sec * 1000000 + it.it_value.tv_nsec / 1000;
+}
+
+#endif

--- a/src/posix_timers.h
+++ b/src/posix_timers.h
@@ -1,0 +1,10 @@
+#ifndef FLUFF_POSIX_TIMERS_H
+#define FLUFF_POSIX_TIMERS_H
+
+#ifdef POSIX_TIMERS
+void init_posix_timers(void);
+void posix_eval_timer_set(int micros);
+int posix_eval_timer_get(void);
+#endif
+
+#endif


### PR DESCRIPTION
Added timer_settime/timer_gettime alternative implementation
for eval_cost.  This fixes the issue where get_eval returns
negative numbers when the elapsed wall time is greater than
the CPU time spent.

The reason for using POSIX timers rather than merely adding
a getitimer() call to the default implementation is better
precision.  On Linux, the values returned by getitimer()
are rounded off to the nearest jiffy (1/250 of a second),
whereas the POSIX timers have nanosecond precision.
