### PR TITLE
Catch errors thrown when compiling LPC files.

### DIFF
--- a/src/compiler/internal/compiler.cc
+++ b/src/compiler/internal/compiler.cc
@@ -44,6 +44,7 @@ extern svalue_t *safe_apply_master_ob(int, int);
 
 static void clean_parser(void);
 static void prolog(std::unique_ptr<LexStream>, const char * /*name*/);
+static void clean_incomplete_parse(void);
 static program_t *epilog(void);
 static void show_overload_warnings(void);
 
@@ -2022,7 +2023,21 @@ program_t *compile_file(std::unique_ptr<LexStream> stream, const char *name) {
     symbol_start(name);
     prolog(std::move(stream), name);
     func_present = 0;
-    yyparse();
+    /*
+     * `yyparse` may throw, so make sure we clean up and then re-throw.
+     */
+    try {
+      yyparse();
+    } catch (const char *) {
+
+      symbol_end();
+      deinit_include_path();
+      clean_incomplete_parse();
+
+      guard = 0;
+      throw;
+
+    }
     symbol_end();
     prog = epilog();
   }
@@ -2196,6 +2211,20 @@ static void handle_functions() {
   }
 }
 
+static void clean_incomplete_parse(void) {
+
+  /* don't print these; they can be wrong, since we didn't parse the
+     entire file */
+  if (pragmas & PRAGMA_WARNINGS) {
+    remove_overload_warnings(nullptr);
+  }
+  clean_parser();
+  end_new_file();
+  free_string(current_file);
+  current_file = nullptr;
+
+}
+
 /*
  * The program has been compiled. Prepare a 'program_t' to be returned.
  */
@@ -2210,15 +2239,7 @@ static program_t *epilog(void) {
   deinit_include_path();
 
   if (num_parse_error > 0 || inherit_file) {
-    /* don't print these; they can be wrong, since we didn't parse the
-       entire file */
-    if (pragmas & PRAGMA_WARNINGS) {
-      remove_overload_warnings(nullptr);
-    }
-    clean_parser();
-    end_new_file();
-    free_string(current_file);
-    current_file = nullptr;
+    clean_incomplete_parse();
     return nullptr;
   }
 


### PR DESCRIPTION
When handling the inclusion of headers, the parser calls the `VALID_READ` apply. This may fail and throw an exception.  If this happens, the `guard` variable in `compile_file` is never cleared and the driver will be unable to load any more objects.

Here we see a roaming monster try to move to a room which is not loaded.  The driver's attempt to load it fails because the `valid_read` call for one of the headers it includes fails.
    
      Tue Oct 11 12:19:42 2022
      *Too long evaluation. Execution aborted.
      program: //adm/obj/master.c,
      object: /adm/obj/master line 250
      TP: kir, Query_verb: 'Unknown', POBJ: /adm/obj/master
      heart_beat     in //std/monster/town_guard.c /d/town/guards/mon/kir#48977 line 72
             Arguments: ({}), Locals: ({0,})
      heart_beat     in //std/monster.c     /d/town/guards/mon/kir#48977 line 318
             Arguments: ({}), Locals: ({({}),0,"",0,0,0,0,0,})
      DoRoam         in //std/monster/roamers/base_roamer.c /d/town/guards/mon/kir#48977 line 94
             Arguments: ({}), Locals: 0
      move_around    in //std/monster/roamers/base_roamer.c /d/town/guards/mon/kir#48977 line 80
             Arguments: ({}), Locals: ({0,})
      <fake>         in //<driver>          /d/town/guards/mon/kir#48977 line 0
             Arguments: 0, Locals: 0
      move_roamer    in //std/monster/town_guard.c /d/town/guards/mon/kir#48977 line 457
             Arguments: ({}), Locals: ({0,})
      move_roamer    in //std/monster/roamers/roamer.c /d/town/guards/mon/kir#48977 line 35
             Arguments: ({}), Locals: ({0,})
      get_valid_exits in //std/monster/roamers/roamer.c /d/town/guards/mon/kir#48977 line 56
             Arguments: ({}), Locals: ({({"east","south","northeast",}),0,0,,0,3,0,})
      query_exit     in //std/room/exits.c  /d/town/church/rooms/cyard line 92
             Arguments: ({"east",}), Locals: ({0,})
      find_object_or_load in //adm/obj/sefun/object/find_object_or_load.c /adm/obj/sefun/sefun line 18
             Arguments: ({"/d/town/church/rooms/cyard2",}), Locals: 0
      valid_read     in //adm/obj/master.c  /adm/obj/master line 250
             Arguments: ({"adm/include/std.h",,"include",}), Locals: 0
    
Shortly afterwards another roaming monster also attempts to move into a unloaded room, but this time the attempt to load it fails with a different error:
    
      Tue Oct 11 12:19:42 2022
      *Object cannot be loaded during compilation.
      program: //adm/obj/sefun/object/find_object_or_load.c,
      object: /adm/obj/sefun/sefun line 18
      TP: hawk, Query_verb: 'Unknown', POBJ: /adm/obj/sefun/sefun
      heart_beat     in //std/monster.c     /d/drakenwood/hoarwood/mon/blood_hawk#49320 line 318
             Arguments: ({}), Locals: ({({}),0,"",0,0,0,0,0,})
      DoRoam         in //std/monster/roamers/base_roamer.c /d/drakenwood/hoarwood/mon/blood_hawk#49320 line 94
             Arguments: ({}), Locals: 0
      move_around    in //std/monster/roamers/base_roamer.c /d/drakenwood/hoarwood/mon/blood_hawk#49320 line 80
             Arguments: ({}), Locals: ({0,})
      <fake>         in //<driver>          /d/drakenwood/hoarwood/mon/blood_hawk#49320 line 0
             Arguments: 0, Locals: 0
      move_roamer    in //std/monster/roamers/roamer.c /d/drakenwood/hoarwood/mon/blood_hawk#49320 line 35
             Arguments: ({}), Locals: ({0,})
      get_valid_exits in //std/monster/roamers/roamer.c /d/drakenwood/hoarwood/mon/blood_hawk#49320 line 56
             Arguments: ({}), Locals: ({({"west","east","southwest",}),0,0,,0,3,0,})
      query_exit     in //std/room/exits.c  /d/drakenwood/hoarwood/rooms/rm21 line 92
             Arguments: ({"west",}), Locals: ({0,})
      find_object_or_load in //adm/obj/sefun/object/find_object_or_load.c /adm/obj/sefun/sefun line 18
             Arguments: ({"/d/drakenwood/hoarwood/rooms/sec07",}), Locals: 0

Wrap `yyparse` in a try-catch block in order to clean up properly before re-throwing.

Signed-off-by: Jeremy Sowden <jeremy@azazel.net>