### PR TITLE
external_start() fix - socketpair() registered in LPC socket event system

### DIFF
--- a/src/packages/external/external.cc
+++ b/src/packages/external/external.cc
@@ -9,8 +9,6 @@
 #include "include/socket_err.h"
 #include "packages/sockets/socket_efuns.h"
 
-void new_lpc_socket_event_listener(int idx, lpc_socket_t *sock, evutil_socket_t real_fd);
-
 #ifdef F_EXTERNAL_START
 int external_start(int which, svalue_t *args, svalue_t *arg1, svalue_t *arg2, svalue_t *arg3) {
   int sv[2];

--- a/src/packages/external/external.cc
+++ b/src/packages/external/external.cc
@@ -9,6 +9,8 @@
 #include "include/socket_err.h"
 #include "packages/sockets/socket_efuns.h"
 
+void new_lpc_socket_event_listener(int idx, lpc_socket_t *sock, evutil_socket_t real_fd);
+
 #ifdef F_EXTERNAL_START
 int external_start(int which, svalue_t *args, svalue_t *arg1, svalue_t *arg2, svalue_t *arg3) {
   int sv[2];
@@ -37,6 +39,8 @@ int external_start(int which, svalue_t *args, svalue_t *arg1, svalue_t *arg2, sv
   if (ret) {
     auto sock = lpc_socks_get(fd);
 
+    new_lpc_socket_event_listener(fd, sock, sv[0]);
+
     close(sv[1]);
     sock->fd = sv[0];
     sock->flags = S_EXTERNAL;
@@ -58,6 +62,9 @@ int external_start(int which, svalue_t *args, svalue_t *arg1, svalue_t *arg2, sv
     sock->w_len = 0;
 
     current_object->flags |= O_EFUN_SOCKET;
+
+    event_add(sock->ev_read, NULL);
+
     return fd;
   } else {
     int flag = 1;

--- a/src/packages/sockets/socket_efuns.cc
+++ b/src/packages/sockets/socket_efuns.cc
@@ -42,6 +42,8 @@ void on_lpc_sock_write(evutil_socket_t fd, short what, void *arg) {
   socket_write_select_handler(data->idx);
 }
 
+}  // namespace
+
 // Initialize LPC socket data structure and register events
 void new_lpc_socket_event_listener(int idx, lpc_socket_t *sock, evutil_socket_t real_fd) {
   auto data = new lpc_socket_event_data;
@@ -50,8 +52,6 @@ void new_lpc_socket_event_listener(int idx, lpc_socket_t *sock, evutil_socket_t 
   sock->ev_write = event_new(g_event_base, real_fd, EV_WRITE, on_lpc_sock_write, data);
   sock->ev_data = data;
 }
-
-}  // namespace
 
 /* flags for socket_close */
 #define SC_FORCE 1

--- a/src/packages/sockets/socket_efuns.h
+++ b/src/packages/sockets/socket_efuns.h
@@ -9,6 +9,7 @@
 
 #include <sys/socket.h>
 #include <deque>
+#include <event2/util.h>
 
 enum socket_mode { MUD, STREAM, DATAGRAM, STREAM_BINARY, DATAGRAM_BINARY };
 
@@ -93,5 +94,7 @@ lpc_socket_t *lpc_socks_get(int i);
 void mark_sockets();
 
 void lpc_socks_closeall();
+
+void new_lpc_socket_event_listener(int idx, lpc_socket_t *sock, evutil_socket_t real_fd);
 
 #endif /* _SOCKET_EFUNS_H_ */


### PR DESCRIPTION
Hi, I've been troubleshooting a problem with external_start() not working in fluffos(next-3.0). Essentially, none of the external commands in our driver were working. I traced the problem to external.cc and determine that the file descriptors created by socketpair() were not been registered in the new LPC socket event system. I've supplied the following fixes for your review:

external.cc needs two lines inserted:

    new_lpc_socket_event_listerner(fd, sock,s v[0]);
    ...
    event_add(sock->ev_read, NULL);

To make this fix possible, socket_efuns.cc needs new_lpc_socket_event_listener() to be moved outside of the anonymous namespace.