### PR TITLE
Enforce C locale during parsing/compiling

### DIFF
--- a/docs/apply/index.md
+++ b/docs/apply/index.md
@@ -201,6 +201,6 @@ title: APPLY
 
 <div class="alert alert-info my-4" role="alert">
     <img src="https://cdnjs.cloudflare.com/ajax/libs/octicons/8.5.0/svg/info.svg">
-    This page is auto generated on 2023-05-29 10:39:12 Pacific Daylight Time for v2019.20220507-35-g8e36eb2e-dirty.</a>
+    This page is auto generated on 2023-05-29 21:09:24 Pacific Daylight Time for v2019.20220507-61-gce9633f3-dirty.</a>
 </div>
 

--- a/docs/concepts/index.md
+++ b/docs/concepts/index.md
@@ -40,6 +40,6 @@ title: concepts
 
 <div class="alert alert-info my-4" role="alert">
     <img src="https://cdnjs.cloudflare.com/ajax/libs/octicons/8.5.0/svg/info.svg">
-    This page is auto generated on 2023-05-29 10:39:13 Pacific Daylight Time for v2019.20220507-35-g8e36eb2e-dirty.</a>
+    This page is auto generated on 2023-05-29 21:09:24 Pacific Daylight Time for v2019.20220507-61-gce9633f3-dirty.</a>
 </div>
 

--- a/docs/driver/index.md
+++ b/docs/driver/index.md
@@ -28,6 +28,6 @@ title: driver
 
 <div class="alert alert-info my-4" role="alert">
     <img src="https://cdnjs.cloudflare.com/ajax/libs/octicons/8.5.0/svg/info.svg">
-    This page is auto generated on 2023-05-29 10:39:13 Pacific Daylight Time for v2019.20220507-35-g8e36eb2e-dirty.</a>
+    This page is auto generated on 2023-05-29 21:09:24 Pacific Daylight Time for v2019.20220507-61-gce9633f3-dirty.</a>
 </div>
 

--- a/docs/efun/index.md
+++ b/docs/efun/index.md
@@ -1129,6 +1129,9 @@ title: EFUN
 <div><a href='system/strptime.html'>strptime</a></div>
 </div>
 <div class='col-sm-4 col-md-3 col-lg-3 col-xl-2'>
+<div><a href='system/sys_reload_tls.html'>sys_reload_tls</a></div>
+</div>
+<div class='col-sm-4 col-md-3 col-lg-3 col-xl-2'>
 <div><a href='system/time.html'>time</a></div>
 </div>
 <div class='col-sm-4 col-md-3 col-lg-3 col-xl-2'>
@@ -1147,6 +1150,6 @@ title: EFUN
 
 <div class="alert alert-info my-4" role="alert">
     <img src="https://cdnjs.cloudflare.com/ajax/libs/octicons/8.5.0/svg/info.svg">
-    This page is auto generated on 2023-05-29 10:39:12 Pacific Daylight Time for v2019.20220507-35-g8e36eb2e-dirty.</a>
+    This page is auto generated on 2023-05-29 21:09:24 Pacific Daylight Time for v2019.20220507-61-gce9633f3-dirty.</a>
 </div>
 

--- a/docs/efun/system/sys_reload_tls.md
+++ b/docs/efun/system/sys_reload_tls.md
@@ -1,0 +1,23 @@
+---
+layout: default
+title: system / sys_reload_tls
+---
+
+### NAME
+
+    sys_reload_tls() - Reload the TLS certificate and key for given port.
+
+### SYNOPSIS
+
+    void sys_reload_tls ( int port_index );
+
+### DESCRIPTION
+
+    Reload the TLS certificate and key for given port index, as specified in config file.
+
+    For example, if you defined external_port_1_tls in the config then you can calling sys_reload_tls(1) to reload
+    it. This allows you to update the certificate and key without restarting the server.
+
+    Note:
+      - you have to overwrite the previous cert/key file on disk before calling this function.
+      - reloading TLS for websocket port is not currently supported.

--- a/docs/lpc/index.md
+++ b/docs/lpc/index.md
@@ -84,6 +84,6 @@ title: lpc
 
 <div class="alert alert-info my-4" role="alert">
     <img src="https://cdnjs.cloudflare.com/ajax/libs/octicons/8.5.0/svg/info.svg">
-    This page is auto generated on 2023-05-29 10:39:13 Pacific Daylight Time for v2019.20220507-35-g8e36eb2e-dirty.</a>
+    This page is auto generated on 2023-05-29 21:09:24 Pacific Daylight Time for v2019.20220507-61-gce9633f3-dirty.</a>
 </div>
 

--- a/docs/stdlib/index.md
+++ b/docs/stdlib/index.md
@@ -90,6 +90,6 @@ title: STDLIB
 
 <div class="alert alert-info my-4" role="alert">
     <img src="https://cdnjs.cloudflare.com/ajax/libs/octicons/8.5.0/svg/info.svg">
-    This page is auto generated on 2023-05-29 10:39:13 Pacific Daylight Time for v2019.20220507-35-g8e36eb2e-dirty.</a>
+    This page is auto generated on 2023-05-29 21:09:24 Pacific Daylight Time for v2019.20220507-61-gce9633f3-dirty.</a>
 </div>
 

--- a/docs/zh-CN/apply/index.md
+++ b/docs/zh-CN/apply/index.md
@@ -186,6 +186,6 @@ title: APPLY
 
 <div class="alert alert-info my-4" role="alert">
     <img src="https://cdnjs.cloudflare.com/ajax/libs/octicons/8.5.0/svg/info.svg">
-    This page is auto generated on 2023-05-29 10:39:13 Pacific Daylight Time for v2019.20220507-35-g8e36eb2e-dirty.</a>
+    This page is auto generated on 2023-05-29 21:09:24 Pacific Daylight Time for v2019.20220507-61-gce9633f3-dirty.</a>
 </div>
 

--- a/docs/zh-CN/index.md
+++ b/docs/zh-CN/index.md
@@ -945,6 +945,6 @@ title: zh-CN
 
 <div class="alert alert-info my-4" role="alert">
     <img src="https://cdnjs.cloudflare.com/ajax/libs/octicons/8.5.0/svg/info.svg">
-    This page is auto generated on 2023-05-29 10:39:13 Pacific Daylight Time for v2019.20220507-35-g8e36eb2e-dirty.</a>
+    This page is auto generated on 2023-05-29 21:09:24 Pacific Daylight Time for v2019.20220507-61-gce9633f3-dirty.</a>
 </div>
 

--- a/src/compiler/internal/compiler.cc
+++ b/src/compiler/internal/compiler.cc
@@ -1995,6 +1995,10 @@ program_t *compile_file(int f, char *name) {
   guard = 1;
 
   {
+    // make sure we use the C locale during parsing
+    auto *current_locale = setlocale(LC_ALL, "C");
+    DEFER{ setlocale(LC_ALL, current_locale);};
+
     symbol_start(name);
     prolog(f, name);
     func_present = 0;

--- a/src/packages/core/core.spec
+++ b/src/packages/core/core.spec
@@ -359,3 +359,5 @@ void trace_end();
 int perf_counter_ns();
 // Return nanosecond time
 int time_ns();
+
+void sys_reload_tls(int);

--- a/src/packages/core/sys.cc
+++ b/src/packages/core/sys.cc
@@ -1,0 +1,35 @@
+#include "base/package_api.h"
+
+#include "net/tls.h"
+
+#ifdef F_SYS_RELOAD_TLS
+void f_sys_reload_tls() {
+  auto port_index_display = sp->u.number;
+  auto port_index = port_index_display - 1;
+
+  DEFER{ pop_stack(); };
+  if (port_index < 0 || port_index > sizeof(external_port)) {
+    error("Invalid port index: %d\n", port_index_display);
+  }
+  auto *port = &external_port[port_index];
+  if (port->kind == PORT_TYPE_UNDEFINED) {
+    error("Invalid port index: %d\n", port_index_display);
+  }
+  if (port->kind == PORT_TYPE_WEBSOCKET) {
+    error("Reloading websocket TLS config is not supported for port %d.\n", port->port);
+  } else {
+    if (port->ssl == nullptr) {
+      error("Port %d is not TLS enabled\n", port_index_display);
+    }
+    auto *ctx = tls_server_init(port->tls_cert, port->tls_key);
+    if (ctx == nullptr) {
+      error("Failed to reload TLS context for port %d\n", port->port);
+    }
+    // no race condition here since connection listener operates on main thread(), as all EFUNs do
+    auto *old_ctx = port->ssl;
+    tls_server_close(old_ctx);
+    port->ssl = ctx;
+    debug_message("Reloading TLS config for port %d.\n", port->port);
+  }
+}
+#endif

--- a/testsuite/single/tests/efuns/sys_reload_tls.c
+++ b/testsuite/single/tests/efuns/sys_reload_tls.c
@@ -1,0 +1,29 @@
+void do_tests_real() {
+  // non tls port
+  ASSERT_NE(0, catch(sys_reload_tls(0)));
+
+  // no support for websocket
+  ASSERT_NE(0, catch(sys_reload_tls(2)));
+
+  // valid tls
+  ASSERT_EQ(0, sys_reload_tls(4));
+}
+void after_boot() {
+  mixed err;
+  write("boot finished, doing test.\n");
+
+  err = catch(do_tests_real());
+
+  if (err) {
+    debug_message(err);
+    shutdown(-1);
+  }
+
+  write("sys_reload_tls: succeed.\n");
+}
+void do_tests() {
+  write("waiting for boot...\n");
+
+  call_out("after_boot", 0);
+}
+


### PR DESCRIPTION
Enforce C locale during parsing/compiling :  fix #962 
EFUN: sys_reload_tls(int port_index) ,  partial fix for #810 