### PR TITLE
Updated English documentation for `fetch_variable`, `store_variable`, and `event`.

### DIFF
--- a/docs/efun/contrib/event.md
+++ b/docs/efun/contrib/event.md
@@ -15,7 +15,8 @@ title: contrib / event.pre
 
 ### DESCRIPTION
 
-    Calls "event_" + event_name in target. 
+    Calls "event_" + event_name in target. "event_" + event_name must be a
+    public function.
 
     Target can be a single object or an array of objects.
 

--- a/docs/efun/contrib/fetch_variable.md
+++ b/docs/efun/contrib/fetch_variable.md
@@ -14,11 +14,15 @@ title: contrib / fetch_variable.pre
 
 ### DESCRIPTION
 
-    This efun returns the value stored in the global variable variable_name in ob.
-    The variable must not be private.
+    This efun returns the value stored in the global variable `variable_name` 
+    in ob.
 
-    variable_name is name of the global variable
-    ob defaults to this_object() if not specified
+    `variable_name` is name of the global variable.
+    `ob` defaults to this_object() if not specified.
+
+    If `ob` is not specified, then `variable_name` can be any global variable
+    in the inheritance hierarchy, regardless of scope.  If `ob` is specified,
+    then `variable_name` must be public scope. 
 
     This is a potential security hazard and, therefore, you may wish to overload
     this function to perform security checks.

--- a/docs/efun/contrib/store_variable.md
+++ b/docs/efun/contrib/store_variable.md
@@ -14,12 +14,15 @@ title: contrib / store_variable.pre
 
 ### DESCRIPTION
 
-    This efun stores the value in the global variable variable_name in ob.
-    The variable must not be private.
+    This efun stores the value in the global variable variable_name in `ob`.
 
-    variable_name is name of the global variable
-    value is the data to be stored in the global variable
-    ob defaults to this_object() if not specified
+    `variable_name` is name of the global variable.
+    `value` is the data to be stored in the global variable.
+    `ob` defaults to this_object() if not specified.
+
+    If `ob` is not specified, then `variable_name` can be any global variable
+    in the inheritance hierarchy, regardless of scope.  If `ob` is specified,
+    then `variable_name` must be public scope. 
 
     This is a potential security hazard and, therefore, you may wish to overload
     this function to perform security checks.
@@ -28,6 +31,6 @@ title: contrib / store_variable.pre
 
     store_variable( "weight", 150, this_player() ) ;
 
-### SEE ALSO
+## SEE ALSO
 
     fetch_variable

--- a/docs/efun/contrib/store_variable.md
+++ b/docs/efun/contrib/store_variable.md
@@ -31,6 +31,6 @@ title: contrib / store_variable.pre
 
     store_variable( "weight", 150, this_player() ) ;
 
-## SEE ALSO
+### SEE ALSO
 
     fetch_variable


### PR DESCRIPTION
`fetch_variable` and `store_variable` document updated to indicate that when `ob` is not specified, any variable in the inheritance hierarchy can be accessed.  When `ob` is specified, only `public` variables can be accessed.

`event` documentation updated to indicate that the event function must be public scope.

Did not change any non-English documentation.