### PR TITLE
Update to documentation for move_or_destruct apply

### DIFF
--- a/docs/apply/object/move_or_destruct.md
+++ b/docs/apply/object/move_or_destruct.md
@@ -9,15 +9,27 @@ title: object / move_or_destruct
 
 ### SYNOPSIS
 
-    int move_or_destruct( object dest );
+    void move_or_destruct( object dest );
 
 ### DESCRIPTION
 
-    If  an  object's is destructed, prior to it's destruction this apply is
-    called on it's contents.  'dest' will be the to be  destructed  object.
-    If  the  target  object  of  this apply does not move itself out of the
+    If an object is destructed, prior to its destruction this apply is called
+    on its contents. 'dest' will be the environment of the object being
+    destructed. target object of this apply does not move itself out of the
     object being destructed, it will be destructed as well.
 
+    For example, if you have a room, and in it an object (ob1) which contains
+    another object (ob2), and a further object (ob3), and you destruct the
+    room, then the following will happen:
+
+    Deep Scanning: OBJ(/d/sable/sable/rooms/ww2) EUID(Sable) UID(Sable)
+    1:  OBJ(/u/g/gesslar/ob1#1481) EUID(gesslar) UID(gesslar)
+      1:  OBJ(/u/g/gesslar/ob2#1482) EUID(gesslar) UID(gesslar)
+        1:  OBJ(/u/g/gesslar/ob3#1483) EUID(gesslar) UID(gesslar)
+
+    2023/09/24 04:02:45 move_or_destruct() called on ob1.c, value of dest is 0
+    2023/09/24 04:02:45 move_or_destruct() called on ob2.c, value of dest is /d/sable/sable/rooms/ww2
+    2023/09/24 04:02:45 move_or_destruct() called on ob3.c, value of dest is /u/g/gesslar/ob1#1481
 ### SEE ALSO
 
     destruct(3), move_object(3), init(4)

--- a/docs/apply/object/move_or_destruct.md
+++ b/docs/apply/object/move_or_destruct.md
@@ -13,10 +13,12 @@ title: object / move_or_destruct
 
 ### DESCRIPTION
 
-    If an object is destructed, prior to its destruction this apply is called
-    on its contents. 'dest' will be the environment of the object being
-    destructed. target object of this apply does not move itself out of the
-    object being destructed, it will be destructed as well.
+    When an object is destructed, prior to its destruction, this apply will be
+    called on all objects in its inventory. 'dest' will be the environment of
+    the object being destructed. target object of this apply does not move
+    itself out of the object being destructed, it will be destructed as well.
+
+### EXAMPLE
 
     For example, if you have a room, and in it an object (ob1) which contains
     another object (ob2), and a further object (ob3), and you destruct the
@@ -30,6 +32,7 @@ title: object / move_or_destruct
     2023/09/24 04:02:45 move_or_destruct() called on ob1.c, value of dest is 0
     2023/09/24 04:02:45 move_or_destruct() called on ob2.c, value of dest is /d/sable/sable/rooms/ww2
     2023/09/24 04:02:45 move_or_destruct() called on ob3.c, value of dest is /u/g/gesslar/ob1#1481
+
 ### SEE ALSO
 
     destruct(3), move_object(3), init(4)

--- a/docs/apply/object/move_or_destruct.md
+++ b/docs/apply/object/move_or_destruct.md
@@ -33,4 +33,3 @@ title: object / move_or_destruct
 ### SEE ALSO
 
     destruct(3), move_object(3), init(4)
-


### PR DESCRIPTION
This documentation was missing some verbiage that made it very confusing. As well, the return should have been void.