### PR TITLE
Add parse_str function for handling STR and WRD tokens

### DIFF
--- a/src/packages/parser/parser.cc
+++ b/src/packages/parser/parser.cc
@@ -3719,7 +3719,6 @@ static void parse_str(int tok, parse_state_t *state) {
   int end = start;
   match_t *mp;
   char tmp[512];
-  int found_handler = 0;
   bitvec_t objects;
 
   // Get all objects to try parallel applies on
@@ -3802,7 +3801,6 @@ static void parse_str(int tok, parse_state_t *state) {
           if (sv && sv->type == T_NUMBER && sv->u.number) {
             // Success - this object will handle the string
             DEBUG_P(("Object %s accepted handling %s", ob->obname, tmp));
-            found_handler = 1;
             parse_rule(state);
             DEBUG_DEC;
             return;
@@ -3828,9 +3826,7 @@ static void parse_str(int tok, parse_state_t *state) {
   }
 
   // If no object handled it, fall back to traditional parsing
-  if (!found_handler) {
-    parse_rule(state);
-  }
+  parse_rule(state);
 
   DEBUG_DEC;
 }

--- a/src/packages/parser/parser.cc
+++ b/src/packages/parser/parser.cc
@@ -25,10 +25,6 @@
 
 #include "base/package_api.h"
 
-#include "packages/core/add_action.h"
-#include "packages/core/file.h"
-#include "packages/core/sprintf.h"
-
 #include "packages/parser/parser.h"
 #include "packages/core/outbuf.h"
 
@@ -3787,9 +3783,9 @@ static void parse_str(int tok, parse_state_t *state) {
         p = strput(p, end_ptr, "_");
 
         if (tok == STR_TOKEN) {
-          p = strput(p, end_ptr, "str");
+          strput(p, end_ptr, "str");
         } else {
-          p = strput(p, end_ptr, "wrd");
+          strput(p, end_ptr, "wrd");
         }
 
         // Try to call direct_verb_str or direct_verb_wrd on the object


### PR DESCRIPTION
This commit introduces a new function, parse_str, to streamline the processing of STR and WRD tokens in the parser. The function enhances the existing logic by allowing parallel applies on objects and handling matches more efficiently. Additionally, the parse_rule function has been updated to utilize parse_str for STR and WRD tokens, improving code clarity and maintainability.

NOTE: Please be advised that this was performed largely by AI. I have tested it on mine and it seems to work. 

Creating as a draft PR so people can pull and see if it doesn't break anything with their games.