### PR TITLE
fix: Add icu-data-full to Dockerfile for non-English encoding support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,9 @@ RUN cmake .. -DMARCH_NATIVE=OFF -DSTATIC=ON \
 
 FROM alpine:3.18
 
+RUN apk add --no-progress --no-cache \
+    icu-data-full
+
 WORKDIR /fluffos
 
 COPY --from=builder /build/fluffos/build/bin ./bin


### PR DESCRIPTION
Fixes #1133

Starting with Alpine 3.16, icu-dev only installs icu-data-en (English only). Applications requiring non-English character handling need icu-data-full explicitly added to the runtime image to prevent crashes when processing non-English text.