### PR TITLE
Correctly Fix #221

### DIFF
--- a/src/testsuite/single/tests/crasher/16.c
+++ b/src/testsuite/single/tests/crasher/16.c
@@ -1,5 +1,6 @@
-void test() {
+void do_tests() {
   // undefined
-  do_tests();
+  something();
+  write("crasher 16: OK.\n");
 }
-inherit "/single/tests/crasher/1.c";
+inherit "/single/tests/crasher/16b.c";

--- a/src/testsuite/single/tests/crasher/16b.c
+++ b/src/testsuite/single/tests/crasher/16b.c
@@ -1,0 +1,2 @@
+void something() {
+}

--- a/src/vm/internal/compiler/compiler.cc
+++ b/src/vm/internal/compiler/compiler.cc
@@ -850,10 +850,7 @@ int copy_functions(program_t *from, int typemod) {
     funp = prog->function_table + index;
 
     ihe = lookup_ident(funp->funcname);
-    // See grammar.y.pre:3549-3550, and testsuite/single/tests/crasher/16.c
-    // When function is not defined, it will be setup as if it was inherited.
-    // Thus we need to check for funp->address here to see if it is really undefined.
-    if (funp->address && ihe && ((num = ihe->dn.function_num) != -1)) {
+    if (ihe && ((num = ihe->dn.function_num) != -1)) {
       /* The function has already been defined in this object */
       overload_function(from, i, prog, index, num, typemod);
     } else {

--- a/src/vm/internal/compiler/grammar.y.pre
+++ b/src/vm/internal/compiler/grammar.y.pre
@@ -3452,43 +3452,33 @@ function_call:
       } else if ((f=$1->dn.efun_num) != -1) {
         $$ = validate_efun_call(f, $4);
       } else {
-        // TODO(sunyc): when exact_type is on, we should simply
-        // return error in this case.
-
         /* This here is a really nasty case that only occurs with
          * exact_types off.  The user has done something gross like:
          *
          * func() { int f; f(); } // if f was prototyped we wouldn't
          * f() { }                // need this case
-         *
-         * Don't complain, just grok it.
          */
-
-        if (current_function_context)
-          current_function_context->bindable = FP_NOT_BINDABLE;
-
-        f = define_new_function($1->name, 0, 0,
-            DECL_PUBLIC|FUNC_UNDEFINED, TYPE_ANY);
-        $$->kind = NODE_CALL_1;
-        $$->v.number = F_CALL_FUNCTION_BY_ADDRESS;
-        $$->l.number = f;
-        $$->type = TYPE_ANY; /* just a guess */
         if (exact_types) {
           char buf[256];
           char *end = EndOf(buf);
           char *p;
           const char *n = $1->name;
           if (*n == ':') n++;
-          /* prevent some errors; by making it look like an
-           * inherited function we prevent redeclaration errors
-           * if it shows up later
-           */
-
-          FUNCTION_FLAGS(f) &= ~FUNC_UNDEFINED;
-          FUNCTION_FLAGS(f) |= (FUNC_INHERITED | FUNC_VARARGS);
           p = strput(buf, end, "Undefined function ");
           p = strput(p, end, n);
           yyerror(buf);
+        } else {
+          /*
+           * Don't complain, just grok it.
+           */
+          if (current_function_context)
+            current_function_context->bindable = FP_NOT_BINDABLE;
+
+          f = define_new_function($1->name, 0, 0, DECL_PUBLIC|FUNC_UNDEFINED, TYPE_ANY);
+          $$->kind = NODE_CALL_1;
+          $$->v.number = F_CALL_FUNCTION_BY_ADDRESS;
+          $$->l.number = f;
+          $$->type = TYPE_ANY; /* just a guess */
         }
       }
       $$ = check_refs(num_refs - $<number>2, $4, $$);
@@ -3521,45 +3511,42 @@ function_call:
              */
           ;
       } else {
+        /* The only way this can happen is if function_name
+         * below made the function name. (directly or inherited.)
+         * The lexer would return L_DEFINED_NAME otherwise.
+         */
         int f;
         ident_hash_elem_t *ihe;
 
         f = (ihe = lookup_ident(name)) ? ihe->dn.function_num : -1;
-        $$->kind = NODE_CALL_1;
-        $$->v.number = F_CALL_FUNCTION_BY_ADDRESS;
-        if (f!=-1) {
-          /* The only way this can happen is if function_name
-           * below made the function name.  The lexer would
-           * return L_DEFINED_NAME instead.
-           */
-          $$->type = validate_function_call(f, $4->r.expr);
-        } else {
-          f = define_new_function(name, 0, 0,
-              DECL_PUBLIC|FUNC_UNDEFINED, TYPE_ANY);
+
+        // Funciton is not yet defined. for exact_types case, we simply return error,
+        // otherwise attempt to create a function, hoping later it will be defined by inherit.
+        if (f == -1) {
+          if (exact_types) {
+            char buf[256];
+            char *end = EndOf(buf);
+            char *p;
+            char *n = $1;
+            if (*n == ':') n++;
+            p = strput(buf, end, "Undefined function ");
+            p = strput(p, end, n);
+            yyerror(buf);
+          } else {
+            f = define_new_function(name, 0, 0, DECL_PUBLIC|FUNC_UNDEFINED, TYPE_ANY);
+          }
         }
-        $$->l.number = f;
-        /*
-         * Check if this function has been defined.
-         * But, don't complain yet about functions defined
-         * by inheritance.
-         */
-        if (exact_types && (FUNCTION_FLAGS(f) & FUNC_UNDEFINED)) {
-          char buf[256];
-          char *end = EndOf(buf);
-          char *p;
-          char *n = $1;
-          if (*n == ':') n++;
-          /* prevent some errors */
-          FUNCTION_FLAGS(f) &= ~FUNC_UNDEFINED;
-          FUNCTION_FLAGS(f) |= (FUNC_INHERITED | FUNC_VARARGS);
-          p = strput(buf, end, "Undefined function ");
-          p = strput(p, end, n);
-          yyerror(buf);
+
+        if (f != -1) {
+          $$->kind = NODE_CALL_1;
+          $$->v.number = F_CALL_FUNCTION_BY_ADDRESS;
+          $$->l.number = f;
+          if (FUNCTION_FLAGS(f) & FUNC_UNDEFINED) {
+            $$->type = TYPE_ANY;  /* Just a guess */
+          } else {
+            $$->type = validate_function_call(f, $4->r.expr);
+          }
         }
-        if (!(FUNCTION_FLAGS(f) & FUNC_UNDEFINED))
-          $$->type = FUNCTION_DEF(f)->type;
-        else
-          $$->type = TYPE_ANY;  /* Just a guess */
       }
       $$ = check_refs(num_refs - $<number>2, $4, $$);
       num_refs = $<number>2;


### PR DESCRIPTION
This commit revert 364eb15b0f1efd9a63a3c8bce164c721eb851e47, and fix #223.

The logic should be simply, correctly emitting errors and abort parsing.
I misunderstood it before and attempted to fix the wrong thing.
