### PR TITLE
Support single test file execution via -ftest:/path syntax

### DIFF
--- a/testsuite/command/tests.c
+++ b/testsuite/command/tests.c
@@ -48,7 +48,7 @@ void recurse(string dir) {
     }
   }
 }
-int execute(string fun)
+int execute(string fun, int single_test: (: 0 :))
 {
   string leaks;
   object tp = this_player();
@@ -80,12 +80,21 @@ int execute(string fun)
     error("MASTER valid inherit functions are not being called!");
   }
 
+  if(single_test) {
+    write("Checks succeeded.\n");
+    // ordinarily doing a full suite test will eventually hit the shutdown
+    // test and shut it down after a certain delay. but not if we're only doing
+    // one file.
+    "single/tests/efuns/shutdown"->do_the_nasty_deed(); // 🤨
+    return 1;
+  }
+
   return 1;
 }
 
-int main() {
+int main(string file) {
 #if !(defined(__DEBUGMALLOC__) && defined(__DEBUGMALLOC_EXTENSIONS__) && defined(__PACKAGE_DEVELOP__))
   write("WARNING: Possible RELEASE build, check_memory() is not being executed.\n");
 #endif
-  return execute("");
+  return execute(file || "", stringp(file) && strlen(file) > 0);
 }

--- a/testsuite/single/master.c
+++ b/testsuite/single/master.c
@@ -32,16 +32,21 @@ public string get_last_error() {
 
 void flag(string str) {
   mixed error;
-  switch (str) {
+  string cmd, arg;
+
+  if(sscanf(str, "%(test|speed):%s", cmd, arg) != 2)
+    cmd = str;
+
+  switch (cmd) {
     case "test":
-      error = catch("/command/tests"->main());
+      error = catch("/command/tests"->main(arg));
       if(error) {
         has_error = 1;
         write(error);
       }
       break;
     case "speed":
-      error = catch("/command/speed"->main());
+      error = catch("/command/speed"->main(arg));
       if(error) {
         has_error = 1;
         write(error);
@@ -49,7 +54,7 @@ void flag(string str) {
       shutdown(0);
       break;
     default:
-      write("The only supproted flag is 'test' and 'speed', got '" + str + "'.\n");
+      write("The only supported flag is 'test' and 'speed', got '" + str + "'.\n");
       break;
   }
   if (has_error) { shutdown(-1); }


### PR DESCRIPTION
## Summary

- Add support for running individual test files with `-ftest:/path/to/file.c` flag
- Allows focused testing of specific test modules instead of full suite
- Includes single test cleanup via shutdown handler

## Changes

### testsuite/single/master.c
- Modified `flag()` function to parse optional file path from `-ftest:/path` syntax using sscanf
- Pass parsed file path to `/command/tests`->main(arg)
- Fixed typo: "supproted" → "supported"

### testsuite/command/tests.c
- Updated `execute()` signature to accept optional `single_test` parameter (default 0)
- Added early shutdown cleanup when running single test file
- Updated `main()` to accept optional file path parameter
- Pass file path and single_test flag to execute() based on whether file was provided

## Test Plan

- [x] Run full test suite normally: `-ftest` (all tests execute, shutdown on completion)
- [x] Run single test file: `-ftest:/path/to/test/file.c` (only that test executes, then shutdown)
- [x] Verify memory/reference counting checks still run in both modes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>