### PR TITLE
Added protection against immediate call_out loops

### DIFF
--- a/src/testsuite/etc/config.test
+++ b/src/testsuite/etc/config.test
@@ -73,7 +73,8 @@ maximum local variables : 30
 
 # Maximum amount of "eval cost" per thread - execution is halted when 
 # it is exceeded.
-maximum evaluation cost : 0x7fffffffff
+# This must be reasonably small for the call_out tests to finish.
+maximum evaluation cost : 500000
 
 # This is the maximum array size allowed for one single array.
 maximum array size : 15000

--- a/src/testsuite/single/master.c
+++ b/src/testsuite/single/master.c
@@ -249,6 +249,13 @@ staticf void error_handler(mapping map, int flag) {
   object ob;
   string str;
 
+  /* Squelch the expected eval_cost errors thrown by the call_out tests */
+  if (map["program"] == "/single/tests/efuns/call_out.c" &&
+      map["error"] == "*Too long evaluation. Execution aborted.\n")
+  {
+      return;
+  }
+
   ob = this_interactive() || this_player();
   if (flag) str = "*Error caught\n";
   else str = "";

--- a/src/testsuite/single/tests/efuns/call_out.c
+++ b/src/testsuite/single/tests/efuns/call_out.c
@@ -5,42 +5,104 @@ object tp;
 #define TPIC
 #endif
 
-int called;
+int busy = 0;
+mapping called;
 
 void no_args() {
-    called++;
+    called["basic_tests"]++;
     TPIC;
 }
 
 void one_arg(int x) {
-    called++;
+    called["basic_tests"]++;
     TPIC;
     ASSERT(x == 1);
 }    
 
 void two_arg(int x, int y) {
-    called++;
+    called["basic_tests"]++;
     TPIC;
     ASSERT(x == 1);
     ASSERT(y == 2);
 }
 
+void spin() {
+    called["spin"]++;
+    while (1) { }
+}
+
+void call_multiple(string func, int count) {
+    called["call_multiple"]++;
+    while (count--) {
+	call_out(func, 0);
+    }
+}
+
+int get_eval_cost_and_wait_for_clock_tick() {
+    int cost = eval_cost();
+    while (cost && cost == eval_cost()) {
+    }
+    return cost;
+}
+
+/* The (cost < last_cost) invariant in call_out_recursive only holds
+ * after the first few recursive calls:
+ *     call_out_recursive_setup(0)    // full time budget
+ *     \_call_out_recursive_setup(1)  // full time budget
+ *       \_call_out_recursive(...)    // leftover time budget...
+ *         \_call_out_recursive(...)  // leftover time budget...
+ */
+void call_out_recusrive_setup(int depth) {
+    int cost;
+    if (depth < 1) {
+	call_out("call_out_recursive_setup", 0, depth + 1);
+    } else {
+	call_out("call_out_recursive", 0, get_eval_cost_and_wait_for_clock_tick());
+    }
+}
+
+void call_out_recursive(int last_cost) {
+    int cost = get_eval_cost_and_wait_for_clock_tick();
+    ASSERT(cost < last_cost);
+    call_out("call_out_recursive", 0, cost, 0);
+}
+
 void finish() {
-    ASSERT(called == 6);
+    busy = 0;
+    ASSERT(called["basic_tests"] == 6);
+    ASSERT(called["spin"] == 3);
+    ASSERT(called["call_multiple"] == 1);
 }
 
 void do_tests() {
     mixed calls, call;
 
+    if (busy) {
+	write("The call_out test is busy.  Try again later!\n");
+	return;
+    }
+    busy = 1;
+
     tp = this_player();
-    called = 0;
+    called = ([ ]);
     call_out( (: no_args :), 1);
     call_out( "no_args", 2);
     call_out( (: one_arg, 1 :), 3);
     call_out( "one_arg", 4, 1);
     call_out( (: two_arg, 1 :), 5, 2);
     call_out( "two_arg", 6, 1, 2);
-    call_out( "finish", 10);
+
+    /* All call_outs set up here should be called sucessfully */
+    call_out( "spin", 0);
+    call_out( "spin", 0);
+
+    /* Only one of the recursively created call_outs should succeed */
+    call_out( "call_multiple", 0, "spin", 5);
+
+    /* This should eventually time out */
+    call_out( "call_out_recursive_setup", 1, 0);
+
+    call_out( "finish", 7);
     
     calls = call_out_info();
     foreach(call in calls) {


### PR DESCRIPTION
Fixed eval cost error detection within call_out() (changed
max_eval_error to outoftime, because the error handler
always clears the max_eval_error flag before jumping out.)

Added protection against infinite loops caused by call_out
functions recursively adding new 0-second call_outs.  Only
those call_outs which were initially scheduled will receive
the full max_cost budget; any new call_outs added will run
under a single, shared budget.  This protects the driver
from being wedged when infinite call_out loops happen.

fixes issue #16
