### PR TITLE
Port to Mac OS X, tested pass to drive es2 mudlib

### DIFF
--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -162,7 +162,7 @@ $(GENFILES): local_options tools/build_packages_genfiles.sh tools/build_applies.
 	@./tools/make_grammar.sh $(CXX) $(CXXFLAGS)
 	@$(BISON) -o vm/internal/compiler/grammar.autogen.cc \
 		--defines=vm/internal/compiler/grammar.autogen.h \
-		--warnings=all --report=all --report-file=vm/internal/compiler/grammar.autogen.report \
+		--report=all \
 		vm/internal/compiler/grammar.autogen.y
 	@echo [Generating options_def...]
 	@$(CXX) $(CXXFLAGS) -E -undef -dM base/internal/options_incl.h | tools/make_options_def.py vm/internal/options.autogen.h

--- a/src/backend.cc
+++ b/src/backend.cc
@@ -153,10 +153,17 @@ void on_walltime_event(int fd, short what, void *arg) {
 tick_event *add_walltime_event(std::chrono::milliseconds delay_msecs,
                                tick_event::callback_type callback) {
   auto event = new tick_event(callback);
+#ifdef __MACH__
+  struct timeval val {
+    static_cast<__darwin_time_t>(delay_msecs.count() / 1000),
+    static_cast<__darwin_suseconds_t>(delay_msecs.count() % 1000 * 1000),
+  };
+#else
   struct timeval val {
     static_cast<time_t>(delay_msecs.count() / 1000),
         static_cast<time_t>(delay_msecs.count() % 1000 * 1000),
   };
+#endif
   struct timeval *delay_ptr = nullptr;
   if (delay_msecs.count() != 0) {
     delay_ptr = &val;

--- a/src/main.cc
+++ b/src/main.cc
@@ -59,7 +59,11 @@ void print_version_and_time() {
   {
     const char *ver;
     size_t resultlen = sizeof(ver);
+#ifdef __MACH__
+    je_mallctl("version", &ver, &resultlen, NULL, 0);
+#else
     mallctl("version", &ver, &resultlen, NULL, 0);
+#endif
     std::cout << "Jemalloc Version: " << ver << std::endl;
   }
 #endif

--- a/src/tools/make_grammar.sh
+++ b/src/tools/make_grammar.sh
@@ -7,8 +7,11 @@ GRAMMAR_Y_PRE=vm/internal/compiler/grammar.y.pre
 GRAMMAR_Y=vm/internal/compiler/grammar.autogen.y
 
 # First step is to run grammar.y.pre through CPP.
-"$@" -E -x c++ -undef -P -CC \
-  -imacros $OPTIONS_H $GRAMMAR_Y_PRE > $GRAMMAR_Y
+#"$@" -E -x c++ -undef -P -CC -imacros $OPTIONS_H $GRAMMAR_Y_PRE > $GRAMMAR_Y
 
 # Second step is to run through sed, replacing $include into #include
-sed -e 's/\/\/ #include/#include/g' -i $GRAMMAR_Y
+#sed -e 's/\/\/ #include/#include/g' -i $GRAMMAR_Y
+
+# Note: as Mac OS X "sed -i" does not work in same way as Linux sed does
+# merge the above two steps into one with pipe, still get same output file.
+"$@" -E -x c++ -undef -P -CC -imacros $OPTIONS_H $GRAMMAR_Y_PRE | sed -e 's/\/\/ #include/#include/g' > $GRAMMAR_Y

--- a/src/vm/internal/posix_timers.cc
+++ b/src/vm/internal/posix_timers.cc
@@ -9,6 +9,24 @@
 
 #include "vm/internal/eval.h"
 
+#ifdef __MACH__
+
+// Notice missing: tiemr_create(), timer_settime(), timer_gettime(),
+// TMR option group of the POSIX API, not implemented in Mac OS X
+// see: http://www.lists.apple.com/archives/unix-porting/2009/May/msg00004.html
+
+void init_posix_timers(void) {
+}
+
+void posix_eval_timer_set(uint64_t micros) {
+}
+
+uint64_t posix_eval_timer_get(void) {
+  return 100;
+}
+
+#else
+
 static timer_t eval_timer_id;
 /*
  * SIGALRM handler.
@@ -80,3 +98,5 @@ uint64_t posix_eval_timer_get(void) {
 
   return it.it_value.tv_sec * static_cast<uint64_t>(1000000) + it.it_value.tv_nsec / 1000;
 }
+
+#endif


### PR DESCRIPTION
Port FluffOS to Mac OS X.

It can be built correctly and generated driver binary. Tested with ES2 mudlib, it can start up correctly.

Known issue: 
timer_create(), timer_settime(), timer_gettime(), are missing. I just replace posix_timers.cc with some dummy functions.
Reason: Mac OS X does not implement the TMR option group of the POSIX API.
See: http://www.lists.apple.com/archives/unix-porting/2009/May/msg00004.html
