### PR TITLE
Fix icode optimize bug with time_expression.

### DIFF
--- a/src/testsuite/include/tests.h
+++ b/src/testsuite/include/tests.h
@@ -11,7 +11,7 @@
 #define ASSERT2(x, r) if (!(x)) { OUTPUT(WHERE + ", Check failed: " + r + ".\n"); }
 #define ASSERT_EQ(x, y) if (!same((x),(y))) { \
   OUTPUT(WHERE + ", Check Failed: \n" + \
-  "Expected: " + sprintf("%O", (x)) + "\nActual: " + sprintf("%O", (y)) + "\n"); }
+  "Expected: \n" + sprintf("%O", (x)) + "\nActual: \n" + sprintf("%O", (y)) + "\n"); }
 
 #define SAVETP tp = this_player()
 #define RESTORETP { if (tp) evaluate(bind( (: enable_commands :), tp)); else { object youd_never_use_this_as_a_var = new("/single/void"); evaluate(bind( (: enable_commands :), youd_never_use_this_as_a_var)); destruct(youd_never_use_this_as_a_var); } }

--- a/src/testsuite/single/tests/compiler/optimize.c
+++ b/src/testsuite/single/tests/compiler/optimize.c
@@ -1,0 +1,15 @@
+void bug(){
+    string err = "", err2 = "test";
+
+    ASSERT_EQ("\"\" \"test\"\n", sprintf("%O %O\n", err, err2));
+
+    // Follow two statement must be togehter for this bug to appear.
+    err += err2;
+    time_expression{
+        ASSERT_EQ("\"test\" \"test\"\n", sprintf("%O %O\n", err, err2));
+    };
+    // No more statement below.
+}
+void do_tests() {
+    bug();
+}

--- a/src/vm/internal/compiler/generate.cc
+++ b/src/vm/internal/compiler/generate.cc
@@ -214,9 +214,13 @@ static parse_node_t *optimize(parse_node_t *expr) {
     case NODE_ANON_FUNC:
       break;
     case NODE_EFUN:
+    case NODE_TIME_EXPRESSION:
       optimize_expr_list(expr->r.expr);
       break;
     default:
+      // This should not happen!
+      // see src/testsuite/single/tests/compiler/optimize.c
+      debug_message("optimizer: unknown node kind: %d.", expr->kind);
       break;
   }
   return expr;


### PR DESCRIPTION
optimize didn't handle time_expression OPCODE, causing it to emit
wrong byte code and cause possible memory leak. A test case was
also added to demonstrate the issue.