### PR TITLE
<fix>(otable.cc): fixes issue #556

### DIFF
--- a/src/vm/internal/otable.cc
+++ b/src/vm/internal/otable.cc
@@ -93,7 +93,7 @@ int ObjectTable::showStatus(outbuffer_t* out, int verbose) {
       break;
   }
   {
-      std::string tmp(std::move(ss.str());
+      std::string tmp = ss.str();
       outbuf_add(out, tmp.c_str());
   }
 

--- a/src/vm/internal/otable.cc
+++ b/src/vm/internal/otable.cc
@@ -92,9 +92,10 @@ int ObjectTable::showStatus(outbuffer_t* out, int verbose) {
     default:
       break;
   }
-  std::string content;
-  ss >> content;
-  outbuf_add(out, content.c_str());
+  {
+      std::string tmp {ss.str()};
+      outbuf_add(out, tmp.c_str());
+  }
 
   return objects_.size() * sizeof(Value);
 }

--- a/src/vm/internal/otable.cc
+++ b/src/vm/internal/otable.cc
@@ -93,7 +93,7 @@ int ObjectTable::showStatus(outbuffer_t* out, int verbose) {
       break;
   }
   {
-      std::string tmp {ss.str()};
+      std::string tmp(std::move(ss.str());
       outbuf_add(out, tmp.c_str());
   }
 

--- a/testsuite/single/tests/efuns/mud_status.c
+++ b/testsuite/single/tests/efuns/mud_status.c
@@ -1,4 +1,9 @@
 void do_tests() {
     ASSERT(stringp(mud_status()));
     ASSERT(stringp(mud_status(1)));
+
+    printf("\n\tmud_status(0):\n%O\n\n\tmud_status(1):\n%O\n\n\tmud_status(-1):\n%O\n\n",
+            mud_status(0),
+            mud_status(1),
+            mud_status(-1));
 }


### PR DESCRIPTION
operator>> extracts formated input from a string_stream, not the whole
string.

Signed-off-by: Shea690901 <ginny690901@hotmail.de>