### PR TITLE
Fix get_argument() to properly count positional arguments

### DIFF
--- a/src/mainlib.cc
+++ b/src/mainlib.cc
@@ -213,13 +213,13 @@ void init_tz() {
 
 // Return the argument at the given position, start from 0.
 std::string get_argument(unsigned int pos, int argc, char **argv) {
+  int argpos = 0;
   for (int i = 1; i < argc; i++) {
-    int argpos = 0;
     if (argv[i][0] != '-') {
-      argpos++;
-      if (argpos - 1 == pos) {
+      if (argpos == pos) {
         return std::string(argv[i]);
       }
+      argpos++;
     }
   }
   return "";


### PR DESCRIPTION
## Summary
Fixes the `get_argument()` function in `src/mainlib.cc` which was preventing the `symbol` CLI tool from working.

## Problem
The `argpos` counter was being initialized **inside** the for loop, causing it to always be 0 on each iteration. This prevented `get_argument()` from ever returning arguments at position > 0.

## Solution
Move `int argpos = 0;` outside the for loop so it properly accumulates across iterations.

## Impact
- Fixes the `symbol` CLI tool which was completely non-functional
- No impact on other code paths

Fixes #1139