### PR TITLE
Correctly push/pop error context for user events.

### DIFF
--- a/src/event.cc
+++ b/src/event.cc
@@ -99,15 +99,16 @@ static void on_user_command(evutil_socket_t fd, short what, void *arg)
   // FIXME: this function currently calls into mudlib and will throw errors
   // This catch block should be moved one level down.
   error_context_t econ;
+  if (!save_context(&econ)) {
+    fatal("BUG: on_user_comamnd can not save context!");
+  }
+  set_eval(max_cost);
   try {
-    if (!save_context(&econ)) {
-      fatal("BUG: on_user_comamnd can not save context!");
-    }
-    set_eval(max_cost);
     process_user_command(user);
   } catch (const char *)  {
     restore_context(&econ);
   }
+  pop_context(&econ);
 
   /* Has to be cleared if we jumped out of process_user_command() */
   current_interactive = 0;

--- a/src/reclaim.cc
+++ b/src/reclaim.cc
@@ -10,6 +10,7 @@
 #include "reclaim.h"
 #include "call_out.h"
 #include "backend.h"
+#include "port.h"
 
 #include <functional>
 
@@ -117,7 +118,7 @@ gc_mapping(mapping_t *m)
 int reclaim_objects(bool is_auto)
 {
   if (is_auto) {
-    add_tick_event(30 * 60, tick_event::callback_type(std::bind(reclaim_objects, true)));
+    add_tick_event(30 + random_number(30), tick_event::callback_type(std::bind(reclaim_objects, true)));
   }
   int i;
   object_t *ob;


### PR DESCRIPTION
Also make reclaim run every minutes, due to high churn.
