### PR TITLE
updating clean_up routine

### DIFF
--- a/src/backend.cc
+++ b/src/backend.cc
@@ -267,6 +267,11 @@ void look_for_objects_to_swap() {
                      tick_event::callback_type(look_for_objects_to_swap));
 
   object_t *ob, *next_ob, *last_good_ob;
+
+  // clean up destructed objects so that ref count will be accurate later for
+  // clean_up()
+  remove_destructed_objects() ;
+  
   /*
    * Objects object can be destructed, which means that next object to
    * investigate is saved in next_ob. If very unlucky, that object can be
@@ -340,7 +345,8 @@ void look_for_objects_to_swap() {
            * keeping them around seems justified.
            */
 
-          push_number(ob->flags & (O_CLONE) ? 0 : ob->prog->ref);
+          // ref - 1, because the ref count includes the object itself
+          push_number(ob->flags & (O_CLONE) ? 0 : ob->prog->ref - 1);
           set_eval(max_eval_cost);
           auto svp = safe_apply(APPLY_CLEAN_UP, ob, 1, ORIGIN_DRIVER);
           if (!svp || (svp->type == T_NUMBER && svp->u.number == 0)) {

--- a/src/backend.cc
+++ b/src/backend.cc
@@ -271,7 +271,6 @@ void look_for_objects_to_swap() {
   // clean up destructed objects so that ref count will be accurate later for
   // clean_up()
   remove_destructed_objects() ;
-  
   /*
    * Objects object can be destructed, which means that next object to
    * investigate is saved in next_ob. If very unlucky, that object can be
@@ -346,7 +345,10 @@ void look_for_objects_to_swap() {
            */
 
           // ref - 1, because the ref count includes the object itself
-          push_number(ob->flags & (O_CLONE) ? 0 : ob->prog->ref - 1);
+          if(ob->flags & (O_CLONE)) push_number(0) ;
+          else if(ob->prog->ref > 0) push_number(ob->prog->ref - 1) ;
+          else push_number(ob->prog->ref) ;
+
           set_eval(max_eval_cost);
           auto svp = safe_apply(APPLY_CLEAN_UP, ob, 1, ORIGIN_DRIVER);
           if (!svp || (svp->type == T_NUMBER && svp->u.number == 0)) {


### PR DESCRIPTION
1. added line to remove destructed objects in the game so that ref counts will be accurate
2. added `-1` to ref count because ref count was previously always sending 1 to the game for non-inherited objects. suspect this was because the ref count was including the object itself. this is counter to documentation which states that 0 will be sent when there are no objects inheriting the object being cleaned up.