### PR TITLE
Define for MYSQL Fetch NewDecimal Type

### DIFF
--- a/src/packages/db.cc
+++ b/src/packages/db.cc
@@ -720,6 +720,7 @@ static array_t *MySQL_fetch(dbconn_t *c, int row)
         case FIELD_TYPE_TINY:
         case FIELD_TYPE_SHORT:
         case FIELD_TYPE_DECIMAL:
+        case FIELD_TYPE_NEWDECIMAL:
         case FIELD_TYPE_LONG:
         case FIELD_TYPE_INT24:
         case FIELD_TYPE_LONGLONG:


### PR DESCRIPTION
This is needed in my system for read a column SUM(xxx) in a SELECT.
