### PR TITLE
update docs for efuns hash, crypt, oldcrypt, and sha1

### DIFF
--- a/docs/efun/index.md
+++ b/docs/efun/index.md
@@ -1012,6 +1012,9 @@ title: EFUN
 <div><a href='strings/explode.html'>explode</a></div>
 </div>
 <div class='col-sm-4 col-md-3 col-lg-3 col-xl-2'>
+<div><a href='strings/hash.html'>hash</a></div>
+</div>
+<div class='col-sm-4 col-md-3 col-lg-3 col-xl-2'>
 <div><a href='strings/implode.html'>implode</a></div>
 </div>
 <div class='col-sm-4 col-md-3 col-lg-3 col-xl-2'>
@@ -1019,6 +1022,9 @@ title: EFUN
 </div>
 <div class='col-sm-4 col-md-3 col-lg-3 col-xl-2'>
 <div><a href='strings/ltrim.html'>ltrim</a></div>
+</div>
+<div class='col-sm-4 col-md-3 col-lg-3 col-xl-2'>
+<div><a href='strings/oldcrypt.html'>oldcrypt</a></div>
 </div>
 <div class='col-sm-4 col-md-3 col-lg-3 col-xl-2'>
 <div><a href='strings/reg_assoc.html'>reg_assoc</a></div>
@@ -1172,6 +1178,6 @@ title: EFUN
 
 <div class="alert alert-info my-4" role="alert">
     <img src="https://cdnjs.cloudflare.com/ajax/libs/octicons/8.5.0/svg/info.svg">
-    This page is auto generated on 2023-06-06 14:39:21 EDT for 39faf554.</a>
+    This page is auto generated on 2023-09-01 14:53:15 EDT for 44dabf8c.</a>
 </div>
 

--- a/docs/efun/index.md
+++ b/docs/efun/index.md
@@ -1042,6 +1042,9 @@ title: EFUN
 <div><a href='strings/set_bit.html'>set_bit</a></div>
 </div>
 <div class='col-sm-4 col-md-3 col-lg-3 col-xl-2'>
+<div><a href='strings/sha1.html'>sha1</a></div>
+</div>
+<div class='col-sm-4 col-md-3 col-lg-3 col-xl-2'>
 <div><a href='strings/sprintf.html'>sprintf</a></div>
 </div>
 <div class='col-sm-4 col-md-3 col-lg-3 col-xl-2'>
@@ -1178,6 +1181,6 @@ title: EFUN
 
 <div class="alert alert-info my-4" role="alert">
     <img src="https://cdnjs.cloudflare.com/ajax/libs/octicons/8.5.0/svg/info.svg">
-    This page is auto generated on 2023-09-01 14:53:15 EDT for 44dabf8c.</a>
+    This page is auto generated on 2023-09-01 15:16:01 EDT for 3e5c788d.</a>
 </div>
 

--- a/docs/efun/strings/crypt.md
+++ b/docs/efun/strings/crypt.md
@@ -13,8 +13,34 @@ title: strings / crypt
 
 ### DESCRIPTION
 
-    Crypt  the string <str> using the first two characters from <seed> as a
-    seed. If <seed> is 0, then random seed is used.
+    Encrypt the string `str` using string `seed`. If `seed` is zero, then
+    a random seed will be used.
 
-    The result has the first two characters as the seed.
+    The encrypted result can be used as the `seed` of a second encrypt,
+    which will return the original encrypted result if both `str` inputs
+    were identical.
 
+### NOTE
+
+    The encryption methods of FluffOS and MudOS are different. For MudOS
+    compatibity you should use oldcrypt().
+
+### EXAMPLE
+
+    Example of verifying a password using crypt():
+
+    // turn user input into crypted password
+    string cryptPasswd = crypt(input, 0);
+
+    // store crypted password in user save somewhere
+
+    // compare login input to stored crypted password
+    if (crypt(input, cryptPasswd) == cryptPasswd) {
+        // valid password
+    } else {
+        // invalid password attempt
+    }
+
+### SEE ALSO
+
+    oldcrypt(3), hash(3)

--- a/docs/efun/strings/hash.md
+++ b/docs/efun/strings/hash.md
@@ -1,0 +1,36 @@
+---
+layout: default
+title: strings / hash
+---
+
+### NAME
+
+    hash() - hash of a string specifying the algorithm
+
+### SYNOPSIS
+
+    string hash( string algo, string str );
+
+### DESCRIPTION
+
+    Returns the hash of string `str` by the `algo` algorithm.
+    
+    Aglorithm `algo` can be one of:
+    md4 md5 sha1 sha224 sha256 sha384 sha512 ripemd160
+
+    This requires PACKAGE_CRYPTO to be enabled when compiling the driver.
+
+### EXAMPLE
+
+    hash("md4", "Something")        =   "abc554cae9acd8f168101954383335df"
+    hash("md5", "Something")        =   "73f9977556584a369800e775b48f3dbe"
+    hash("ripemd160", "Something")  =   ...40 characters...
+    hash("sha1", "Something")       =   ...40 characters...
+    hash("sha224", "Something")     =   ...56 characters...
+    hash("sha256", "Something")     =   ...64 characters...
+    hash("sha384", "Something")     =   ...96 characters...
+    hash("sha512", "Something")     =   ...128 characters...
+
+### SEE ALSO
+
+    crypt(3), oldcrypt(3)

--- a/docs/efun/strings/hash.md
+++ b/docs/efun/strings/hash.md
@@ -5,7 +5,7 @@ title: strings / hash
 
 ### NAME
 
-    hash() - hash of a string specifying the algorithm
+    hash() - hash a string with the specified algorithm
 
 ### SYNOPSIS
 
@@ -33,4 +33,4 @@ title: strings / hash
 
 ### SEE ALSO
 
-    crypt(3), oldcrypt(3)
+    crypt(3), oldcrypt(3), sha1(3)

--- a/docs/efun/strings/oldcrypt.md
+++ b/docs/efun/strings/oldcrypt.md
@@ -1,0 +1,70 @@
+---
+layout: default
+title: strings / oldcrypt
+---
+
+### NAME
+
+    oldcrypt() - encrypt a string
+
+### SYNOPSIS
+
+    string oldcrypt( string str, string seed );
+
+### DESCRIPTION
+
+    Encrypt the string `str` using the first two characters from string 
+    `seed`. If `seed` is zero, then a random seed will be used.
+
+    The encrypted result can be used as the `seed` of a second encrypt,
+    which will return the original encrypted result if both `str` inputs
+    were identical.
+
+### NOTE
+
+    The encryption methods of FluffOS and MudOS are different. For MudOS
+    compatibity you should use oldcrypt().
+
+### EXAMPLE
+
+    Example of verifying a password using oldcrypt():
+
+    // turn user input into crypted password
+    string cryptPasswd = oldcrypt(input, 0);
+
+    // store crypted password in user save somewhere
+
+    // compare login input to stored crypted password
+    if (oldcrypt(input, cryptPasswd) == cryptPasswd) {
+        // valid password
+    } else {
+        // invalid password attempt
+    }
+
+### UPGRADE
+
+    Example of upgrading existing user passwords to crypt():
+
+    // confirm if user provided correct password for existing user
+    int verify_password (string input) {
+        string password = query_password();
+
+        // crypt comparison
+        if (password[0..2] == "$6$" && crypt(input, password) == password) {
+            return 1;
+        }
+
+        // oldcrypt comparison & upgrade to crypt
+        if (oldcrypt(input, password) == password) {
+            set_password(crypt(input, 0));
+            write("Your password hash has been updated to use to SHA-512.");
+            return 1;
+        }
+
+        // invalid password
+        return 0;
+    }
+
+### SEE ALSO
+
+    crypt(3), hash(3)

--- a/docs/efun/strings/oldcrypt.md
+++ b/docs/efun/strings/oldcrypt.md
@@ -41,30 +41,6 @@ title: strings / oldcrypt
         // invalid password attempt
     }
 
-### UPGRADE
-
-    Example of upgrading existing user passwords to crypt():
-
-    // confirm if user provided correct password for existing user
-    int verify_password (string input) {
-        string password = query_password();
-
-        // crypt comparison
-        if (password[0..2] == "$6$" && crypt(input, password) == password) {
-            return 1;
-        }
-
-        // oldcrypt comparison & upgrade to crypt
-        if (oldcrypt(input, password) == password) {
-            set_password(crypt(input, 0));
-            write("Your password hash has been updated to use to SHA-512.");
-            return 1;
-        }
-
-        // invalid password
-        return 0;
-    }
-
 ### SEE ALSO
 
     crypt(3), hash(3)

--- a/docs/efun/strings/sha1.md
+++ b/docs/efun/strings/sha1.md
@@ -1,0 +1,29 @@
+---
+layout: default
+title: strings / sha1
+---
+
+### NAME
+
+    sha1() - hash a string using SHA-1
+
+### SYNOPSIS
+
+    string sha1(string str | buffer bf);
+
+### DESCRIPTION
+
+    Returns the SHA-1 hash of string `str` or buffer `bf` using SHA-1.
+
+    This requires PACKAGE_CRYPTO to be enabled when compiling the driver.
+
+    Note:
+    The `hash(algo, str)` external function can handle SHA-1 and more.
+
+### EXAMPLE
+
+    sha1("something") = "1af17e73721dbe0c40011b82ed4bb1a7dbe3ce29"
+
+### SEE ALSO
+
+    hash(3)

--- a/src/packages/crypto/crypto.cc
+++ b/src/packages/crypto/crypto.cc
@@ -102,7 +102,7 @@ void f_hash() {
 
 result:
   if (!result) {
-    error("hash() unknown hash type: %s", algo);
+    error("hash() unknown hash type: %s\n", algo);
   }
 
   /* Pop the arguments off the stack and push the result */

--- a/testsuite/single/tests/efuns/hash.c
+++ b/testsuite/single/tests/efuns/hash.c
@@ -1,10 +1,7 @@
 void do_tests() {
-
 #ifndef __PACKAGE_CRYPTO__
     write("PACKAGE_CRYPTO not defined: test not run.\n");
-    return;
-#endif
-
+#else
     ASSERT_EQ(hash("md5", "11111"), "b0baee9d279d34fa1dfd71aadb908c3f");
     ASSERT_EQ(hash("md5", "abc"), "900150983cd24fb0d6963f7d28e17f72");
     ASSERT_EQ(hash("md5", "something"), "437b930db84b8079c2dd804a71936b5f");
@@ -27,4 +24,5 @@ void do_tests() {
     ASSERT_EQ(sizeof(hash("sha384", "12345")), 96);
     ASSERT_EQ(hash("sha512", "12345"), "3627909a29c31381a071ec27f7c9ca97726182aed29a7ddd2e54353322cfb30abb9e3a6df2ac2c20fe23436311d678564d0c8d305930575f60e2d3d048184d79");
     ASSERT_EQ(sizeof(hash("sha512", "12345")), 128);
+#endif
 }

--- a/testsuite/single/tests/efuns/hash.c
+++ b/testsuite/single/tests/efuns/hash.c
@@ -1,8 +1,30 @@
 void do_tests() {
+
 #ifndef __PACKAGE_CRYPTO__
-  write("PACKAGE_CRYPTO not defined: test not run.\n");
-#else
-  ASSERT_EQ(hash("md5", "11111"), "b0baee9d279d34fa1dfd71aadb908c3f");
-  // TODO: adding more test cases.
+    write("PACKAGE_CRYPTO not defined: test not run.\n");
+    return;
 #endif
+
+    ASSERT_EQ(hash("md5", "11111"), "b0baee9d279d34fa1dfd71aadb908c3f");
+    ASSERT_EQ(hash("md5", "abc"), "900150983cd24fb0d6963f7d28e17f72");
+    ASSERT_EQ(hash("md5", "something"), "437b930db84b8079c2dd804a71936b5f");
+
+    ASSERT_EQ(hash("md4", "12345"), "23580e2a459f7ea40f9efa148b63cafb");
+    ASSERT_EQ(sizeof(hash("md4", "12345")), 32);
+    ASSERT_EQ(hash("md5", "12345"), "827ccb0eea8a706c4c34a16891f84e7b");
+    ASSERT_EQ(sizeof(hash("md5", "12345")), 32);
+
+    ASSERT_EQ(hash("ripemd160", "12345"), "e9cbd2ea8015a084ce9cf83a3c65b51f8fa10a39");
+    ASSERT_EQ(sizeof(hash("ripemd160", "12345")), 40);
+
+    ASSERT_EQ(hash("sha1", "12345"), "8cb2237d0679ca88db6464eac60da96345513964");
+    ASSERT_EQ(sizeof(hash("sha1", "12345")), 40);
+    ASSERT_EQ(hash("sha224", "12345"), "a7470858e79c282bc2f6adfd831b132672dfd1224c1e78cbf5bcd057");
+    ASSERT_EQ(sizeof(hash("sha224", "12345")), 56);
+    ASSERT_EQ(hash("sha256", "12345"), "5994471abb01112afcc18159f6cc74b4f511b99806da59b3caf5a9c173cacfc5");
+    ASSERT_EQ(sizeof(hash("sha256", "12345")), 64);
+    ASSERT_EQ(hash("sha384", "12345"), "0fa76955abfa9dafd83facca8343a92aa09497f98101086611b0bfa95dbc0dcc661d62e9568a5a032ba81960f3e55d4a");
+    ASSERT_EQ(sizeof(hash("sha384", "12345")), 96);
+    ASSERT_EQ(hash("sha512", "12345"), "3627909a29c31381a071ec27f7c9ca97726182aed29a7ddd2e54353322cfb30abb9e3a6df2ac2c20fe23436311d678564d0c8d305930575f60e2d3d048184d79");
+    ASSERT_EQ(sizeof(hash("sha512", "12345")), 128);
 }


### PR DESCRIPTION
## Docs
* Create `docs/efun/strings/hash.md`
* Update `docs/efun/strings/crypt.md`
* Create `docs/efun/strings/oldcrypt.md`
* Create `doc/efun/strings/sha1.md`

## Changes
* Change `src/packages/crypto/crypto.cc` f_hash error() to include a line return

## Tests
* Expand testing in `testsuite/single/tests/efun/hash`