### PR TITLE
load_object: fix buffer overruns.

### DIFF
--- a/src/vm/internal/simulate.cc
+++ b/src/vm/internal/simulate.cc
@@ -425,7 +425,7 @@ object_t *load_object(const char *lname, int callcreate) {
   object_t *ob;
   svalue_t *mret;
   struct stat c_st;
-  char real_name[402], name[400], actualname[400], obname[402];
+  char name[400], actualname[400], real_name[sizeof(name)+2], obname[sizeof(real_name)];
 
   const char *pname = check_valid_path(lname, master_ob, "load_object", 0);
   if (!pname) {

--- a/src/vm/internal/simulate.cc
+++ b/src/vm/internal/simulate.cc
@@ -425,7 +425,7 @@ object_t *load_object(const char *lname, int callcreate) {
   object_t *ob;
   svalue_t *mret;
   struct stat c_st;
-  char real_name[400], name[400], actualname[400], obname[400];
+  char real_name[402], name[400], actualname[400], obname[402];
 
   const char *pname = check_valid_path(lname, master_ob, "load_object", 0);
   if (!pname) {


### PR DESCRIPTION
`real_name` and `obname` are the same size as `name` and `actualname`.
This means that if `lname` is 400 or more characters long, `actualname`
and `obname` will be filled and the `strcat` calls to append `".c"` to
`real_name` and `obname` will result in buffer overruns.

Extend `real_name` and `obname` to make room for `".c"`.

Signed-off-by: Jeremy Sowden <jeremy@azazel.net>