### PR TITLE
Add tests for 0-size buffer in sprintf

### DIFF
--- a/src/packages/core/sprintf.cc
+++ b/src/packages/core/sprintf.cc
@@ -372,6 +372,10 @@ void svalue_to_string(svalue_t *obj, outbuffer_t *outbuf, int indent, int traili
       }
       break;
     case T_BUFFER:
+      if(!(obj->u.buf->size)) {
+        outbuf_add(outbuf, "BUFFER ( 0 )");
+        break;
+      }
       outbuf_add(outbuf, "BUFFER ( /* sizeof() == ");
       outbuf_addv(outbuf, "%d", obj->u.buf->size);
       outbuf_add(outbuf, " */\n");

--- a/src/packages/core/sprintf.cc
+++ b/src/packages/core/sprintf.cc
@@ -373,7 +373,7 @@ void svalue_to_string(svalue_t *obj, outbuffer_t *outbuf, int indent, int traili
       break;
     case T_BUFFER:
       if(!(obj->u.buf->size)) {
-        outbuf_add(outbuf, "BUFFER ( 0 )");
+        outbuf_add(outbuf, "BUFFER ( )");
         break;
       }
       outbuf_add(outbuf, "BUFFER ( /* sizeof() == ");

--- a/testsuite/single/tests/crasher/17.c
+++ b/testsuite/single/tests/crasher/17.c
@@ -1,0 +1,4 @@
+void do_tests() {
+    debug_message("printf with allocate_buffer(0)") ;
+    printf("%O\n", allocate_buffer(0)) ;
+}

--- a/testsuite/single/tests/crasher/17b.c
+++ b/testsuite/single/tests/crasher/17b.c
@@ -1,0 +1,4 @@
+void do_tests() {
+    debug_message("sprintf with allocate_buffer(0)") ;
+    debug_message(sprintf("%O", allocate_buffer(0))) ;
+}


### PR DESCRIPTION
This pull request adds tests for 0-size buffer in sprintf. The tests include a crasher test and a test for printf with allocate_buffer(0). This ensures that the code handles 0-size buffers correctly.

This fixes #1082 