### PR TITLE
Port code to Mac OS X, and compiled pass

### DIFF
--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -162,7 +162,7 @@ $(GENFILES): local_options tools/build_packages_genfiles.sh tools/build_applies.
 	@./tools/make_grammar.sh $(CXX) $(CXXFLAGS)
 	@$(BISON) -o vm/internal/compiler/grammar.autogen.cc \
 		--defines=vm/internal/compiler/grammar.autogen.h \
-		--warnings=all --report=all --report-file=vm/internal/compiler/grammar.autogen.report \
+		--report=all \
 		vm/internal/compiler/grammar.autogen.y
 	@echo [Generating options_def...]
 	@$(CXX) $(CXXFLAGS) -E -undef -dM base/internal/options_incl.h | tools/make_options_def.py vm/internal/options.autogen.h

--- a/src/backend.cc
+++ b/src/backend.cc
@@ -153,10 +153,17 @@ void on_walltime_event(int fd, short what, void *arg) {
 tick_event *add_walltime_event(std::chrono::milliseconds delay_msecs,
                                tick_event::callback_type callback) {
   auto event = new tick_event(callback);
+#ifdef __MACH__
+  struct timeval val {
+    static_cast<__darwin_time_t>(delay_msecs.count() / 1000),
+    static_cast<__darwin_suseconds_t>(delay_msecs.count() % 1000 * 1000),
+  };
+#else
   struct timeval val {
     static_cast<time_t>(delay_msecs.count() / 1000),
-        static_cast<time_t>(delay_msecs.count() % 1000 * 1000),
+    static_cast<time_t>(delay_msecs.count() % 1000 * 1000),
   };
+#endif
   struct timeval *delay_ptr = nullptr;
   if (delay_msecs.count() != 0) {
     delay_ptr = &val;

--- a/src/main.cc
+++ b/src/main.cc
@@ -57,9 +57,13 @@ void print_version_and_time() {
 #if USE_JEMALLOC == 1
   /* Print jemalloc version */
   {
-    const char *ver;
+    const char *ver = "";
     size_t resultlen = sizeof(ver);
+#ifdef __MACH__
+    je_mallctl("version", &ver, &resultlen, NULL, 0);
+#else
     mallctl("version", &ver, &resultlen, NULL, 0);
+#endif
     std::cout << "Jemalloc Version: " << ver << std::endl;
   }
 #endif

--- a/src/thirdparty/libtelnet/.travis.yml
+++ b/src/thirdparty/libtelnet/.travis.yml
@@ -1,0 +1,12 @@
+language: cpp
+compiler:
+  - clang
+  - gcc
+os:
+  - linux
+before_install:
+  - libtoolize
+  - aclocal
+  - autoheader
+  - automake --add-missing
+  - autoconf

--- a/src/thirdparty/libtelnet/README
+++ b/src/thirdparty/libtelnet/README
@@ -644,3 +644,29 @@ telnet-proxy will display status information about the data passing
 through both ends of the tunnel.  telnet-proxy can only support a
 single tunnel at a time.  It will continue running until an error
 occurs or a terminating signal is sent to the proxy process.
+
+IX. HOW TO BUILD
+=======================================================================
+
+libtool, autoconf, automake required, for Mac, install them with brew:
+
+$ brew install libtool
+(GNU libtool installed as glibtool & glibtoolize to avoid conflict with 
+Apple libtool)
+
+$ brew install automake
+(autoconf will auto be installed as dependency)
+
+$ libtoolize
+$ aclocal
+$ autoheader
+$ automake --add-missing
+$ autoconf
+(if autoconf fail, run ./configure, if fails, vi ./configure, go to line
+13288, comment the error lines)
+
+$ make
+
+
+
+

--- a/src/thirdparty/libtelnet/util/telnet-proxy.c
+++ b/src/thirdparty/libtelnet/util/telnet-proxy.c
@@ -158,9 +158,9 @@ static void print_buffer(const char *buffer, size_t size) {
 			printf("%c", (char)buffer[i]);
 		else if (buffer[i] == '\n')
 			printf("<" COLOR_BOLD "0x%02X" COLOR_UNBOLD ">\n",
-					(int)buffer[i]);
+					((int)buffer[i]) & 0xff);
 		else
-			printf("<" COLOR_BOLD "0x%02X" COLOR_UNBOLD ">", (int)buffer[i]);
+			printf("<" COLOR_BOLD "0x%02X" COLOR_UNBOLD ">", ((int)buffer[i]) & 0xff);
 	}
 }
 
@@ -195,6 +195,10 @@ static void _event_handler(telnet_t *telnet, telnet_event_t *ev,
 	/* data received */
 	case TELNET_EV_DATA:
 		printf("%s DATA: ", conn->name);
+		char buf[1024];
+		strncpy(buf, ev->data.buffer, ev->data.size);
+		buf[ev->data.size] = '\0';
+		printf(buf);
 		print_buffer(ev->data.buffer, ev->data.size);
 		printf(COLOR_NORMAL "\n");
 

--- a/src/tools/make_grammar.sh
+++ b/src/tools/make_grammar.sh
@@ -7,8 +7,14 @@ GRAMMAR_Y_PRE=vm/internal/compiler/grammar.y.pre
 GRAMMAR_Y=vm/internal/compiler/grammar.autogen.y
 
 # First step is to run grammar.y.pre through CPP.
-"$@" -E -x c++ -undef -P -CC \
-  -imacros $OPTIONS_H $GRAMMAR_Y_PRE > $GRAMMAR_Y
+#"$@" -E -x c++ -undef -P -CC -imacros $OPTIONS_H $GRAMMAR_Y_PRE > $GRAMMAR_Y
 
 # Second step is to run through sed, replacing $include into #include
-sed -e 's/\/\/ #include/#include/g' -i $GRAMMAR_Y
+#sed -e 's/\/\/ #include/#include/g' -i $GRAMMAR_Y
+
+
+# First step is to run grammar.y.pre through CPP.
+# Second step is to run through sed, replacing $include into #include
+"$@" -E -x c++ -undef -P -CC -imacros $OPTIONS_H $GRAMMAR_Y_PRE | sed -e 's/\/\/ #include/#include/g' > $GRAMMAR_Y
+
+echo $GRAMMAR_Y

--- a/src/vm/internal/compiler/lex.cc
+++ b/src/vm/internal/compiler/lex.cc
@@ -187,7 +187,10 @@ static keyword_t reswords[] = {
 #endif
     {"return", L_RETURN, 0},
     {"sscanf", L_SSCANF, 0},
-#ifndef SENSIBLE_MODIFIERS
+#ifdef SENSIBLE_MODIFIERS
+    // keep old mudlib compatible
+    {"static", L_TYPE_MODIFIER, 0},
+#else
     {"static", L_TYPE_MODIFIER, DECL_NOSAVE | DECL_PROTECTED},
 #endif
     {"string", L_BASIC_TYPE, TYPE_STRING},

--- a/src/vm/internal/posix_timers.cc
+++ b/src/vm/internal/posix_timers.cc
@@ -9,7 +9,6 @@
 
 #include "vm/internal/eval.h"
 
-static timer_t eval_timer_id;
 /*
  * SIGALRM handler.
  */
@@ -18,6 +17,27 @@ void sigalrm_handler(int sig, siginfo_t *si, void *uc) {
     outoftime = 1;
   }
 } /* sigalrm_handler() */
+
+#ifdef __MACH__
+
+// Notice missing: tiemr_create(), timer_settime(), timer_gettime(),
+// TMR option group of the POSIX API, not implemented in Mac OS X
+// see: http://www.lists.apple.com/archives/unix-porting/2009/May/msg00004.html
+
+void init_posix_timers(void) {
+}
+
+void posix_eval_timer_set(uint64_t micros) {
+}
+
+uint64_t posix_eval_timer_get(void) {
+  return 100;
+}
+
+#else
+
+static timer_t eval_timer_id;
+
 /* Called by main() to initialize all timers (currently only eval_cost) */
 void init_posix_timers(void) {
   struct sigevent sev;
@@ -80,3 +100,5 @@ uint64_t posix_eval_timer_get(void) {
 
   return it.it_value.tv_sec * static_cast<uint64_t>(1000000) + it.it_value.tv_nsec / 1000;
 }
+
+#endif


### PR DESCRIPTION
A little effort to make FluffOS to run on Mac OS X.

Known issue: timer_create(), timer_settime(), timer_gettime(), TMR option group of the POSIX API, not implemented in Mac OS X. See: http://www.lists.apple.com/archives/unix-porting/2009/May/msg00004.html
