### PR TITLE
Add OLD_STRING support to allow disabling UTF8 validation to make str…

### DIFF
--- a/src/compiler/internal/lex.cc
+++ b/src/compiler/internal/lex.cc
@@ -2418,11 +2418,13 @@ int yylex() {
             int n;
 
             auto *p = outp;
+#ifndef OLD_STRING            
             if (!u8_validate(&p)) {
               lexerror("Bad UTF-8 string in string block");
               outp = p;
               break;
             }
+#endif            
             /*
              * make string token and clean up
              */
@@ -2708,10 +2710,12 @@ int parseStringLiteral(unsigned char c) {
 
       case '"':
         *to++ = 0;
+#ifndef OLD_STRING        
         if (!u8_validate(reinterpret_cast<const char *>(scr_tail + 1))) {
           lexerror("Invalid UTF8 codepoint in string literal");
           return YYerror;
         }
+#endif
         if (!l && (to == scratch_end)) {
           char *res = scratch_large_alloc(to - scr_tail - 1);
           strcpy(res, reinterpret_cast<char *>(scr_tail + 1));
@@ -2931,11 +2935,13 @@ int parseStringLiteral(unsigned char c) {
         res = scratch_large_alloc((yyp - yytext) + (to - scr_tail) - 1);
         strncpy(res, reinterpret_cast<char *>(scr_tail + 1), (to - scr_tail) - 1);
         strcpy(res + (to - scr_tail) - 1, yytext);
+#ifndef OLD_STRING        
         if (!u8_validate(res)) {
           lexerror("Invalid UTF8 string");
           scratch_free(res);
           return YYerror;
         }
+#endif        
         yylval.string = res;
         return L_STRING;
       }
@@ -3043,12 +3049,14 @@ int parseStringLiteral(unsigned char c) {
     res = scratch_large_alloc((yyp - yytext) + (to - scr_tail) - 1);
     strncpy(res, reinterpret_cast<char *>(scr_tail + 1), (to - scr_tail) - 1);
     strcpy(res + (to - scr_tail) - 1, yytext);
+#ifndef OLD_STRING
     // Validate UTF8
     if (!u8_validate(res)) {
       lexerror("Invalid UTF8 string");
       scratch_free(res);
       return YYerror;
     }
+#endif
     yylval.string = res;
     return L_STRING;
   }

--- a/src/local_options
+++ b/src/local_options
@@ -43,6 +43,9 @@
 #undef NO_SHADOWS
 #undef USE_ICONV
 #undef IPV6
+// configs to change how strings are handled
+#undef OLD_STRING
+#undef UTF8_ERROR_TO_BUFFER
 
 /****************************************************************************
  *                              PACKAGES                                    *

--- a/src/local_options.README
+++ b/src/local_options.README
@@ -369,4 +369,14 @@
 
 #define PACKAGE_MATRIX
 
+/* OLD_STRING: disable utf8 validation making strings work like 2.x strings
+ */
+#undef OLD_STRING
+
+/* UTF8_ERROR_TO_BUFFER: Convert invalid UTF8 strings to buffer type
+ *   for restore_object/restore_variable
+ *   Requires OLD_STRING to be undefined
+ */
+#undef UTF8_ERROR_TO_BUFFER
+
 #endif /* _LOCAL_OPTIONS_H_ */

--- a/src/vm/internal/base/mapping.cc
+++ b/src/vm/internal/base/mapping.cc
@@ -399,8 +399,12 @@ static mapping_t *copyMapping(mapping_t *m) {
 
 int restore_hash_string(char **val, svalue_t *sv) {
   char *cp = *val;
-  char c, *start = cp, *newstr;
+  char c, *start = cp;
+#if !defined(OLD_STRING) && defined(UTF8_ERROR_TO_BUFFER)
+  //only define if needed
+  char *newstr;
   int len;
+#endif
 
   while ((c = *cp++) != '"') {
     switch (c) {

--- a/src/vm/internal/base/object.cc
+++ b/src/vm/internal/base/object.cc
@@ -488,10 +488,22 @@ static int restore_interior_string(char **val, svalue_t *sv) {
           *val = cp;
           newstr = new_string(len = (news - start), "restore_string");
           strcpy(newstr, start);
+#ifndef OLD_STRING          
           if (!u8_validate(newstr)) {
+#ifdef UTF8_ERROR_TO_BUFFER
+            buffer_t *buf;
+            buf = allocate_buffer(len);
+            memcpy(buf->item, newstr, len);
+            sv->type = T_BUFFER;
+            sv->u.buf = buf;
+            FREE_MSTR(newstr);
+            return 0;
+#else
             FREE_MSTR(newstr);
             return ROB_STRING_UTF8_ERROR;
+#endif
           }
+#endif
           sv->u.string = newstr;
           sv->type = T_STRING;
           sv->subtype = STRING_MALLOC;
@@ -512,10 +524,22 @@ static int restore_interior_string(char **val, svalue_t *sv) {
   len = cp - start;
   newstr = new_string(len, "restore_string");
   strcpy(newstr, start);
+#ifndef OLD_STRING  
   if (!u8_validate(newstr)) {
+#ifdef UTF8_ERROR_TO_BUFFER
+    buffer_t *buf;
+    buf = allocate_buffer(len);
+    memcpy(buf->item, newstr, len);
+    sv->type = T_BUFFER;
+    sv->u.buf = buf;
+    FREE_MSTR(newstr);
+    return 0;
+#else
     FREE_MSTR(newstr);
     return ROB_STRING_UTF8_ERROR;
+#endif
   }
+#endif  
   sv->u.string = newstr;
   sv->type = T_STRING;
   sv->subtype = STRING_MALLOC;
@@ -1098,10 +1122,22 @@ static int restore_string(char *val, svalue_t *sv) {
           *news = '\0';
           newstr = new_string(news - start, "restore_string");
           strcpy(newstr, start);
+#ifndef OLD_STRING
           if (!u8_validate(newstr)) {
+#ifdef UTF8_ERROR_TO_BUFFER
+            buffer_t *buf;
+            buf = allocate_buffer(len);
+            memcpy(buf->item, newstr, len);
+            sv->type = T_BUFFER;
+            sv->u.buf = buf;
+            FREE_MSTR(newstr);
+            return 0;
+#else
             FREE_MSTR(newstr);
             return ROB_STRING_UTF8_ERROR;
+#endif
           }
+#endif
           sv->u.string = newstr;
           sv->type = T_STRING;
           sv->subtype = STRING_MALLOC;
@@ -1122,10 +1158,22 @@ static int restore_string(char *val, svalue_t *sv) {
   len = cp - start;
   newstr = new_string(len, "restore_string");
   strcpy(newstr, start);
+#ifndef OLD_STRING
   if (!u8_validate(newstr)) {
+#ifdef UTF8_ERROR_TO_BUFFER
+    buffer_t *buf;
+    buf = allocate_buffer(len);
+    memcpy(buf->item, newstr, len);
+    sv->type = T_BUFFER;
+    sv->u.buf = buf;
+    FREE_MSTR(newstr);
+    return 0;
+#else
     FREE_MSTR(newstr);
     return ROB_STRING_UTF8_ERROR;
+#endif
   }
+#endif
   sv->u.string = newstr;
   sv->type = T_STRING;
   sv->subtype = STRING_MALLOC;


### PR DESCRIPTION
Add OLD_STRING support to allow disabling UTF8 validation to make strings work closer to 2.x

Add UTF8_ERROR_TO_BUFFER to convert non valid UTF8 strings into buffer data type for restore_object and restore_variable to allow loading of old data that may not be UTF8 compatible