### PR TITLE
Added support for POSIX line endings at end of file - Closes #798

### DIFF
--- a/src/packages/core/file.cc
+++ b/src/packages/core/file.cc
@@ -420,6 +420,10 @@ char *read_file(const char *file, int start, int lines) {
         ptr_start++;
       }
     }  
+    
+    if (start < 0) {
+      ptr_start = theBuff;
+    }
   }
 
   char *ptr_end = (char *)theBuff + total_bytes_read;

--- a/src/packages/core/file.cc
+++ b/src/packages/core/file.cc
@@ -399,9 +399,14 @@ char *read_file(const char *file, int start, int lines) {
   else if ( start < 0 )
   {
     // move backwards from end by "start"-th lines
-    ptr_start += total_bytes_read;
+    ptr_start += total_bytes_read - 1;
+    
+    // account for non-POSIX line endings at end of file, if not POSIX then
+    // move pointer forward so decrementing doesn't clip the last character
+    if ( *ptr_start != '\n' )
+      ptr_start++;
+      
     while (start < 0 && ptr_start > theBuff) {
-      // start decrementing pointer first because we start on '\0'
       ptr_start--;
       if (*ptr_start == '\0') {
         debug(file, "read_file: file contains '\\0': %s.\n", file);
@@ -415,10 +420,6 @@ char *read_file(const char *file, int start, int lines) {
         ptr_start++;
       }
     }  
-    
-    if (start < 0) {
-      ptr_start = theBuff;
-    }
   }
 
   char *ptr_end = (char *)theBuff + total_bytes_read;

--- a/testsuite/single/tests/efuns/read_file.c
+++ b/testsuite/single/tests/efuns/read_file.c
@@ -23,7 +23,9 @@ void do_tests() {
     ASSERT_EQ(implode(explode(foo, "\n")[<15..<6], "\n") + "\n", read_file("/testfile", -15, 10));
     // if we start too many lines before the end of the file, start at the beginning
     ASSERT(read_file("/testfile", -10000, 1));
+    
+    
     // CRLF tests
     ASSERT(read_file("/crlf_test_file.lf") == read_file("/crlf_test_file.crlf"));
-
+    ASSERT(read_file("/crlf_test_file.lf", -1000) == read_file("/crlf_test_file.crlf", -1000));
 }

--- a/testsuite/single/tests/efuns/read_file.c
+++ b/testsuite/single/tests/efuns/read_file.c
@@ -27,5 +27,6 @@ void do_tests() {
     
     // CRLF tests
     ASSERT(read_file("/crlf_test_file.lf") == read_file("/crlf_test_file.crlf"));
-    ASSERT(read_file("/crlf_test_file.lf", -1000) == read_file("/crlf_test_file.crlf", -1000));
+    ASSERT_EQ(read_file("/crlf_test_file.lf", -2, 1), read_file("/crlf_test_file.crlf", -2, 1));
+    ASSERT_EQ(read_file("/crlf_test_file.lf", -1000), read_file("/crlf_test_file.crlf", -1000));
 }

--- a/testsuite/single/tests/efuns/read_file.c
+++ b/testsuite/single/tests/efuns/read_file.c
@@ -20,11 +20,9 @@ void do_tests() {
     ASSERT(!read_file("/testfile", 10000, 1));
     
     // Start tests for end of file -lines
-    mid = implode(explode(foo, "\n")[<14..<5], "\n") + "\n";
-    ASSERT_EQ(mid, read_file("/testfile", -15, 10));
+    ASSERT_EQ(implode(explode(foo, "\n")[<15..<6], "\n") + "\n", read_file("/testfile", -15, 10));
     // if we start too many lines before the end of the file, start at the beginning
     ASSERT(read_file("/testfile", -10000, 1));
-
     // CRLF tests
     ASSERT(read_file("/crlf_test_file.lf") == read_file("/crlf_test_file.crlf"));
 


### PR DESCRIPTION
Due to different line ending standards (POSIX vs non-POSIX), support was added in to handle both of these.  