### PR TITLE
adding new efun: telnet_ga() to send go ahead telnet message sequence

### DIFF
--- a/docs/efun/index.md
+++ b/docs/efun/index.md
@@ -551,6 +551,9 @@ title: EFUN
 <div><a href='interactive/snoop.html'>snoop</a></div>
 </div>
 <div class='col-sm-4 col-md-3 col-lg-3 col-xl-2'>
+<div><a href='interactive/telnet_ga.html'>telnet_ga</a></div>
+</div>
+<div class='col-sm-4 col-md-3 col-lg-3 col-xl-2'>
 <div><a href='interactive/telnet_nop.html'>telnet_nop</a></div>
 </div>
 <div class='col-sm-4 col-md-3 col-lg-3 col-xl-2'>
@@ -1101,6 +1104,6 @@ title: EFUN
 
 <div class="alert alert-info my-4" role="alert">
     <img src="https://cdnjs.cloudflare.com/ajax/libs/octicons/8.5.0/svg/info.svg">
-    This page is auto generated on 2021-05-09 21:09:57 CST for v2019.20210429-15-g8827ca4b.</a>
+    This page is auto generated on 2021-06-05 19:30:14 EDT for v2019.20210429-15-gf6db6945-dirty.</a>
 </div>
 

--- a/docs/efun/interactive/telnet_ga.md
+++ b/docs/efun/interactive/telnet_ga.md
@@ -1,0 +1,22 @@
+---
+layout: default
+title: interactive / telnet_ga
+---
+
+### NAME
+
+    telnet_nop() - send an TELNET GA message
+
+### SYNOPSIS
+
+    void telnet_ga();
+
+### DESCRIPTION
+
+    if user is under telnet, then send an TELNET_IAC TELNET_GA sequence,
+    useful for prompts that don't terminate with a newline character.
+
+### SEE ALSO
+
+    N/A
+

--- a/src/packages/core/core.spec
+++ b/src/packages/core/core.spec
@@ -340,6 +340,7 @@ void request_term_type();
 void start_request_term_type();
 void request_term_size(void | int);
 void telnet_nop();
+void telnet_ga();
 
 /* shutdown is at the end because it is only called once per boot cycle :) */
 void shutdown(void | int);

--- a/src/packages/core/telnet_ext.cc
+++ b/src/packages/core/telnet_ext.cc
@@ -65,6 +65,18 @@ void f_telnet_nop() {
 }
 #endif
 
+#ifdef F_TELNET_GA
+void f_telnet_ga() {
+  auto ip = current_object->interactive;
+  if (ip && ip->telnet) {
+    telnet_send_ga(ip->telnet);
+    flush_message(ip);
+  } else if (!ip) {
+    debug_message("Warning: wrong usage. telnet_ga() should only be called by a user object.\n");
+  }
+}
+#endif
+
 /* MXP */
 #ifdef F_HAS_MXP
 void f_has_mxp(void) {

--- a/testsuite/single/tests/efuns/telnet_ga.c
+++ b/testsuite/single/tests/efuns/telnet_ga.c
@@ -1,0 +1,3 @@
+void do_tests() {
+  telnet_ga();
+}


### PR DESCRIPTION
The only thing I would like to mention is that, not only f_telnet_ga(), but f_telnet_nop() send a debug_message BEFORE sending the codes.

```c
void f_telnet_nop() {
  auto ip = current_object->interactive;
  if (ip && ip->telnet) {
    telnet_send_nop(ip->telnet);
    flush_message(ip);
  } else if (!ip) {
    debug_message("Warning: wrong usage. telnet_nop() should only be called by a user object.\n");
  }
}
```
The debug message gets executed before the telnet_send. Happens with other, related efuns as well. So that's a mystery that I am not equipped to solve, but maybe someone else can?