### PR TITLE
<fix>(net/telnet.cc): wrong index in telnet_subprotocol negotiation

### DIFF
--- a/src/net/telnet.cc
+++ b/src/net/telnet.cc
@@ -293,7 +293,7 @@ static inline void on_telnet_subnegotiation(unsigned char cmd, const char *buf, 
       char *str = new_string(size, "telnet suboption");
       str[size] = '\0';
       for (int i = 0; i < size; i++) {
-        str[i] = (buf[i] ? buf[1] : 'I');
+        str[i] = (buf[i] ? buf[i] : 'I');
       }
       push_malloced_string(str);
       safe_apply(APPLY_TELNET_SUBOPTION, ip->ob, 1, ORIGIN_DRIVER);


### PR DESCRIPTION
telnet_subprotocol negotiation handled via apply::telnet_suboption got
wrong argument:
depending on 2nd value in buf (which might not even exist!!!) the apply
got an empty string, a string of creect length but each character the
same or (probably worst case) an overlong string with random contents
(leaked from stack).