### PR TITLE
Updating external_start() to use debug_levels rather than debug_message to log

### DIFF
--- a/docs/efun/general/clear_debug_level.md
+++ b/docs/efun/general/clear_debug_level.md
@@ -31,6 +31,7 @@ title: general / clear_debug_level
         add_action
         telnet
         websocket
+        external_start
 
 ### EXAMPLE
 

--- a/docs/efun/internals/set_debug_level.md
+++ b/docs/efun/internals/set_debug_level.md
@@ -22,7 +22,7 @@ title: internals / set_debug_level
     The information is printed to stdout as well as to the file specified in
     the runtime configuration file as the "debug log file" setting.
 
-    The level is a bitmask integer or a string. If using an integer, multiple 
+    The level is a bitmask integer or a string. If using an integer, multiple
     levels can be set by using the bitwise OR operator (|).
 
     The following levels are available:
@@ -40,6 +40,7 @@ title: internals / set_debug_level
         "add_action"      1 << 12
         "telnet"          1 << 13
         "websocket"       1 << 14
+        "debug_level"     1 << 14
 
     When level is an integer, the debug level will be set to that value,
     erasing any previous settings.

--- a/src/base/internal/log.cc
+++ b/src/base/internal/log.cc
@@ -15,7 +15,8 @@
 
 const debug_t levels[] = {E(call_out),      E(d_flag),     E(connections), E(mapping),  E(sockets),
                           E(comp_func_tab), E(LPC),        E(LPC_line),    E(event),    E(dns),
-                          E(file),          E(add_action), E(telnet),      E(websocket)};
+                          E(file),          E(add_action), E(telnet),      E(websocket),
+                          E(external_start)};
 
 const int sizeof_levels = (sizeof(levels) / sizeof(levels[0]));
 

--- a/src/base/internal/log.h
+++ b/src/base/internal/log.h
@@ -80,6 +80,7 @@ void debug_level_clear(const char *);
 #define DBG_add_action 1u << 12
 #define DBG_telnet 1u << 13
 #define DBG_websocket 1u << 14
+#define DBG_external_start 1u << 15
 // remember to add new entry to levels in log.cc!
 
 #define DBG_DEFAULT (DBG_connections | DBG_telnet)

--- a/src/packages/external/external.cc
+++ b/src/packages/external/external.cc
@@ -131,7 +131,7 @@ int external_start(int which, svalue_t *args, svalue_t *arg1, svalue_t *arg2, sv
   evutil_socket_t childfd = sv[0];
   sv[0] = -1;
 
-  debug(external_start, "Launching external command '%s %s', pid: %jd.\n", external_cmd[which],
+  debug(external_start, "external_start: Launching external command '%s %s', pid: %jd.\n", external_cmd[which],
                 args->type == T_STRING ? args->u.string : "<ARRAY>", (intmax_t)pid);
 
   std::thread([=]() {
@@ -139,7 +139,7 @@ int external_start(int which, svalue_t *args, svalue_t *arg1, svalue_t *arg2, sv
     do {
       const int s = waitpid(pid, &status, WUNTRACED | WCONTINUED);
       if (s == -1) {
-        debug(external_start, "external_start(): waitpid() error: %s (%d).\n", strerror(errno), errno);
+        debug(external_start, "external_start: waitpid() error: %s (%d).\n", strerror(errno), errno);
         return;
       }
       std::string res = fmt::format(FMT_STRING("external_start(): child {} status: "), pid);
@@ -153,7 +153,7 @@ int external_start(int which, svalue_t *args, svalue_t *arg1, svalue_t *arg2, sv
         res += "continued\n";
       }
 
-      debug(external_start, "%s\n", format_time(res).c_str());
+      debug(external_start, "external_start: %s\n", format_time(res).c_str());
     } while (!WIFEXITED(status) && !WIFSIGNALED(status));
   }).detach();
 
@@ -298,7 +298,7 @@ int external_start(int which, svalue_t *args, svalue_t *arg1, svalue_t *arg2, sv
     error("CreateProcess() in external_start() failed: %s\n", strerror(errno));
     return EESOCKET;
   }
-  debug(external_start, "Launching external command '%s', pid: %d.\n", cmdline.c_str(),
+  debug(external_start, "external_start: Launching external command '%s', pid: %d.\n", cmdline.c_str(),
                 processInfo.dwProcessId);
 
   std::thread([=]() {
@@ -306,7 +306,7 @@ int external_start(int which, svalue_t *args, svalue_t *arg1, svalue_t *arg2, sv
     DWORD exitCode = -1;
     // Get the exit code.
     GetExitCodeProcess(processInfo.hProcess, &exitCode);
-    debug(external_start, "pid: %d exited with %d.\n", processInfo.dwProcessId, exitCode);
+    debug(external_start, "external_start: pid: %d exited with %d.\n", processInfo.dwProcessId, exitCode);
     CloseHandle(processInfo.hProcess);
     CloseHandle(processInfo.hThread);
     evutil_closesocket(sv[0]);

--- a/src/packages/external/external.cc
+++ b/src/packages/external/external.cc
@@ -27,6 +27,13 @@ void split(const std::string &s, char delim, Out result) {
   }
 }
 
+// Added because debug() macro won't take a struct tm as an argument.
+std::string format_time(const struct tm& timeinfo) {
+  char buffer[64];
+  strftime(buffer, sizeof(buffer), "%Y-%m-%d %H:%M:%S", &timeinfo);
+  return std::string(buffer);
+}
+
 int external_start(int which, svalue_t *args, svalue_t *arg1, svalue_t *arg2, svalue_t *arg3) {
   std::vector<std::string> newargs_data = {std::string(external_cmd[which])};
   if (args->type == T_ARRAY) {
@@ -50,7 +57,7 @@ int external_start(int which, svalue_t *args, svalue_t *arg1, svalue_t *arg2, sv
   posix_spawn_file_actions_t file_actions;
   int ret = posix_spawn_file_actions_init(&file_actions);
   if (ret != 0) {
-    debug_message("external_start: posix_spawn_file_actions_init() error: %s\n", strerror(ret));
+    debug(external_start, "external_start: posix_spawn_file_actions_init() error: %s\n", strerror(ret));
     return EESOCKET;
   }
   DEFER { posix_spawn_file_actions_destroy(&file_actions); };
@@ -74,7 +81,7 @@ int external_start(int which, svalue_t *args, svalue_t *arg1, svalue_t *arg2, sv
         posix_spawn_file_actions_adddup2(&file_actions, sv[1], 1) ||
         posix_spawn_file_actions_adddup2(&file_actions, sv[1], 2);
   if (ret != 0) {
-    debug_message("external_start: posix_spawn_file_actions_adddup2() error: %s\n", strerror(ret));
+    debug(external_start, "external_start: posix_spawn_file_actions_adddup2() error: %s\n", strerror(ret));
     return EESOCKET;
   }
 
@@ -114,7 +121,7 @@ int external_start(int which, svalue_t *args, svalue_t *arg1, svalue_t *arg2, sv
   char *newenviron[] = {nullptr};
   ret = posix_spawn(&pid, newargs[0], &file_actions, nullptr, newargs.data(), newenviron);
   if (ret) {
-    debug_message("external_start: posix_spawn() error: %s\n", strerror(ret));
+    debug(external_start, "external_start: posix_spawn() error: %s\n", strerror(ret));
     return EESOCKET;
   }
 
@@ -124,7 +131,7 @@ int external_start(int which, svalue_t *args, svalue_t *arg1, svalue_t *arg2, sv
   evutil_socket_t childfd = sv[0];
   sv[0] = -1;
 
-  debug_message("Launching external command '%s %s', pid: %jd.\n", external_cmd[which],
+  debug(external_start, "Launching external command '%s %s', pid: %jd.\n", external_cmd[which],
                 args->type == T_STRING ? args->u.string : "<ARRAY>", (intmax_t)pid);
 
   std::thread([=]() {
@@ -132,7 +139,7 @@ int external_start(int which, svalue_t *args, svalue_t *arg1, svalue_t *arg2, sv
     do {
       const int s = waitpid(pid, &status, WUNTRACED | WCONTINUED);
       if (s == -1) {
-        debug_message("external_start(): waitpid() error: %s (%d).\n", strerror(errno), errno);
+        debug(external_start, "external_start(): waitpid() error: %s (%d).\n", strerror(errno), errno);
         return;
       }
       std::string res = fmt::format(FMT_STRING("external_start(): child {} status: "), pid);
@@ -145,7 +152,8 @@ int external_start(int which, svalue_t *args, svalue_t *arg1, svalue_t *arg2, sv
       } else if (WIFCONTINUED(status)) {
         res += "continued\n";
       }
-      debug_message("%s", res.c_str());
+
+      debug(external_start, "%s\n", format_time(res).c_str());
     } while (!WIFEXITED(status) && !WIFSIGNALED(status));
   }).detach();
 
@@ -290,7 +298,7 @@ int external_start(int which, svalue_t *args, svalue_t *arg1, svalue_t *arg2, sv
     error("CreateProcess() in external_start() failed: %s\n", strerror(errno));
     return EESOCKET;
   }
-  debug_message("Launching external command '%s', pid: %d.\n", cmdline.c_str(),
+  debug(external_start, "Launching external command '%s', pid: %d.\n", cmdline.c_str(),
                 processInfo.dwProcessId);
 
   std::thread([=]() {
@@ -298,7 +306,7 @@ int external_start(int which, svalue_t *args, svalue_t *arg1, svalue_t *arg2, sv
     DWORD exitCode = -1;
     // Get the exit code.
     GetExitCodeProcess(processInfo.hProcess, &exitCode);
-    debug_message("pid: %d exited with %d.\n", processInfo.dwProcessId, exitCode);
+    debug(external_start, "pid: %d exited with %d.\n", processInfo.dwProcessId, exitCode);
     CloseHandle(processInfo.hProcess);
     CloseHandle(processInfo.hThread);
     evutil_closesocket(sv[0]);

--- a/testsuite/command/external_curl.c
+++ b/testsuite/command/external_curl.c
@@ -2,21 +2,24 @@ mapping fd_to_msg;
 mapping fd_to_obj;
 
 void on_read(int fd, string msg) {
-  debug_message(sprintf("on_read: %d \n", fd));
+  debug_message(sprintf("on_read: %d", fd));
 
   fd_to_msg[fd] += sprintf("%s", msg);
 }
 
 void on_write(int fd) {
-  debug_message(sprintf("on_write: %d \n", fd));
+  debug_message(sprintf("on_write: %d", fd));
 }
 
 void on_close(int fd) {
-  debug_message(sprintf("on_close: %d \n", fd));
+  debug_message(sprintf("on_close: %d", fd));
 
   tell_object(fd_to_obj[fd], fd_to_msg[fd]);
   map_delete(fd_to_msg, fd);
   map_delete(fd_to_obj, fd);
+
+  // Turn off debug messages for external_start
+  clear_debug_level("external_start") ;
 }
 
 int main(string arg)
@@ -26,6 +29,9 @@ int main(string arg)
   if(__ARCH__ == "Microsoft Windows") CURL_CMD = 2;
 
   if (!arg) arg = "";
+
+  // Turn on debug messages for external_start
+  set_debug_level("external_start") ;
   fd = external_start(CURL_CMD, arg, "on_read", "on_write", "on_close");
 
   if (!fd_to_msg) {


### PR DESCRIPTION
I have refactored the debug messages in the code to use a debug macro and set/clear_debug_level functions. 

This improves debugging by removing unnecessary clutter from debug.log and the console with frequent external_start invocations.

Additionally, I have added a new debug level for the external_start function to enable or disable debug messages specifically for that function. 

Doumentation for set/clear_debug_level have been updated.

external_curl command in testsuite has been updated to invoke this new debug level.