### PR TITLE
fix: avoid corruption after using test_load

### DIFF
--- a/src/packages/contrib/contrib.cc
+++ b/src/packages/contrib/contrib.cc
@@ -3039,6 +3039,7 @@ object_t *testloadob;
 static void fix_object_names() {
   if (testloadob) {
     SETOBNAME(testloadob, saved_extra_name);
+    ObjectTable::instance().insert(testloadob->obname,testloadob);
   }
 }
 
@@ -3047,6 +3048,7 @@ void f_test_load() {
   object_t *new_ob;
   if ((testloadob = find_object2(sp->u.string))) {
     tmp = testloadob->obname;
+    ObjectTable::instance().remove(testloadob->obname);
     SETOBNAME(testloadob, "");
   }
   saved_extra_name = tmp;
@@ -3070,6 +3072,7 @@ void f_test_load() {
   push_number(1);
   if (testloadob) {
     SETOBNAME(testloadob, saved_extra_name);
+    ObjectTable::instance().insert(testloadob->obname,testloadob);
   }
 }
 #endif

--- a/src/vm/internal/otable.cc
+++ b/src/vm/internal/otable.cc
@@ -58,11 +58,9 @@ bool ObjectTable::remove(Key const& key) {
   objects_.erase(it1);
   // guaranteed to exist if object exists
   auto it2 = children_.find(basename(key));
-  if (it2 == children_.end()) return false;
   auto it3 = std::find_if(it2->second.begin(), it2->second.end(),
                           [&key](Value v) -> bool { return v->obname == key; });
   // guaranteed to be in list if basename(key) exists in children_
-  if (it3 == it2->second.end()) return false;
   it2->second.erase(it3);
   if (it2->second.size() == 0) {
     children_.erase(it2);

--- a/testsuite/single/tests/crasher/1063-aux.c
+++ b/testsuite/single/tests/crasher/1063-aux.c
@@ -1,0 +1,2 @@
+void create() {
+}

--- a/testsuite/single/tests/crasher/1063.c
+++ b/testsuite/single/tests/crasher/1063.c
@@ -1,0 +1,28 @@
+void do_tests() {
+  object ob, *all;
+  string path;
+
+  // Loading an object and making sure it is correctly loaded
+  path = base_name() + "-aux.c";
+  ob = load_object(path);
+  all = children(path);
+  ASSERT_EQ(sizeof(all), 1);
+
+  // Using test_load and making sure children() is not corrupted
+  test_load(path);
+  all = children(path);
+  ASSERT_EQ(sizeof(all), 1);
+
+  // Destroying an object and doubling down on the children() check
+  destruct(ob);
+  all = children(path);
+  ASSERT_EQ(sizeof(all), 0);
+
+  // Loading it again to finally check that's the case
+  load_object(path);
+  all = children(path);
+  ASSERT_EQ(sizeof(all), 1);
+
+  // Make sure no lingering orphaned entries in the children list
+  ASSERT_EQ(member_array(0, all), -1);
+}

--- a/testsuite/single/tests/crasher/843.c
+++ b/testsuite/single/tests/crasher/843.c
@@ -1,3 +1,0 @@
-void do_tests() {
-  test_load(__FILE__);
-}


### PR DESCRIPTION
When using `test_load` on a loaded object the object list ends up corrupted. The details are obscure, but doing this reproduces the error:

1. Load any object in memory. Check that both `find_object()` and `children()` return the single existing object
2. Run `test_load` on the object. At this point `find_object()` will probably return `0` (sometimes it doesn't)
3. Destroy and use `load_object()` again. `children()` will now return an array with two duplicates of the same object or, sometimes, a `0` and the existing copy of the object

In some instances i've seen different objects returned by `children()` than the one being passed as path (this usually happened with clones).

This PR tries to work around it. I've also reverted #843 because I believe this PR fixes the underlying cause for the issue, not just the symptom.

All credit goes to Zoilder (one of the developers on our mud) that happened to fix this a long time ago. We're just sending these fixes upstream since we're starting to update our outdated driver.

Please let me know if there's anything I should change in the PR. I've tried to add a proper test for this, but I don't know if that's the location you're expecting for it.