### PR TITLE
update sprintf to convert int/float if wrong type passed

### DIFF
--- a/src/packages/core/sprintf.cc
+++ b/src/packages/core/sprintf.cc
@@ -1293,25 +1293,19 @@ char *string_print_formatted(const char *format_str, int argc, svalue_t *argv) {
             default:
               SPRINTF_ERROR(ERR_BAD_INT_TYPE);
           }
-          if ((cheat[i - 1] == 'f' && carg->type != T_REAL) ||
+          if ((cheat[i - 1] == 'f' && carg->type == T_NUMBER)) {
+            // convert to T_REAL
+            LPC_FLOAT temp = carg->u.number;
+            carg->type = T_REAL;
+            carg->u.real = temp;
+          } else if ((cheat[i - 1] == 'd' && carg->type == T_REAL)) {
+            // convert to T_NUMBER
+            LPC_INT temp = floor(carg->u.real);
+            carg->type = T_NUMBER;
+            carg->u.number = temp;
+          } else if ((cheat[i - 1] == 'f' && carg->type != T_REAL) ||
               (cheat[i - 1] != 'f' && carg->type != T_NUMBER)) {
-#ifdef RETURN_ERROR_MESSAGES
-            sprintf(buff,
-                    "ERROR: (s)printf(): Incorrect argument type to %%%c. "
-                    "(arg: %u)\n",
-                    cheat[i - 1], sprintf_state->cur_arg);
-            debug_message("Program /%s File: %s: %s", current_prog->name, get_line_number_if_any(),
-                          buff);
-            debug_message("%s", buff);
-            if (current_object) {
-              debug_message("program: /%s, object: %s, file: %s\n",
-                            current_prog ? current_prog->name : "", current_object->name,
-                            get_line_number_if_any());
-            }
-            ERROR(ERR_RECOVERY_ONLY);
-#else
             error("ERROR: (s)printf(): Incorrect argument type to %%%c.\n", cheat[i - 1]);
-#endif /* RETURN_ERROR_MESSAGES */
           }
           cheat[i] = '\0';
 

--- a/testsuite/single/tests/efuns/sprintf.c
+++ b/testsuite/single/tests/efuns/sprintf.c
@@ -282,4 +282,30 @@ TEXT;
   ASSERT_EQ(shouldbe, sprintf("%-=1s %-=2s\n",
                               implode(({ "11111",     "2222",      "333"}), "\n"),
                               implode(({ "aaa",  "bbb",   "cccc" }), "\n")));
+
+#define UNDEFINED (([])[0])
+    // UNDEFINED checks
+    ASSERT_EQ("0", sprintf("%s", UNDEFINED));
+    ASSERT_EQ("0", sprintf("%d", UNDEFINED));
+    ASSERT_EQ("0", sprintf("%O", UNDEFINED));
+    ASSERT_EQ("0", sprintf("%o", UNDEFINED));
+    ASSERT_EQ("0", sprintf("%x", UNDEFINED));
+    ASSERT_EQ("0.000000", sprintf("%f", UNDEFINED));
+
+    // zero checks
+    ASSERT_EQ("0", sprintf("%s", 0));
+    ASSERT_EQ("0", sprintf("%d", 0));
+    ASSERT_EQ("0", sprintf("%O", 0));
+    ASSERT_EQ("0", sprintf("%o", 0));
+    ASSERT_EQ("0", sprintf("%x", 0));
+    ASSERT_EQ("0.000000", sprintf("%f", 0));
+
+    // expected number checks
+    ASSERT_EQ("123", sprintf("%d", 123));
+    ASSERT_EQ("123.000000", sprintf("%f", 123.0));
+
+    // converted number checks
+    ASSERT_EQ("123", sprintf("%d", 123.0));
+    ASSERT_EQ("123", sprintf("%d", 123.123)); // truncates
+    ASSERT_EQ("123.000000", sprintf("%f", 123));
 }


### PR DESCRIPTION
Changes:
* convert a `T_REAL` to a `T_NUMBER` for `%d` flag
* convert a `T_NUMBER` to a `T_REAL` for `%f` flag
* expand testing in `testsuite/single/tests/efuns/sprintf.c`
* remove `RETURN_ERROR_MESSAGES` check which does not appear to exist anywhere else in the code base

The following conditions will no longer error:
```c
sprintf("%f", UNDEFINED)    // 0.000000
sprintf("%f", 0)            // 0.000000
sprintf("%d", 123.0)        // 123
sprintf("%d", 123.123)      // 123
sprintf("%f", 123)          // 123.000000
```