### PR TITLE
updating Ubuntu build instructions

### DIFF
--- a/docs/build.md
+++ b/docs/build.md
@@ -55,7 +55,7 @@ $ sudo pip install --upgrade cmake
 $ mkdir build
 $ cd build
 $ cmake ..
-$ make -j4 install
+$ make -j `nproc` install
 ```
 
 - Find binary files and support files in ./bin/


### PR DESCRIPTION
Updating the make command to include ``nproc`` rather than specifying the number processors. This way it will use the number processors available.