### PR TITLE
fix async_db_exec docs and test to use correct callback argument name

### DIFF
--- a/docs/efun/async/async_db_exec.md
+++ b/docs/efun/async/async_db_exec.md
@@ -21,9 +21,16 @@ title: async / async_db_exec
 
     The callback should follow this format:
 
-        function (int handle) {
+    ```c
+    async_db_exec(
+        handle,
+        sql_query, 
+        function (int rows) { // number of matched rows
+            mixed *results = db_fetch(handle, 1);
             db_close(handle);
         }
+    );
+    ```
 
 ### SEE ALSO
 

--- a/testsuite/single/tests/efuns/db.c
+++ b/testsuite/single/tests/efuns/db.c
@@ -2,6 +2,7 @@
 int calledDB;
 #endif
 
+int conn = 0;
 void do_tests() {
 #ifndef __PACKAGE_DB__
     write("PACKAGE_DB is not enabled, skipping DB tests...\n");
@@ -12,7 +13,7 @@ void do_tests() {
     return;
 #else
     // test db functions through sqlite
-    int conn = 0, rows = 0;
+    int rows = 0;
     mixed res;
 
     // Open & Close
@@ -62,13 +63,12 @@ void do_tests() {
     ASSERT_NE(0, conn);
     db_exec(conn, "DROP TABLE IF EXISTS tbl1");
     db_exec(conn, "create table IF NOT EXISTS tbl1(one varchar(10), two smallint);");
-    async_db_exec(conn, "insert into tbl1 values('hello!',10);", function(int conn) {
-        int rows = 0;
+    async_db_exec(conn, "insert into tbl1 values('hello!',10);", function(int rows) {
         mixed res;
 
         calledDB = 1;
 
-        write("ASYNC: async_db_exec callback: " + conn + "\n");
+        write("ASYNC: async_db_exec callback: " + conn + " matched " + rows + " rows\n");
 
         rows = db_exec(conn, "select * from tbl1;");
         ASSERT_EQ(1, rows);


### PR DESCRIPTION
Per #1036, fix `async_db_exec` doc and test of  to use the correct callback argument name.