### PR TITLE
Allowing '#' in file path for objects with OID. Fixes erroneous read access error in simulate.cc.

### DIFF
--- a/src/base/internal/file.cc
+++ b/src/base/internal/file.cc
@@ -7,6 +7,7 @@
 
 #include <cstring>
 #include <cstdlib>
+#include <ctype.h>
 
 /*
  * Check that it is an legal path. No '..' are allowed.
@@ -20,13 +21,7 @@ int legal_path(const char *path) {
   if (path[0] == '/') {
     return 0;
   }
-  /*
-   * disallowing # seems the easiest way to solve a bug involving loading
-   * files containing that character
-   */
-  if (strchr(path, '#')) {
-    return 0;
-  }
+
   p = path;
   while (p) { /* Zak, 930530 - do better checking */
     if (p[0] == '.') {
@@ -45,5 +40,22 @@ int legal_path(const char *path) {
       p++; /* step over `/' */
     }
   }
+  
+  /*
+   * disallow # if it is not indicating an OID
+   */
+  p = strchr(path, '#');
+  while (p) {
+    p++;
+    if ( p[0] == '\0' ) {
+      break;
+    }
+    if (isdigit(p[0])) {
+      continue;
+    }
+    return 0;
+  }
+
+  
   return 1;
 } /* legal_path() */


### PR DESCRIPTION
Fixes erroneous error "Read access denied" when using `load_object()` on a file path containing an OID for an object that has been destructed.  The error now correctly states "Cannot load a clone."

```
base/internal/file.cc->legal_path()              // <-- This would return 0
src/packages/core/file.cc->check_valid_path()    // <-- Causing this to return 0
vm/internal/simulate.cc->load_object()           // <-- Causing this to return 'Read access denied."
```
`load_object()` in simulate.cc already contained logic to disallow '#' for clones which generates appropriate error messaging.  This was never being hit due to how '#' was being handled in `legal_path()`