### PR TITLE
update github actions/checkout@v3 to v4

### DIFF
--- a/.github/workflows/ci-osx.yml
+++ b/.github/workflows/ci-osx.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Install packages
       env:
         HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK: 1

--- a/.github/workflows/ci-sanitizer.yml
+++ b/.github/workflows/ci-sanitizer.yml
@@ -22,7 +22,7 @@ jobs:
         build: ["Debug", "RelWithDebInfo"]
     runs-on: "ubuntu-latest"
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Install packages
       run: |
         sudo apt update

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -28,7 +28,7 @@ jobs:
       - uses: msys2/setup-msys2@v2
         with:
           update: true
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Install
         run: |
           if [ "$MSYSTEM" = "MINGW32" ]; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Install packages
       run: |
         sudo apt update

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -32,7 +32,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         # We must fetch at least the immediate parents so that if this is
         # a pull request then we can checkout the head.

--- a/.github/workflows/coverity-scan.yml
+++ b/.github/workflows/coverity-scan.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Install packages
         run: |
           sudo apt update

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -33,7 +33,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       # Login against a Docker registry except on PR
       # https://github.com/docker/login-action

--- a/.github/workflows/qodana.yml
+++ b/.github/workflows/qodana.yml
@@ -14,7 +14,7 @@ jobs:
       pull-requests: write
       checks: write
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha }}  # to check out the actual pull request commit, not the merge commit
           fetch-depth: 0  # a full history is required for pull request analysis


### PR DESCRIPTION
This will resolve the various warnings on Github Workflows about `actions/checkout@v3` using a deprecated node.js version:
![image](https://github.com/user-attachments/assets/c00fe140-a250-4992-9a1f-dc893b12cd9d)
