### PR TITLE
Made undefinedp() work on unassigned class members.

### DIFF
--- a/src/vm/internal/base/class.cc
+++ b/src/vm/internal/base/class.cc
@@ -43,7 +43,7 @@ array_t *allocate_class(class_def_t *cld, int has_values) {
     }
   } else {
     while (n--) {
-      p->item[n] = const0;
+      p->item[n] = const0u;
     }
   }
   return p;
@@ -61,7 +61,7 @@ array_t *allocate_class_by_size(int size) {
   p->size = size;
 
   while (size--) {
-    p->item[size] = const0;
+    p->item[size] = const0u;
   }
 
   return p;

--- a/testsuite/single/tests/compiler/class.c
+++ b/testsuite/single/tests/compiler/class.c
@@ -1,0 +1,115 @@
+
+class TestClass {
+  int i;
+  float ft;
+  int *t;
+  string s;
+  mapping m;
+  function f;
+}
+
+class TestClass test_class;
+
+void do_tests() {
+
+  int i;
+  float ft;
+  mapping m;
+ 
+  i = 1;
+  ft = 1.0;
+  test_class = new(class TestClass);
+  
+  ASSERT(undefinedp(test_class.i));
+  ASSERT(undefinedp(test_class.ft));
+  ASSERT(undefinedp(test_class.t));
+  ASSERT(undefinedp(test_class.s));
+  ASSERT(undefinedp(test_class.m));
+  ASSERT(undefinedp(test_class.f));
+  
+  test_class->i = i;
+  test_class->ft = ft;
+  test_class->t = ({ 1, 2, 3 });
+
+  ASSERT(classp(test_class));
+  ASSERT(intp(test_class->i));
+  ASSERT(floatp(test_class.ft));
+  
+  ASSERT_EQ("class", typeof(test_class));
+
+  ASSERT_EQ(test_class->i, i);
+  ASSERT_EQ(test_class->ft, ft);
+  
+  ASSERT_EQ(test_class->i, test_class->i);
+  ASSERT_EQ(test_class.i, test_class.i);
+  ASSERT_EQ(test_class->i, test_class.i);
+  ASSERT_NE(test_class->i, test_class->ft);
+  ASSERT_NE(test_class.i, test_class.ft);
+  ASSERT_NE(test_class->i, test_class.ft);
+
+  ASSERT(intp(test_class->i));
+  ASSERT(intp(test_class.i));
+  ASSERT(floatp(test_class->ft));
+  ASSERT(floatp(test_class.ft));
+  
+  ASSERT_NE(2, test_class->i++);
+  ASSERT_NE(2.0, test_class->ft++);
+  ASSERT_EQ(3, ++test_class->i);
+  ASSERT_EQ(3.0, ++test_class->ft);
+  
+  ASSERT_NE(4, test_class.i++);
+  ASSERT_NE(4.0, test_class.ft++);
+  ASSERT_EQ(5, ++test_class.i);
+  ASSERT_EQ(5.0, ++test_class.ft);
+  
+  test_class.i = ++i;
+  test_class.ft = ++ft;
+  
+  ASSERT_EQ(test_class.i, i);
+  ASSERT_EQ(test_class.ft, ft);
+  
+  ASSERT_EQ(i + ft, test_class->i + test_class.ft);
+  
+  ASSERT_EQ(([ i : ft ]), ([ test_class->i : test_class.ft ]));
+    
+  ASSERT_EQ(i + ft, test_class->i + test_class.ft);
+  ASSERT_EQ(i + ft, test_class.i + test_class->ft);
+  ASSERT_EQ(i + ft, test_class->i + test_class->ft);
+  ASSERT_EQ(i + ft, test_class.i + test_class.ft);
+  
+  ASSERT_EQ(i - ft, test_class->i - test_class.ft);
+  ASSERT_EQ(i - ft, test_class.i - test_class->ft);
+  ASSERT_EQ(i - ft, test_class->i - test_class->ft);
+  ASSERT_EQ(i - ft, test_class.i - test_class.ft);
+  
+  ASSERT_EQ(i * ft, test_class->i * test_class.ft);
+  ASSERT_EQ(i * ft, test_class.i * test_class->ft);
+  ASSERT_EQ(i * ft, test_class->i * test_class->ft);
+  ASSERT_EQ(i * ft, test_class.i * test_class.ft);
+  
+  ASSERT_EQ(i / ft, test_class->i / test_class.ft);
+  ASSERT_EQ(i / ft, test_class.i / test_class->ft);
+  ASSERT_EQ(i / ft, test_class->i / test_class->ft);
+  ASSERT_EQ(i / ft, test_class.i / test_class.ft);
+  
+  ASSERT_EQ(({ 3 }), test_class->t[test_class->i..test_class->i]);
+  ASSERT_EQ(({ 3 }), test_class.t[test_class.i..test_class.i]);
+  ASSERT_EQ(({ 2, 3 }), test_class.t[test_class.i/test_class.i..test_class.i]);
+  ASSERT_EQ(({ 2, 3 }), test_class->t[test_class->i/test_class->i..test_class->i]);
+  ASSERT_EQ(({ 1, 2, 3 }), test_class.t[test_class.i-test_class.i..test_class.i]);
+  ASSERT_EQ(({ 1, 2, 3 }), test_class->t[test_class->i-test_class->i..test_class->i]);
+  
+  ASSERT_EQ(({ 1, test_class->i, 3 }), test_class->t);
+  ASSERT_EQ(({ 1, test_class.i, 3 }), test_class->t);
+  ASSERT_EQ(({ test_class.i/test_class.i, 2, 3 }), test_class->t);
+  ASSERT_EQ(({ test_class->i/test_class->i, 2, 3 }), test_class->t);
+  
+  m = ([ i : ft ]);
+  ASSERT_EQ(m[2], m[test_class->i]);
+  ASSERT_EQ(m[2], m[test_class.i]);
+  
+  ASSERT_EQ(test_class->t[1], test_class->t[1]);
+  ASSERT_EQ(test_class.t[1], test_class.t[1]);
+  
+  ASSERT_EQ(6, sizeof(test_class));  
+}


### PR DESCRIPTION
Made classes initialize members with `const0u` so that they can be tested with `undefinedp()`.  Added assertions to testsuite for undefined class members and moved test file from `testsuite/single/tests/operators/class.c` to `testsuite/single/tests/compiler/class.c`.

Fixes issue:  https://github.com/fluffos/fluffos/issues/903

```c
class SuperClass {
  int foo;
}

class SuperClass super;

void test()
{  
  string ret = "";
  super = new(class SuperClass);
  
  ret += sprintf("super.foo: %O\n", super.foo);
  ret += sprintf("identify(super.foo): %O\n", identify(super.foo));
  ret += sprintf("undefinedp(super.foo): %O\n", undefinedp(super.foo));
  ret += sprintf("typeof(super.foo): %O\n", typeof(super.foo));

  debug(":jezu", ret, wizards());
}
```
```
> eval return "/open/jezu/class.c"->test()
super.foo: 0
identify(super.foo): "UNDEFINED"
undefinedp(super.foo): 1
typeof(super.foo): "int"
```