### PR TITLE
fix: efun::sys_network_ports

### DIFF
--- a/docs/efun/system/sys_network_ports.md
+++ b/docs/efun/system/sys_network_ports.md
@@ -20,7 +20,7 @@ title: system / sys_network_ports
 
     An array of the following sub-array will be returned with each active port:
 
-        ({ (string) type, (int) port, (int) tls, })
+        ({ (int) external_port_#, (string) type, (int) port, (int) tls, })
 
 ### SEE ALSO
 

--- a/src/packages/core/sys.cc
+++ b/src/packages/core/sys.cc
@@ -5,15 +5,17 @@
 #ifdef F_SYS_NETWORK_PORTS
 void f_sys_network_ports() {
   array_t *info;
-  int i, ports = 0;
+  int i = 0, p = 0;
 
   for (i = 0; i < 5; i++) {
     if (external_port[i].port) {
-      ports += 1;
+      p ++;
     }
   }
 
-  info = allocate_empty_array(ports);
+  info = allocate_empty_array(p);
+  p = 0;
+
   for (i = 0; i < 5; i++) {
     if (!external_port[i].port) {
       continue;
@@ -32,9 +34,11 @@ void f_sys_network_ports() {
     p->item[2].subtype = 0;
     p->item[2].u.number = !external_port[i].tls_cert.empty() && !external_port[i].tls_key.empty();
 
-    info->item[i].type = T_ARRAY;
-    info->item[i].u.arr = p;
+    info->item[p].type = T_ARRAY;
+    info->item[p].u.arr = pInfo;
+    p ++;
   }
+
   push_refed_array(info);
 }
 #endif

--- a/src/packages/core/sys.cc
+++ b/src/packages/core/sys.cc
@@ -20,19 +20,23 @@ void f_sys_network_ports() {
     if (!external_port[i].port) {
       continue;
     }
-    array_t *p = allocate_empty_array(3);
+    array_t *pInfo = allocate_empty_array(4);
 
-    p->item[0].type = T_STRING;
-    p->item[0].subtype = STRING_CONSTANT;
-    p->item[0].u.string = port_kind_name(external_port[i].kind);
+    pInfo->item[0].type = T_NUMBER;
+    pInfo->item[0].subtype = 0;
+    pInfo->item[0].u.number = i + 1;
 
-    p->item[1].type = T_NUMBER;
-    p->item[1].subtype = 0;
-    p->item[1].u.number = external_port[i].port;
+    pInfo->item[1].type = T_STRING;
+    pInfo->item[1].subtype = STRING_CONSTANT;
+    pInfo->item[1].u.string = port_kind_name(external_port[i].kind);
 
-    p->item[2].type = T_NUMBER;
-    p->item[2].subtype = 0;
-    p->item[2].u.number = !external_port[i].tls_cert.empty() && !external_port[i].tls_key.empty();
+    pInfo->item[2].type = T_NUMBER;
+    pInfo->item[2].subtype = 0;
+    pInfo->item[2].u.number = external_port[i].port;
+
+    pInfo->item[3].type = T_NUMBER;
+    pInfo->item[3].subtype = 0;
+    pInfo->item[3].u.number = !external_port[i].tls_cert.empty() && !external_port[i].tls_key.empty();
 
     info->item[p].type = T_ARRAY;
     info->item[p].u.arr = pInfo;

--- a/testsuite/single/tests/efuns/sys_network_ports.c
+++ b/testsuite/single/tests/efuns/sys_network_ports.c
@@ -5,23 +5,27 @@ void do_tests() {
     ASSERT_EQ(1, arrayp(ports));
     ASSERT_EQ(4, sizeof(ports));
 
-    port = filter(ports, (: $1[1] == 4000 :))[0];
-    ASSERT_EQ("telnet", port[0]);
-    ASSERT_EQ(4000, port[1]);
-    ASSERT_EQ(0, port[2]); // no tls
+    port = filter(ports, (: $1[2] == 4000 :))[0];
+    ASSERT_EQ(1, port[0]);
+    ASSERT_EQ("telnet", port[1]);
+    ASSERT_EQ(4000, port[2]);
+    ASSERT_EQ(0, port[3]); // no tls
 
-    port = filter(ports, (: $1[1] == 4001 :))[0];
-    ASSERT_EQ("websocket", port[0]);
-    ASSERT_EQ(4001, port[1]);
-    ASSERT_EQ(0, port[2]); // no tls
+    port = filter(ports, (: $1[2] == 4001 :))[0];
+    ASSERT_EQ(2, port[0]);
+    ASSERT_EQ("websocket", port[1]);
+    ASSERT_EQ(4001, port[2]);
+    ASSERT_EQ(0, port[3]); // no tls
 
-    port = filter(ports, (: $1[1] == 4002 :))[0];
-    ASSERT_EQ("websocket", port[0]);
-    ASSERT_EQ(4002, port[1]);
-    ASSERT_EQ(1, port[2]); // tls
+    port = filter(ports, (: $1[2] == 4002 :))[0];
+    ASSERT_EQ(3, port[0]);
+    ASSERT_EQ("websocket", port[1]);
+    ASSERT_EQ(4002, port[2]);
+    ASSERT_EQ(1, port[3]); // tls
 
-    port = filter(ports, (: $1[1] == 4003 :))[0];
-    ASSERT_EQ("telnet", port[0]);
-    ASSERT_EQ(4003, port[1]);
-    ASSERT_EQ(1, port[2]); // tls
+    port = filter(ports, (: $1[2] == 4003 :))[0];
+    ASSERT_EQ(4, port[0]);
+    ASSERT_EQ("telnet", port[1]);
+    ASSERT_EQ(4003, port[2]);
+    ASSERT_EQ(1, port[3]); // tls
 }


### PR DESCRIPTION
Changed:
* efun::sys_network_ports was returning `T_INVALID` if your external_ports config skipped a number (ex: `external_port_1`, `external_port_3`, `external_port_5` would return only `external_port_1`)
* efun::sys_network_ports will include `external_port_#` for use with efun::sys_refresh_tls