### PR TITLE
fix backwards.hpp for mac m1

### DIFF
--- a/src/thirdparty/backward-cpp/backward.hpp
+++ b/src/thirdparty/backward-cpp/backward.hpp
@@ -4160,6 +4160,8 @@ public:
     error_addr = reinterpret_cast<void *>(uctx->uc_mcontext.gregs[REG_EIP]);
 #elif defined(__arm__)
     error_addr = reinterpret_cast<void *>(uctx->uc_mcontext.arm_pc);
+#elif defined(__aarch64__) && defined(BACKWARD_SYSTEM_DARWIN)
+    error_addr = reinterpret_cast<void *>(uctx->uc_mcontext->__ss.__pc);
 #elif defined(__aarch64__)
     error_addr = reinterpret_cast<void *>(uctx->uc_mcontext.pc);
 #elif defined(__mips__)


### PR DESCRIPTION
This PR adds support for compiling on Apple M1. I **have** not verified this still works on intel-based Apple.