### PR TITLE
Small fix in regexp.cc

### DIFF
--- a/src/regexp.cc
+++ b/src/regexp.cc
@@ -60,6 +60,7 @@
 #include "lpc_incl.h"
 #include "comm.h"
 #include "ed.h"
+#include "outbuf.h"
 
 /*
  * The "internal use only" fields in regexp.h are present to pass info from


### PR DESCRIPTION
need to have outbuf.h included otherwise make fails with
regexp.cc: In function ‘void regerror(const char*)’:
regexp.cc:268:64: error: ‘outbuf_addv’ was not declared in this scope
