### PR TITLE
Crypto package multiple fixes and enhancements

### DIFF
--- a/src/edit_source.c
+++ b/src/edit_source.c
@@ -1676,6 +1676,8 @@ static void handle_configure() {
         check_library("-lssl");
     if (lookup_define("PACKAGE_PCRE"))
         check_library("-lpcre");
+    if (lookup_define("PACKAGE_CRYPTO"))
+        check_library("-lcrypto");
     if (lookup_define("POSIX_TIMERS"))
         check_library("-lrt");
     fprintf(stderr, "Checking for flaky Linux systems ...\n");


### PR DESCRIPTION
- Fixed build issue with newer openssl where support for hash
  functions such as MD2 can be conditionally disabled
- Added -lcrypto to edit_source.c when PACKAGE_CRYPTO is enabled
- Efficiency improvements to the hexdump function
- Fixed improper use of strlen on byte-counted strings
- Fixed memory leak of error string on "unknown hash" error
- Fixed memory corruption from storing the wrong type of malloced
  memory on the stack
- Added support for sha512, sha384, sha256, and sha224
