### PR TITLE
Update origin.md

### DIFF
--- a/docs/efun/calls/origin.md
+++ b/docs/efun/calls/origin.md
@@ -10,23 +10,22 @@ title: calls / origin
 
 ### SYNOPSIS
 
-    int origin( void );
+    string origin(void);
 
 ### DESCRIPTION
 
-    Returns  an  integer  specifying  how  the current function was called.
+    Returns string specifying how the current function was called.
     Current values are:
 
-      1    Driver (heart_beats, etc)
-      2    Local function call
-      4    call_other()
-      8    simul_efun object via a simul_efun call
-     16    call_out()
-     32    called by an efun (sort_array, etc)
-     64    function_pointer
-    128    functional
+    "driver"            Driver (heart_beats, etc)
+    "local"             Local function call
+    "call_other"        call_other()
+    "simul"             simul_efun object via a simul_efun call
+    "internal"          call_out(), etc
+    "efun"              called by an efun (sort_array, etc)
+    "function pointer"  function_pointer
+    "functional"        functional
 
 ### SEE ALSO
 
     previous_object(3), /include/origin.h
-

--- a/docs/efun/calls/origin.md
+++ b/docs/efun/calls/origin.md
@@ -14,7 +14,7 @@ title: calls / origin
 
 ### DESCRIPTION
 
-    Returns string specifying how the current function was called.
+    Returns a string specifying how the current function was called.
     Current values are:
 
     "driver"            Driver (heart_beats, etc)


### PR DESCRIPTION
It now does not lie and say it returns an int, when it doesn't. It returns a string! After merge, will have @jlchmura update his references for the LPC Language server to stop me from getting angry messages from it telling me how an int and a string aren't meant to be together. Pssh.