### PR TITLE
Use mkdir to create the build directory on MacOS

### DIFF
--- a/docs/build.md
+++ b/docs/build.md
@@ -74,7 +74,7 @@ $ brew install cmake pkg-config mysql pcre libgcrypt libevent openssl jemalloc i
 
 3. build same as under linux, you will need to pass two environment variables
 ```shell
-$ make build && cd build
+$ mkdir build && cd build
 $ OPENSSL_ROOT_DIR="/usr/local/opt/openssl" ICU_ROOT="/usr/local/opt/icu4c" cmake ..
 $ make install
 ```


### PR DESCRIPTION
The MacOS instructions suggest using `make` instead of `mkdir`. This errors since `make` does not have a build target in that directory. 

```shell
 $  make build
make: Nothing to be done for `build'.
```

Use `mkdir` to create the directory.