### PR TITLE
Update object.cc

### DIFF
--- a/src/vm/internal/base/object.cc
+++ b/src/vm/internal/base/object.cc
@@ -501,7 +501,7 @@ static int restore_interior_string(char **val, svalue_t *sv) {
 
 static int parse_numeric(char **cpp, unsigned char c, svalue_t *dest) {
   char *cp = *cpp;
-  LPC_INT res, neg;
+  LPC_FLOAT res, neg;
 
   if (c == '-') {
     neg = 1;


### PR DESCRIPTION
处理restore_variable，超过64位整数最大值的double数值溢出的bug，({922337203685477114900.000,})
