### PR TITLE
expand printf / sprintf documentation with dynamic field size examples

### DIFF
--- a/docs/efun/interactive/printf.md
+++ b/docs/efun/interactive/printf.md
@@ -106,6 +106,11 @@ title: interactive / printf
         printf("%10.2f", 1.2345)      =   "      1.23"
         printf("%10.6f", 0.123)       =   "  0.123000"
 
+    Dynamic Field Size:
+        printf("%-*s", 10, "ten")     =   "ten       "
+        printf("%|*s", 20, "twenty")  =   "       twenty       "
+        printf("%*s", 30, "thirty")   =   "                        thirty"
+
 ### AUTHOR
 
     Sean A. Reith (Lynscar)

--- a/docs/efun/strings/sprintf.md
+++ b/docs/efun/strings/sprintf.md
@@ -104,6 +104,11 @@ title: strings / sprintf
         sprintf("%10.2f", 1.2345)     =   "      1.23"
         sprintf("%10.6f", 0.123)      =   "  0.123000"
 
+    Dynamic Field Size:
+        sprintf("%-*s", 10, "ten")    =   "ten       "
+        sprintf("%|*s", 20, "twenty") =   "       twenty       "
+        sprintf("%*s", 30, "thirty")  =   "                        thirty"
+
 ### AUTHOR
 
     Sean A. Reith (Lynscar)


### PR DESCRIPTION
Updates `docs/efun/interactive/printf.md` and `docs/efun/strings/sprintf.md` with examples of using dynamic field sizes with printf / sprintf.