### PR TITLE
Draft PostgreSQL build support for v2019

### DIFF
--- a/src/packages/db/CMakeLists.txt
+++ b/src/packages/db/CMakeLists.txt
@@ -52,7 +52,13 @@ if(${PACKAGE_DB})
               "${PACKAGE_DB_POSTGRESQL}" STREQUAL "{PACKAGE_DB_SQLITE}")
         message(FATAL "Conflicting DB type!")
       endif()
-      message(FATAL "Not supported yet!")
+
+      find_package(PostgreSQL REQUIRED)
+      message(STATUS "PACKAGE_DB USE_POSTGRES: ${PACKAGE_DB_POSTGRESQL}, Found version ${PostgreSQL_VERSION_STRING}")
+
+      target_compile_definitions(package_db PUBLIC "USE_POSTGRES=${PACKAGE_DB_POSTGRESQL}")
+      target_include_directories(package_db SYSTEM PUBLIC ${PostgreSQL_INCLUDE_DIRS})
+      target_link_libraries(package_db PRIVATE -L${PostgreSQL_LIBRARY_DIRS} ${PostgreSQL_LIBRARIES})
     endif()
 
 endif()


### PR DESCRIPTION
This patch add PostgreSQL build support for v2019.

I am still not sure if the binaries built out are actually working or not. But, at least the build process completed successfully. And the dynamic library of PostgreSQL client, `libpq.so.5`, is properly linked against `driver` and `lpcc`. Plus `driver` and `lpcc` can be run, without crash. So, at least, smoke test passed.

Tested on Debian GNU/Linux "buster" 10.8 amd64.