### PR TITLE
remove remnants of POSIX_TIMERS option

### DIFF
--- a/src/local_options.testdev
+++ b/src/local_options.testdev
@@ -10,7 +10,6 @@
 #undef NO_SNOOP
 #undef NO_ENVIRONMENT
 #undef NO_WIZARDS
-#define POSIX_TIMERS
 
 #define PACKAGE_CRYPTO
 #define PACKAGE_PCRE

--- a/src/local_options.testdev32
+++ b/src/local_options.testdev32
@@ -10,7 +10,6 @@
 #undef NO_SNOOP
 #undef NO_ENVIRONMENT
 #undef NO_WIZARDS
-#define POSIX_TIMERS
 
 #undef PACKAGE_DB
 #ifdef PACKAGE_DB

--- a/src/main.cc
+++ b/src/main.cc
@@ -150,12 +150,10 @@ int main(int argc, char **argv) {
   }
 
   g_current_virtual_time = get_current_time();
-#ifdef POSIX_TIMERS
   /*
    * Initialize the POSIX timers.
    */
   init_posix_timers();
-#endif
 
   /* read in the configuration file */
 

--- a/src/posix_timers.h
+++ b/src/posix_timers.h
@@ -3,10 +3,8 @@
 
 void sigalrm_handler(int, siginfo_t *, void *);
 
-#ifdef POSIX_TIMERS
 void init_posix_timers(void);
 void posix_eval_timer_set(LPC_INT micros);
 LPC_INT posix_eval_timer_get(void);
-#endif
 
 #endif


### PR DESCRIPTION
Throws compile-time error due to posix_timer.h having its prototypes wrapped in a POSIX_TIMER check.
