### PR TITLE
<refactor>(contrib.cc): removed obsolete '#ifdef/#endif'

### DIFF
--- a/src/packages/contrib/contrib.cc
+++ b/src/packages/contrib/contrib.cc
@@ -2071,7 +2071,6 @@ static int memory_share(svalue_t *sv) {
  *
  * map["program name"]["variable name"] = memory usage
  */
-#ifdef F_MEMORY_SUMMARY
 static void fms_recurse(mapping_t *map, object_t *ob, int *idx, program_t *prog) {
   int i;
   svalue_t *entry;
@@ -2117,7 +2116,6 @@ void f_memory_summary(void) {
   }
   push_refed_mapping(result);
 }
-#endif
 
 #endif
 


### PR DESCRIPTION
within '#ifdef F_MEMORY_SUMMARY/#endif' it's redundant to check '#ifdef F_MEMORY_SUMMARY'