### PR TITLE
Reverse Defer

### DIFF
--- a/src/options.h
+++ b/src/options.h
@@ -949,4 +949,13 @@
  */
 #define POSIX_TIMERS
 
+/*
+  REVERSE_DEFER: 
+  
+  If not defined executes defer functions in LIFO mode.
+  
+  If defined executes defer functions in FIFO mode.
+*/
+#define REVERSE_DEFER
+
 #endif /* _OPTIONS_H */

--- a/src/testsuite/single/tests/efuns/defer.c
+++ b/src/testsuite/single/tests/efuns/defer.c
@@ -1,0 +1,28 @@
+object tp;
+int *result;
+
+void my_func(int num){
+  result += ({ num });
+
+  // this_player check.
+  ASSERT(this_player() == tp);
+
+  // Reverse defer: last result = max result
+#ifdef __REVERSE_DEFER__
+  ASSERT_EQ(max(result), num);
+  // Normal defer: last result = min result
+#else
+  ASSERT_EQ(min(result), num);
+#endif
+}
+
+void do_tests() {
+  // This function is call 3 times, so I reset global here or crash ASSERT_EQ.
+  result = ({ });
+  tp == this_player();
+
+  // In normal mode, second defer is executed first.
+  // In reverse mode, first defer is executed first.
+  defer((: my_func, 1 :));
+  defer((: my_func, 2 :));
+}


### PR DESCRIPTION
Defer efuns executes functions in lifo mode (The last function that i added with defer efun, is executed first)

I think that execute those functions in fifo mode will be useful, so i've modified this efun for this purpose.

I added defined REVERSE_DEFER in options.h for compatibility with original efun. My english is very bad, if you accept this change, could you write a good comment in this define, please?

I've wrote defer efun tests in testsuite too.

I hope this change it's useful. If don't, no matter!
