### PR TITLE
support the RANDOMIZED_RESETS option

### DIFF
--- a/src/local_options.pkuxkx
+++ b/src/local_options.pkuxkx
@@ -326,7 +326,7 @@
 
 #undef SANE_SORTING
 
-#undef STRUCT_CLASS
+#define STRUCT_CLASS
 
 #undef CALLOUT_LOOP_PROTECTION
 
@@ -423,6 +423,14 @@
  *   reloaded that otherwise would).
  */
 #undef LAZY_RESETS
+
+/* RANDOMIZED_RESETS: if this is defined, the reset() will be called in randomized
+ *   time interval. The interval vary from TIME_TO_RESET/2 to TIME_TO_RESET-1 .
+ *   if this is undefined, the reset() will be called among all objects at the same time,
+ *   with the interval as TIME_TO_RESET
+*/
+#undef RANDOMIZED_RESETS
+
 
 /* SAVE_EXTENSION: defines the file extension used by save_object().
  *   and restore_object().  Some sysadmins run scripts that periodically

--- a/src/object.cc
+++ b/src/object.cc
@@ -1977,8 +1977,12 @@ object_t *get_empty_object(int num_var)
 void reset_object(object_t *ob)
 {
   /* Be sure to update time first ! */
+#ifdef RANDOMIZED_RESETS
   ob->next_reset = current_time + TIME_TO_RESET / 2 +
                    random_number(TIME_TO_RESET / 2);
+#else
+    ob->next_reset = current_time + TIME_TO_RESET;
+#endif
 
   save_command_giver(0);
   if (!apply(APPLY_RESET, ob, 0, ORIGIN_DRIVER)) {

--- a/src/options.h
+++ b/src/options.h
@@ -299,6 +299,14 @@
  */
 #undef LAZY_RESETS
 
+
+/* RANDOMIZED_RESETS: if this is defined, the reset() will be called in randomized
+ *   time interval. The interval vary from TIME_TO_RESET/2 to TIME_TO_RESET-1 .
+ *   if this is undefined, the reset() will be called among all objects at the same time,
+ *   with the interval as TIME_TO_RESET
+*/
+#define RANDOMIZED_RESETS
+
 /* SAVE_EXTENSION: defines the file extension used by save_object().
  *   and restore_object().  Some sysadmins run scripts that periodically
  *   scan for and remove files ending in .o (but many mudlibs are already


### PR DESCRIPTION
Some muds want to reset all the objects at the same time, while some other muds do not want this to avoid CPU peak. The latter is the default design of fluffos. 
New option: RANDOMIZED_RESETS is introduced to enable user choose different behave. 
