### PR TITLE
cleanup efun::has_gmcp text

### DIFF
--- a/docs/efun/interactive/has_gmcp.md
+++ b/docs/efun/interactive/has_gmcp.md
@@ -6,8 +6,8 @@ title: interactive / has_gmcp
 
 ### NAME
 
-    has_gmcp() - returns whether or not a given interactive user's client 
-    has GMCP protocol enabled.
+    has_gmcp() - returns whether a given interactive user's client has
+    GMCP protocol enabled
 
 ### SYNOPSIS
 
@@ -15,17 +15,17 @@ title: interactive / has_gmcp
 
 ### DESCRIPTION
 
-    Return non-zero if interactive user has the GMCP protocol enabled in 
-    their client. 0 will be returned if the user does not.
+    If the interactive user has the GMCP protocol enabled in their client,
+    this function will return 1, otherwise 0 will be returned.
 
     Note:
-    Fluffos requires the following option to be set in the startup config
+    FluffOS requires the following option to be set in the runtime config
     in order to support the GMCP protocol.
 
-    ```
-    enable gmcp : 1
-    ```
+```
+enable gmcp : 1
+```
 
 ### SEE ALSO
 
-    gmcp_enable(4), gmcp(4), send_gmcp(3), has_zmp(), has_mxp()
+    gmcp_enable(4), gmcp(4), send_gmcp(3), has_zmp(3), has_mxp(3)


### PR DESCRIPTION
Round 2 of editing `efun::has_gmcp`, cleanup description and various formatting issues.