### PR TITLE
update has_gmcp docs to mention `enable gmcp` in config

### DIFF
--- a/docs/efun/interactive/has_gmcp.md
+++ b/docs/efun/interactive/has_gmcp.md
@@ -18,6 +18,14 @@ title: interactive / has_gmcp
     Return non-zero if interactive user has the GMCP protocol enabled in 
     their client. 0 will be returned if the user does not.
 
+    Note:
+    Fluffos requires the following option to be set in the startup config
+    in order to support the GMCP protocol.
+
+    ```
+    enable gmcp : 1
+    ```
+
 ### SEE ALSO
 
     gmcp_enable(4), gmcp(4), send_gmcp(3), has_zmp(), has_mxp()


### PR DESCRIPTION
Update `has_gmcp.md` to mention `enable gmcp` is required in the config file passed to fluffos in order for GMCP protocol to be supported.