### PR TITLE
fix typo in config example

### DIFF
--- a/src/Config.example
+++ b/src/Config.example
@@ -291,10 +291,10 @@ old type behavior : 0
 old range behavior : 0
 warn old range behavior : 1
 
-# supress warnings about unused arguments; only warn about unused local
+# suppress warnings about unused arguments; only warn about unused local
 # variables.  Makes older code (where argument names were required) compile
 # more quietly.
-supress argument warnings : 1
+suppress argument warnings : 1
 
 #
 enable_commands call init : 1

--- a/testsuite/etc/config.test
+++ b/testsuite/etc/config.test
@@ -326,7 +326,7 @@ old range behavior : 0
 # when you're not actually using the old range behavior
 warn old range behavior : 1
 
-# supress warnings about unused arguments; only warn about unused local
+# suppress warnings about unused arguments; only warn about unused local
 # variables.  Makes older code (where argument names were required) compile
 # more quietly.
 #


### PR DESCRIPTION
In the example config file, the `suppress argument warnings` option is misspelled as `supress`. This could cause someone copying the default config file and disabling this option to mistakenly think the option was changed when it was not. 😅