### PR TITLE
Auto dump backtrace when driver crash.

### DIFF
--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -86,7 +86,7 @@ grammar.tab.c: grammar.y
 
 $(DRIVER_BIN): $(OBJ) dtrace_compile
 	-mv -f $(DRIVER_BIN) $(DRIVER_BIN).old
-	$(CC) $(CFLAGS) $(OBJ) packages/*.$(O) `./dtrace_compile` -o $(DRIVER_BIN) `cat system_libs`
+	$(CC) -rdynamic $(CFLAGS) $(OBJ) packages/*.$(O) `./dtrace_compile` -o $(DRIVER_BIN) `cat system_libs`
 
 dtrace_compile: dtrace_compile.c local_options
 	$(CC) dtrace_compile.c -o dtrace_compile

--- a/src/edit_source.c
+++ b/src/edit_source.c
@@ -1458,6 +1458,7 @@ static void handle_configure() {
     check_include("INCL_CRYPT_H", "crypt.h");
     check_include("INCL_MALLOC_H", "my_malloc.h");
     check_include("INCL_ALLOCA_H", "alloca.h");
+    check_include("INCL_EXECINFO_H", "execinfo.h");
 
     /* for NeXT */
     if (!check_include("INCL_MACH_MACH_H", "mach/mach.h"))

--- a/src/simulate.c
+++ b/src/simulate.c
@@ -1559,18 +1559,22 @@ void fatal (const char *fmt, ...)
       debug_message("(current object was /%s)\n", current_object->obname);
 
     dump_trace(1);
-
 #ifdef PACKAGE_MUDLIB_STATS
-        save_stat_files();
+    save_stat_files();
 #endif
   case 1:
     in_fatal = 2;
+#ifdef TRAP_CRASHES
     copy_and_push_string(msg_buf);
     push_object(command_giver);
     push_object(current_object);
     safe_apply_master_ob(APPLY_CRASH, 3);
     debug_message("crash() in master called successfully.  Aborting.\n");
+#endif /* TRAP_CRASHES */
   }
+
+  in_fatal = 0;
+
   /* Make sure we don't trap our abort() */
 #ifdef SIGABRT
   signal(SIGABRT, SIG_DFL);
@@ -1582,10 +1586,9 @@ void fatal (const char *fmt, ...)
   signal(SIGIOT, SIG_DFL);
 #endif
 
-#if !defined(DEBUG_NON_FATAL) || !defined(DEBUG)
+#if !defined(DEBUG_NON_FATAL)
   abort();
 #endif
-  in_fatal = 0;
 }
 
 static int num_error = 0;

--- a/src/std_incl.h
+++ b/src/std_incl.h
@@ -115,6 +115,10 @@ int dos_style_link (char *, char *);
 #include <bstring.h>
 #endif
 
+#ifdef INCL_EXECINFO_H
+#include <execinfo.h>
+#endif
+
 /* Note: This is now only used if _both_ USHRT_MAX and MAXSHORT fail to exist*/
 #ifndef USHRT_MAX
 #define USHRT_MAX ((1 << (sizeof(short)*8)) - 1)


### PR DESCRIPTION
Also warn on startup if RLIMIT_CORE is set to 0, no core will be produced.
