### PR TITLE
<fix>(src/CMakeLists.txt): fixed warning options

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -110,7 +110,7 @@ if (${CMAKE_C_COMPILER_ID} STREQUAL "GNU" OR ${CMAKE_C_COMPILER_ID} STREQUAL "Cl
     "-Wextra"
     "-Wformat"
     "-Werror=format-security"
-    "-Werror=implicit-function-declaration"
+    $<$<COMPILE_LANGUAGE:C>:-Werror=implicit-function-declaration>
     # Turn off some warnings from GCC.
     "-Wno-char-subscripts"
     "-Wno-sign-compare"


### PR DESCRIPTION
C-compiler option
    -Werror=implicit-function-declaration
got previously added to C++-compilers too...

Signed-off-by: Shea690901 <ginny690901@hotmail.de>