### PR TITLE
Stop treating array-bounds as error, this doesn't work under GCC 6.4

### DIFF
--- a/src/build.FluffOS
+++ b/src/build.FluffOS
@@ -27,7 +27,6 @@ WARN=(
 "-Wextra"
 "-Wformat"
 "-Werror=format-security"
-"-Werror=array-bounds"
 # Turn off some warnings from GCC.
 "-Wno-char-subscripts"
 "-Wno-sign-compare"


### PR DESCRIPTION
solve issues in #386  