### PR TITLE
terminal_colour_text

### DIFF
--- a/ChangeLog.fluffos-3.x
+++ b/ChangeLog.fluffos-3.x
@@ -49,6 +49,9 @@ Known Issues:
 ================================================================================
   Per-release ChangeLog
 ================================================================================
+FluffOS 3.0-alpha6.5
+  * Fixed efun terminal_colour for allow use the return string from terminal_colour_replace apply correctly when it isn't ansi color.
+
 FluffOS 3.0-alpha6.4
   * Fixed efun present() issue for object id that ends with digits, added test.
 

--- a/src/packages/contrib.cc
+++ b/src/packages/contrib.cc
@@ -730,6 +730,7 @@ f_terminal_colour(void)
     repused = 0;
     copy_and_push_string(parts[i]);
     svalue_t *reptmp = apply(APPLY_TERMINAL_COLOUR_REPLACE, current_object, 1, ORIGIN_EFUN);
+
     if (reptmp && reptmp->type == T_STRING) {
       rep = (char *)alloca(SVALUE_STRLEN(reptmp) + 1);
       strcpy(rep, reptmp->u.string);
@@ -765,11 +766,18 @@ f_terminal_colour(void)
       if (!elt) { //end of for loop, so not found!
         if (repused) {
           parts[i] = rep;
-          lens[i] = wrap ? -SVALUE_STRLEN(reptmp) : SVALUE_STRLEN(reptmp);
-          if (curcolourlen + SVALUE_STRLEN(reptmp) < MAX_COLOUR_STRING - 1) {
-            strcat(curcolour, rep);
-            curcolourlen += SVALUE_STRLEN(reptmp);
+
+          // First Character is scape character.
+          if(rep[0] == 27) {
+            lens[i] = wrap ? -SVALUE_STRLEN(reptmp) : SVALUE_STRLEN(reptmp);
+            if (curcolourlen + SVALUE_STRLEN(reptmp) < MAX_COLOUR_STRING - 1) {
+              strcat(curcolour, rep);
+              curcolourlen += SVALUE_STRLEN(reptmp);
+            }
           }
+          // Only Text.
+          else
+            lens[i] = SVALUE_STRLEN(reptmp);
         } else {
           lens[i] = SHARED_STRLEN(cp);
         }
@@ -777,11 +785,18 @@ f_terminal_colour(void)
     } else {
       if (repused) {
         parts[i] = rep;
-        lens[i] = wrap ? -SVALUE_STRLEN(reptmp) : SVALUE_STRLEN(reptmp);
-        if (curcolourlen + SVALUE_STRLEN(reptmp) < MAX_COLOUR_STRING - 1) {
-          strcat(curcolour, rep);
-          curcolourlen += SVALUE_STRLEN(reptmp);
+
+        // First Character is scape character.
+        if(rep[0] == 27) {
+          lens[i] = wrap ? -SVALUE_STRLEN(reptmp) : SVALUE_STRLEN(reptmp);
+          if (curcolourlen + SVALUE_STRLEN(reptmp) < MAX_COLOUR_STRING - 1) {
+            strcat(curcolour, rep);
+            curcolourlen += SVALUE_STRLEN(reptmp);
+          }
         }
+        // Only Text.
+        else
+          lens[i] = SVALUE_STRLEN(reptmp);
       } else {
         lens[i] = strlen(parts[i]);
       }


### PR DESCRIPTION
A little change for sustitute texts with terminal_colour system.

In previous version, if apply terminal_colour_replace returns a text (not colour), in every new line, line starts with the last text retuns in that apply.

Example:
string terminal_colour_replace(string tx){
   if(tx == "ME")
      return this_object()->query_cap_name();
}

User text: say Hello, I'm %^YO_MISMO%^ and then bla bla bla bla bla bla bla bla bla bla bla bla bla bla bla bla bla bla bla bla bla bla bla bla

Output in term with 75 cols length:
Dices en elfico: Hello, I'm Zoilder and then bla bla bla bla bla bla bla bla bla
Zoilder     bla bla bla bla bla bla bla bla bla bla bla bla bla bla bla
Zoilder/obj> 

In every line, it writes text returns by apply, because this system is for return only colours codes.

With my modification, if this apply doesn't returns a string, then executes second apply (terminal_colour_replace_text) and if it returns a string, it uses that text instead original.

Example:
string terminal_colour_replace_text(string tx){
   if(tx == "ME")
      return this_object()->query_cap_name();
}

User text: say Hello, I'm %^ME%^ and then bla bla bla bla bla bla bla bla bla bla bla bla bla bla bla bla bla bla bla bla bla bla bla bla

Output with 75 cols length:
Dices en elfico: Hello, I'm Zoilder and then bla bla bla bla bla bla bla
     bla bla bla bla bla bla bla bla bla bla bla bla bla bla bla bla bla

terminal_colour_replace : returns colour codes.
terminal_colour_replace_text: returns replace text.

it uses 2 applies for differentiate colour codes from texts.

Thank you very much.
