### PR TITLE
update github actions/checkout version to fix warnings

### DIFF
--- a/.github/workflows/ci-osx.yml
+++ b/.github/workflows/ci-osx.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Install packages
       run: brew install cmake pkg-config pcre libgcrypt openssl jemalloc icu4c mysql-client sqlite3
     - name: compile

--- a/.github/workflows/ci-sanitizer.yml
+++ b/.github/workflows/ci-sanitizer.yml
@@ -22,7 +22,7 @@ jobs:
         build: ["Debug", "RelWithDebInfo"]
     runs-on: "ubuntu-latest"
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Install packages
       run: |
         sudo apt update

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -28,7 +28,7 @@ jobs:
       - uses: msys2/setup-msys2@v2
         with:
           update: true
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Install
         run: |
           if [ "$MSYSTEM" = "MINGW32" ]; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Install packages
       run: |
         sudo apt update

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -29,7 +29,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         # We must fetch at least the immediate parents so that if this is
         # a pull request then we can checkout the head.

--- a/.github/workflows/coverity-scan.yml
+++ b/.github/workflows/coverity-scan.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Install packages
         run: |
           sudo apt update

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -33,7 +33,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       # Login against a Docker registry except on PR
       # https://github.com/docker/login-action


### PR DESCRIPTION
Updates `actions/checkout` from `v2` (which uses `node.js 12`) to `v3` (which uses `node.js 16`). `node.js 12` has been deprecated from Github Actions and is generating the following warnings at the bottom of each Action's Summary:
![image](https://user-images.githubusercontent.com/1260602/209737783-379585bb-97e6-41a0-9077-92cb7986247d.png)
