### PR TITLE
<feat>: new predefine "__PORT_CONFIG__" #290

### DIFF
--- a/src/base/internal/rc.cc
+++ b/src/base/internal/rc.cc
@@ -283,7 +283,7 @@ void read_config(char *filename) {
                 port, port, tmp);
       }
     }
-    for (i = port_start; i < 5; i++) {
+    for (i = port_start; i < 5; i++) {  // attention: maximum portnr also in vm/internal/compiler/lex.cc for predefine __PORT_CONFIG__
       external_port[i].kind = 0;
       external_port[i].fd = -1;
 

--- a/src/include/port_config.h
+++ b/src/include/port_config.h
@@ -1,0 +1,19 @@
+/// @file port_config.h
+/// @brief include file for predefkne __PORT_CONFIG__
+///
+/// macros from ```base/internal/external_port.h``` for possible port types
+/// @author René Müller
+/// @version 0.0.0
+/// @date 2016-06-01
+
+#ifndef __PORT_CONFIG_H
+#define __PORT_CONFIG_H
+
+#define PORT_UNDEFINED 0
+#define PORT_TELNET 1
+#define PORT_BINARY 2
+#define PORT_ASCII 3
+#define PORT_MUD 4
+#define PORT_WEBSOCKET 5
+
+#endif // __PORT_CONFIG_H

--- a/src/vm/internal/compiler/lex.cc
+++ b/src/vm/internal/compiler/lex.cc
@@ -2859,6 +2859,17 @@ void add_predefines() {
 
   sprintf(save_buf, "%d", external_port[0].port);
   add_predefine("__PORT__", -1, save_buf);
+  strcpy(save_buf, "([ ");
+  for (i = 0; i < 5; i++)           // attention: maximum portnr. also in base/internal/rc.cc [Process ports]
+  {
+      // attention: in case of change:
+      // format of format string has to have constant length independent of
+      // portnr and configured values!
+      sprintf(save_buf + i * 30 + 3, "\"port_d\": ({ 0x%04X, 0x%02X }), ",
+              i, external_port[i].port, external_port[i].kind);
+  }
+  strcpy(save_buf + 151, " ])");
+  add_predefine("__PORT_CONFIG__", -1, save_buf);
   for (i = 0; i < (sizeof(option_defs) / sizeof(const char *)); i += 2) {
     add_predefine(option_defs[i], -1, option_defs[i + 1]);
   }


### PR DESCRIPTION
Solution via predefine:

```
    #define __PORT_CONFIG__ ([                                  \
                                "port_0": ({ 0x1234, 0x12 }),   \
                                ...                             \
                                "port_4": ({ 0x1234, 0x12 }),   \
                            ])
```
