### PR TITLE
Keywork in Dockerfile should be uppercase

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.18 as builder
+FROM alpine:3.18 AS builder
 
 RUN apk add --no-progress --no-cache \
     linux-headers gcc g++ clang-dev make cmake bash \


### PR DESCRIPTION
Fix warning on docker build:  keyword `AS` should be in uppercase. 