### PR TITLE
Add PCRE flag support to PCRE efuns and docs/tests

### DIFF
--- a/docs/efun/pcre/pcre_assoc.md
+++ b/docs/efun/pcre/pcre_assoc.md
@@ -10,12 +10,15 @@ title: pcre / pcre_assoc
 
 ### SYNOPSIS
 
-    mixed *pcre_assoc(string input, string *patterns, mixed *token_aray, void|mixed default);
+    mixed *pcre_assoc(string input, string *patterns, mixed *token_aray, void|mixed default, void|int pcre_flags);
 
 ### DESCRIPTION
 
     analog with reg_assoc efun for backwards compatibility reasons but utilizing
     the PCRE library.
+
+    The optional `pcre_flags` set PCRE options (e.g., `PCRE_I` case-insensitive,
+    `PCRE_M` multiline). Defaults to 0.
 
 ### SEE ALSO
 

--- a/docs/efun/pcre/pcre_extract.md
+++ b/docs/efun/pcre/pcre_extract.md
@@ -10,7 +10,7 @@ title: pcre / pcre_extract
 
 ### SYNOPSIS
 
-    string *pcre_extract(string input, string pattern, void|int include_named);
+    string *pcre_extract(string input, string pattern, void|int include_named, void|int pcre_flags);
 
 ### DESCRIPTION
 
@@ -21,6 +21,9 @@ title: pcre / pcre_extract
     mapping from group name to the captured string. If the pattern has no
     named groups (or none participated), the mapping is empty; otherwise only
     participating named groups are present.
+
+    The optional fourth argument `pcre_flags` sets PCRE options (e.g., `PCRE_I`
+    for case-insensitive, `PCRE_M` for multiline). Defaults to 0.
 
     Example (named groups):
 

--- a/docs/efun/pcre/pcre_match.md
+++ b/docs/efun/pcre/pcre_match.md
@@ -10,12 +10,17 @@ title: pcre / pcre_match
 
 ### SYNOPSIS
 
-    mixed pcre_match(string|string *lines, string pattern, void|int flag);
+    mixed pcre_match(string|string *lines, string pattern, void|int flag, void|int pcre_flags);
 
 ### DESCRIPTION
 
     analog with regexp efun for backwards compatibility reasons but utilizing
     the PCRE library.
+
+    The optional `pcre_flags` set PCRE options (e.g., `PCRE_I` case-insensitive,
+    `PCRE_M` multiline). For string input, the 3rd argument is treated as
+    `pcre_flags`; for array input, the 3rd argument remains the legacy flag and
+    `pcre_flags` is the 4th argument. Defaults to 0.
 
 ### SEE ALSO
 

--- a/docs/efun/pcre/pcre_match_all.md
+++ b/docs/efun/pcre/pcre_match_all.md
@@ -10,7 +10,7 @@ title: pcre / pcre_match_all
 
 ### SYNOPSIS
 
-    mixed pcre_match_all(string input, string pattern);
+    mixed pcre_match_all(string input, string pattern, void|int pcre_flags);
 
 ### DESCRIPTION
 
@@ -18,9 +18,10 @@ title: pcre / pcre_match_all
     containing all matches and captured groups.
 
 ### Example
+
     // https://tools.ietf.org/html/rfc3986#appendix-B
     pcre_match_all("http://www.ics.uci.edu/pub/ietf/uri/#Related",
-                       "^(([^:/?#]+):)?(//([^/?#]*))?([^?#]*)(\\?([^#]*))?(#(.*))?" ));
+                       "^(([^:/?#]+):)?(//([^/?#]*))?([^?#]*)(\\?([^#]*))?(#(.*))?" , PCRE_M));
 
     Will return
       ({ /* sizeof() == 1 */

--- a/docs/efun/pcre/pcre_replace.md
+++ b/docs/efun/pcre/pcre_replace.md
@@ -10,13 +10,16 @@ title: pcre / pcre_replace
 
 ### SYNOPSIS
 
-    string pcre_replace(string input, string pattern, string *replacments);
+    string pcre_replace(string input, string pattern, string *replacements, void|int pcre_flags);
 
 ### DESCRIPTION
 
     returns a string where all captured groups have been replaced by the
     elements of the replacement array. Number of subgroups and the size of the
     replacement array must match.
+
+    The optional `pcre_flags` lets you set PCRE options (e.g., `PCRE_I` for
+    case-insensitive, `PCRE_M` for multiline). Defaults to 0.
 
 ### SEE ALSO
 

--- a/docs/efun/pcre/pcre_replace_callback.md
+++ b/docs/efun/pcre/pcre_replace_callback.md
@@ -10,13 +10,16 @@ title: pcre / pcre_replace_callback
 
 ### SYNOPSIS
 
-    string pcre_replace_callback(string input, string pattern, string|function, mixed *args...);
+    string pcre_replace_callback(string input, string pattern, string|function, mixed *args..., void|int pcre_flags);
 
 ### DESCRIPTION
 
     returns a string where all captured groups have been replaced by the return
-    value of function pointer fun or function fun in object ob. (called with the
-    matched string and match number, starting with 0)
+    value of function pointer fun or function fun in object ob. (called with
+    the matched string and match number, starting with 0).
+
+    The optional `pcre_flags` sets PCRE options (e.g., `PCRE_I` for
+    case-insensitive, `PCRE_M` for multiline). Defaults to 0.
 
 ### SEE ALSO
 

--- a/docs/zh-CN/efun/index.md
+++ b/docs/zh-CN/efun/index.md
@@ -156,6 +156,7 @@ title: APPLY
 * [pcre_cache](pcre_cache.html)
 * [pcre_extract](pcre_extract.html)
 * [pcre_match](pcre_match.html)
+* [pcre_match_all](pcre_match_all.html)
 * [pcre_replace](pcre_replace.html)
 * [pcre_replace_callback](pcre_replace_callback.html)
 * [pcre_version](pcre_version.html)

--- a/docs/zh-CN/efun/pcre_assoc.md
+++ b/docs/zh-CN/efun/pcre_assoc.md
@@ -10,11 +10,13 @@ title: pcre / pcre_assoc
 
 ### SYNOPSIS
 
-    mixed *pcre_assoc(string, string *, mixed *, mixed | void);
+    mixed *pcre_assoc(string, string *, mixed *, mixed | void, void | int pcre_flags);
 
 ### DESCRIPTION
 
     analog with reg_assoc efun for backwards compatibility reasons but utilizing the PCRE library.
+
+    可选参数 `pcre_flags` 用于设置 PCRE 选项（如 `PCRE_I` 大小写不敏感，`PCRE_M` 多行等），默认 0。
 
 ### SEE ALSO
 

--- a/docs/zh-CN/efun/pcre_extract.md
+++ b/docs/zh-CN/efun/pcre_extract.md
@@ -10,13 +10,15 @@ title: pcre / pcre_extract
 
 ### SYNOPSIS
 
-    string *pcre_extract(string, string, void|int include_named);
+    string *pcre_extract(string, string, void|int include_named, void|int pcre_flags);
 
 ### DESCRIPTION
 
     返回模式中捕获分组组成的数组。
 
     第三个参数 `include_named` 可选，默认 0。当其非零时，返回值末尾总会追加一个映射，键为分组名称，值为对应的捕获内容。若正则没有命名分组（或均未匹配），映射为空；否则仅包含实际参与匹配的分组。
+
+    第四个参数 `pcre_flags` 可选，默认 0，用于设置 PCRE 选项（如 `PCRE_I` 大小写不敏感，`PCRE_M` 多行等）。
 
     示例（命名分组）：
 

--- a/docs/zh-CN/efun/pcre_match.md
+++ b/docs/zh-CN/efun/pcre_match.md
@@ -10,12 +10,16 @@ title: pcre / pcre_match
 
 ### SYNOPSIS
 
-    mixed pcre_match(string | string *, string, void | int);
+    mixed pcre_match(string | string *, string, void | int flag, void | int pcre_flags);
 
 ### DESCRIPTION
 
     analog with regexp efun for backwards compatibility reasons
     but utilizing the PCRE library.
+
+    可选参数 `pcre_flags` 用于设置 PCRE 选项（如 `PCRE_I` 大小写不敏感，
+    `PCRE_M` 多行等），默认为 0。字符串输入时第 3 个参数视为 `pcre_flags`；
+    数组输入时第 3 个参数仍是旧 flag，第 4 个参数才是 `pcre_flags`。
 
 ### SEE ALSO
 

--- a/docs/zh-CN/efun/pcre_match_all.md
+++ b/docs/zh-CN/efun/pcre_match_all.md
@@ -1,0 +1,27 @@
+---
+layout: doc
+title: pcre / pcre_match_all
+---
+# pcre_match_all
+
+### NAME
+
+    pcre_match_all() - 查找所有匹配
+
+### SYNOPSIS
+
+    mixed pcre_match_all(string input, string pattern, void|int pcre_flags);
+
+### DESCRIPTION
+
+    类似 PHP 的 preg_match_all，返回一个字符串数组的数组，包含所有匹配及其捕获分组。
+
+    可选参数 `pcre_flags` 用于设置 PCRE 选项（如 `PCRE_I` 大小写不敏感，`PCRE_M` 多行等），默认 0。
+
+### Example
+
+    // https://tools.ietf.org/html/rfc3986#appendix-B
+    pcre_match_all("http://www.ics.uci.edu/pub/ietf/uri/#Related",
+                       "^(([^:/?#]+):)?(//([^/?#]*))?([^?#]*)(\\?([^#]*))?(#(.*))?" , PCRE_M));
+
+    返回的数组第 1 项是完整匹配，后续依次为各捕获分组。

--- a/docs/zh-CN/efun/pcre_replace.md
+++ b/docs/zh-CN/efun/pcre_replace.md
@@ -10,13 +10,16 @@ title: pcre / pcre_replace
 
 ### SYNOPSIS
 
-    string pcre_replace(string, string, string *);
+    string pcre_replace(string, string, string *, void|int pcre_flags);
 
 ### DESCRIPTION
 
     returns a string where all captured groups have been replaced by the elements
     of the replacement array. Number of subgroups and the size of the replacement
     array must match.
+
+    可选参数 `pcre_flags` 用于设置 PCRE 选项（如 `PCRE_I` 大小写不敏感，
+    `PCRE_M` 多行等），默认 0。
 
 ### SEE ALSO
 

--- a/docs/zh-CN/efun/pcre_replace_callback.md
+++ b/docs/zh-CN/efun/pcre_replace_callback.md
@@ -10,13 +10,16 @@ title: pcre / pcre_replace_callback
 
 ### SYNOPSIS
 
-    string pcre_replace_callback(string, string, string | function, ...);
+    string pcre_replace_callback(string, string, string | function, ..., void|int pcre_flags);
 
 ### DESCRIPTION
 
     returns a string where all captured groups have been replaced by the
     return value of function pointe fun or function fun in object ob.
     (called with the matched string and match number, starting with 0)
+
+    可选参数 `pcre_flags` 用于设置 PCRE 选项（如 `PCRE_I` 大小写不敏感，
+    `PCRE_M` 多行等），默认 0。
 
 ### SEE ALSO
 

--- a/src/include/pcre_flags.h
+++ b/src/include/pcre_flags.h
@@ -1,0 +1,17 @@
+// PCRE efun flags (kept in high bits to avoid legacy flag collisions)
+#ifndef SRC_INCLUDE_PCRE_FLAGS_H_
+#define SRC_INCLUDE_PCRE_FLAGS_H_
+
+#define PCRE_DEFAULT 0
+
+// Compile-time options
+#define PCRE_I (1 << 16)  // PCRE_CASELESS
+#define PCRE_M (1 << 17)  // PCRE_MULTILINE
+#define PCRE_S (1 << 18)  // PCRE_DOTALL
+#define PCRE_U (1 << 19)  // PCRE_UNGREEDY
+#define PCRE_X (1 << 20)  // PCRE_EXTENDED
+
+// Exec-time option
+#define PCRE_A (1 << 21)  // PCRE_ANCHORED
+
+#endif  // SRC_INCLUDE_PCRE_FLAGS_H_

--- a/src/packages/pcre/pcre.cc
+++ b/src/packages/pcre/pcre.cc
@@ -65,6 +65,7 @@
 #include "base/package_api.h"
 
 #include "pcre.h"
+#include "include/pcre_flags.h"
 #include "vm/internal/base/mapping.h"
 
 // Prototype declarations
@@ -73,14 +74,16 @@ static pcre *pcre_local_compile(pcre_t *p);
 static int pcre_local_exec(pcre_t *p);
 static int pcre_magic(pcre_t *p);
 static int pcre_query_match(pcre_t *p);
-static int pcre_match_single(svalue_t *str, const char *pattern);
-static array_t *pcre_match(array_t *v, const char *pattern, int flag);
-static array_t *pcre_assoc(svalue_t *str, array_t *pat, array_t *tok, svalue_t *def);
+static inline int compute_compile_options(int flags);
+static inline int compute_exec_options(int flags);
+static int pcre_match_single(svalue_t *str, const char *pattern, int pcre_flags);
+static array_t *pcre_match(array_t *v, const char *pattern, int flag, int pcre_flags);
+static array_t *pcre_assoc(svalue_t *str, array_t *pat, array_t *tok, svalue_t *def, int pcre_flags);
 static char *pcre_get_replace(pcre_t *run, array_t *replacements);
 static array_t *pcre_get_substrings(pcre_t *run, bool include_names);
 // Caching functions
-static int pcre_cache_pattern(struct pcre_cache_t *table, pcre *cpat, const char *pattern);
-static pcre *pcre_get_cached_pattern(struct pcre_cache_t *table, const char *pattern);
+static int pcre_cache_pattern(struct pcre_cache_t *table, pcre *cpat, const char *pattern, int compile_flags);
+static pcre *pcre_get_cached_pattern(struct pcre_cache_t *table, const char *pattern, int compile_flags);
 static mapping_t *pcre_get_cache();
 int pcrecachesize = 0;
 // Globals
@@ -96,26 +99,39 @@ void f_pcre_version() {
 void f_pcre_match() {
   array_t *v;
   int flag = 0;
+  int pcre_flags = 0;
+  bool is_string = ((sp - 1)->type == T_STRING);
 
-  if (st_num_arg > 2) {
+  // optional 4th arg: pcre_flags
+  if (st_num_arg > 3) {
+    if (sp->type != T_NUMBER) {
+      error("Bad argument 4 to pcre_match()\n");
+    }
+    pcre_flags = (sp--)->u.number;
+    st_num_arg--;
+  }
+
+  // optional 3rd arg:
+  if (st_num_arg == 3) {
     if (sp->type != T_NUMBER) {
       error("Bad argument 3 to pcre_match()\n");
     }
-    if ((sp - 2)->type == T_STRING) {
-      error("3rd argument illegal for pcre_match(string, string)\n");
+    if (is_string) {
+      pcre_flags = (sp--)->u.number;
+    } else {
+      flag = (sp--)->u.number;
     }
-
-    flag = (sp--)->u.number;
+    st_num_arg--;
   }
 
-  if ((sp - 1)->type == T_STRING) {
-    flag = pcre_match_single((sp - 1), sp->u.string);
+  if (is_string) {
+    flag = pcre_match_single((sp - 1), sp->u.string, pcre_flags);
 
     free_string_svalue(sp--);
     free_string_svalue(sp);
     put_number(flag);
   } else {
-    v = pcre_match((sp - 1)->u.arr, sp->u.string, flag);
+    v = pcre_match((sp - 1)->u.arr, sp->u.string, flag, pcre_flags);
 
     free_string_svalue(sp--);
     free_array(sp->u.arr);
@@ -126,6 +142,16 @@ void f_pcre_match() {
 void f_pcre_assoc() {
   svalue_t *arg;
   array_t *vec;
+  int pcre_flags = 0;
+
+  if (st_num_arg == 5) {
+    if (sp->type != T_NUMBER) {
+      error("Bad argument 5 to pcre_assoc()\n");
+    }
+    pcre_flags = sp->u.number;
+    sp--;
+    st_num_arg--;
+  }
 
   arg = sp - st_num_arg + 1;
 
@@ -133,7 +159,7 @@ void f_pcre_assoc() {
     error("Bad argument 3 to pcre_assoc()\n");
   }
 
-  vec = pcre_assoc(arg, (arg + 1)->u.arr, (arg + 2)->u.arr, st_num_arg > 3 ? (arg + 3) : &const0);
+  vec = pcre_assoc(arg, (arg + 1)->u.arr, (arg + 2)->u.arr, st_num_arg > 3 ? (arg + 3) : &const0, pcre_flags);
 
   if (st_num_arg == 4) {
     pop_3_elems();
@@ -150,8 +176,19 @@ void f_pcre_assoc() {
 void f_pcre_extract() {
   pcre_t *run;
   array_t *ret;
-  svalue_t *arg = sp - st_num_arg + 1;
   int include_names = 0;
+  int pcre_flags = 0;
+
+  if (st_num_arg >= 4) {
+    if (sp->type != T_NUMBER) {
+      error("Bad argument 4 to pcre_extract()\n");
+    }
+    pcre_flags = sp->u.number;
+    sp--;
+    st_num_arg--;
+  }
+
+  svalue_t *arg = sp - st_num_arg + 1;
 
   if (st_num_arg == 3) {
     if ((arg + 2)->type != T_NUMBER) {
@@ -168,6 +205,8 @@ void f_pcre_extract() {
   run->s_length = SVALUE_STRLEN(arg);
   run->ovector = nullptr;
   run->ovecsize = 0;
+  run->compile_flags = compute_compile_options(pcre_flags);
+  run->exec_flags = compute_exec_options(pcre_flags);
   DEFER { pcre_free_memory(run); };
 
   if (pcre_magic(run) < 0) {
@@ -194,6 +233,15 @@ void f_pcre_replace() {
   array_t *replacements;
 
   char *ret;
+  int pcre_flags = 0;
+
+  if (st_num_arg >= 4) {
+    if (sp->type != T_NUMBER) {
+      error("Bad argument 4 to pcre_replace()\n");
+    }
+    pcre_flags = (sp--)->u.number;
+    st_num_arg--;
+  }
 
   run = (pcre_t *)DCALLOC(1, sizeof(pcre_t), TAG_TEMPORARY, "f_pcre_replace: run");
 
@@ -204,6 +252,8 @@ void f_pcre_replace() {
   replacements = sp->u.arr;
 
   run->s_length = SVALUE_STRLEN(sp - 2);
+  run->compile_flags = compute_compile_options(pcre_flags);
+  run->exec_flags = compute_exec_options(pcre_flags);
   DEFER { pcre_free_memory(run); };
 
   if (pcre_magic(run) < 0) {
@@ -247,6 +297,14 @@ void f_pcre_replace_callback() {
   svalue_t *arg;
   array_t *arr, *r;
   function_to_call_t ftc;
+  int pcre_flags = 0;
+
+  if (num_arg >= 4 && sp->type == T_NUMBER) {
+    pcre_flags = sp->u.number;
+    sp--;
+    st_num_arg--;
+    num_arg--;
+  }
 
   arg = sp - num_arg + 1;
 
@@ -257,6 +315,8 @@ void f_pcre_replace_callback() {
   run->pattern = (arg + 1)->u.string;
 
   run->s_length = SVALUE_STRLEN(arg);
+  run->compile_flags = compute_compile_options(pcre_flags);
+  run->exec_flags = compute_exec_options(pcre_flags);
   DEFER { pcre_free_memory(run); };
 
   if (pcre_magic(run) < 0) {
@@ -327,8 +387,24 @@ void f_pcre_cache() {
 }
 
 // Internal functions utilized by the efuns
+static inline int compute_compile_options(int flags) {
+  int opts = PCRE_UTF8;
+  if (flags & PCRE_I) opts |= PCRE_CASELESS;
+  if (flags & PCRE_M) opts |= PCRE_MULTILINE;
+  if (flags & PCRE_S) opts |= PCRE_DOTALL;
+  if (flags & PCRE_U) opts |= PCRE_UNGREEDY;
+  if (flags & PCRE_X) opts |= PCRE_EXTENDED;
+  return opts;
+}
+
+static inline int compute_exec_options(int flags) {
+  int opts = 0;
+  if (flags & PCRE_A) opts |= PCRE_ANCHORED;
+  return opts;
+}
+
 static pcre *pcre_local_compile(pcre_t *p) {
-  p->re = pcre_compile(p->pattern, PCRE_UTF8, &p->error, &p->erroffset, nullptr);
+  p->re = pcre_compile(p->pattern, p->compile_flags, &p->error, &p->erroffset, nullptr);
 
   return p->re;
 }
@@ -352,17 +428,17 @@ static int pcre_local_exec(pcre_t *p) {
   pcre_fullinfo(p->re, nullptr, PCRE_INFO_NAMEENTRYSIZE, &p->name_entry_size);
   pcre_fullinfo(p->re, nullptr, PCRE_INFO_NAMETABLE, &p->name_table);
 
-  p->rc = pcre_exec(p->re, nullptr, p->subject, p->s_length, 0, 0, p->ovector, capture_count);
+  p->rc = pcre_exec(p->re, nullptr, p->subject, p->s_length, 0, p->exec_flags, p->ovector, capture_count);
 
   return p->rc;
 }
 
 static int pcre_magic(pcre_t *p) {
-  p->re = pcre_get_cached_pattern(&pcre_cache, p->pattern);
+  p->re = pcre_get_cached_pattern(&pcre_cache, p->pattern, p->compile_flags);
 
   if (p->re == nullptr) {
     pcre_local_compile(p);
-    pcre_cache_pattern(&pcre_cache, p->re, p->pattern);
+    pcre_cache_pattern(&pcre_cache, p->re, p->pattern, p->compile_flags);
   }
 
   if (p->re == nullptr) {
@@ -381,7 +457,7 @@ static int pcre_magic(pcre_t *p) {
 
 static int pcre_query_match(pcre_t *p) { return p->rc < 0 ? 0 : 1; }
 
-auto pcre_match_all(const char *subject, size_t subject_len, const char *pattern) {
+auto pcre_match_all(const char *subject, size_t subject_len, const char *pattern, int pcre_flags) {
   pcre_t *run;
 
   run = (pcre_t *)DCALLOC(1, sizeof(pcre_t), TAG_TEMPORARY, "pcre_match_single : run");
@@ -390,14 +466,16 @@ auto pcre_match_all(const char *subject, size_t subject_len, const char *pattern
   run->pattern = pattern;
   run->subject = subject;
   run->s_length = subject_len;
+  run->compile_flags = compute_compile_options(pcre_flags);
+  run->exec_flags = compute_exec_options(pcre_flags);
 
   DEFER { pcre_free_memory(run); };
 
-  run->re = pcre_get_cached_pattern(&pcre_cache, run->pattern);
+  run->re = pcre_get_cached_pattern(&pcre_cache, run->pattern, run->compile_flags);
 
   if (run->re == nullptr) {
     pcre_local_compile(run);
-    pcre_cache_pattern(&pcre_cache, run->re, run->pattern);
+    pcre_cache_pattern(&pcre_cache, run->re, run->pattern, run->compile_flags);
   }
 
   if (run->re == nullptr) {
@@ -422,7 +500,7 @@ auto pcre_match_all(const char *subject, size_t subject_len, const char *pattern
   int rc = 0;
   int offset = 0;
   while (offset < run->s_length && (rc = pcre_exec(run->re, nullptr, run->subject, run->s_length,
-                                                   offset, 0, run->ovector, run->ovecsize)) >= 0) {
+                                                   offset, run->exec_flags, run->ovector, run->ovecsize)) >= 0) {
     std::vector<svalue_t> match;
     for (int i = 0; i < rc; ++i) {
       unsigned int start, length;
@@ -445,7 +523,7 @@ auto pcre_match_all(const char *subject, size_t subject_len, const char *pattern
   return matches;
 }
 
-static int pcre_match_single(svalue_t *str, const char *pattern) {
+static int pcre_match_single(svalue_t *str, const char *pattern, int pcre_flags) {
   pcre_t *run;
   int ret;
 
@@ -455,6 +533,8 @@ static int pcre_match_single(svalue_t *str, const char *pattern) {
   run->pattern = pattern;
   run->subject = str->u.string;
   run->s_length = SVALUE_STRLEN(str);
+  run->compile_flags = compute_compile_options(pcre_flags);
+  run->exec_flags = compute_exec_options(pcre_flags);
 
   DEFER { pcre_free_memory(run); };
 
@@ -467,7 +547,7 @@ static int pcre_match_single(svalue_t *str, const char *pattern) {
   return ret;
 }
 
-static array_t *pcre_match(array_t *v, const char *pattern, int flag) {
+static array_t *pcre_match(array_t *v, const char *pattern, int flag, int pcre_flags) {
   pcre_t *run;
   array_t *ret;
   svalue_t *sv1, *sv2;
@@ -482,8 +562,10 @@ static array_t *pcre_match(array_t *v, const char *pattern, int flag) {
   run->ovector = nullptr;
   run->ovecsize = 0;
   run->pattern = pattern;
+  run->compile_flags = compute_compile_options(pcre_flags);
+  run->exec_flags = compute_exec_options(pcre_flags);
 
-  run->re = pcre_get_cached_pattern(&pcre_cache, run->pattern);
+  run->re = pcre_get_cached_pattern(&pcre_cache, run->pattern, run->compile_flags);
 
   DEFER { pcre_free_memory(run); };
 
@@ -494,7 +576,7 @@ static array_t *pcre_match(array_t *v, const char *pattern, int flag) {
 
       error("PCRE compilation failed at offset %d: %s\n", offset, rerror);
     } else {
-      pcre_cache_pattern(&pcre_cache, run->re, run->pattern);
+      pcre_cache_pattern(&pcre_cache, run->re, run->pattern, run->compile_flags);
     }
   }
 
@@ -558,7 +640,7 @@ static array_t *pcre_match(array_t *v, const char *pattern, int flag) {
 /* This is mostly copy/paste from reg_assoc, some parts are changed
  * TODO: rewrite with new logic
  */
-static array_t *pcre_assoc(svalue_t *str, array_t *pat, array_t *tok, svalue_t *def) {
+static array_t *pcre_assoc(svalue_t *str, array_t *pat, array_t *tok, svalue_t *def, int pcre_flags) {
   int i;
   size_t size;
   const char *tmp;
@@ -595,7 +677,9 @@ static array_t *pcre_assoc(svalue_t *str, array_t *pat, array_t *tok, svalue_t *
       rgpp[i]->ovector = nullptr;
       rgpp[i]->ovecsize = 0;
       rgpp[i]->pattern = pat->item[i].u.string;
-      rgpp[i]->re = pcre_get_cached_pattern(&pcre_cache, rgpp[i]->pattern);
+      rgpp[i]->compile_flags = compute_compile_options(pcre_flags);
+      rgpp[i]->exec_flags = compute_exec_options(pcre_flags);
+      rgpp[i]->re = pcre_get_cached_pattern(&pcre_cache, rgpp[i]->pattern, rgpp[i]->compile_flags);
 
       if (rgpp[i]->re == nullptr) {
         if (pcre_local_compile(rgpp[i]) == nullptr) {
@@ -611,7 +695,7 @@ static array_t *pcre_assoc(svalue_t *str, array_t *pat, array_t *tok, svalue_t *
           free_empty_array(ret);
           error("PCRE compilation failed at offset %d: %s\n", offset, rerror);
         } else {
-          pcre_cache_pattern(&pcre_cache, rgpp[i]->re, rgpp[i]->pattern);
+          pcre_cache_pattern(&pcre_cache, rgpp[i]->re, rgpp[i]->pattern, rgpp[i]->compile_flags);
         }
       }
     }
@@ -891,10 +975,10 @@ static void pcre_free_memory(pcre_t *p) {
 // Caching functions, add new ones at the front of the bucket so we find them
 // faster
 static int pcre_cache_pattern(struct pcre_cache_t *table, pcre *cpat,
-                              const char *pattern)  // must be shared string
+                              const char *pattern, int compile_flags)  // must be shared string
 {
   const auto *shared_pattern = make_shared_string(pattern);
-  unsigned int const bucket = HASH(BLOCK(shared_pattern)) % PCRE_CACHE_SIZE;
+  unsigned int const bucket = (HASH(BLOCK(shared_pattern)) ^ compile_flags) % PCRE_CACHE_SIZE;
   size_t sz;
   struct pcre_cache_bucket_t *tmp;
   struct pcre_cache_bucket_t *node;
@@ -907,7 +991,7 @@ static int pcre_cache_pattern(struct pcre_cache_t *table, pcre *cpat,
 
   full = (pcrecachesize > 2 * PCRE_CACHE_SIZE);
   while (tmp) {
-    if (shared_pattern == tmp->pattern) {
+    if (shared_pattern == tmp->pattern && tmp->compile_flags == compile_flags) {
       break;
     }
 
@@ -955,21 +1039,22 @@ static int pcre_cache_pattern(struct pcre_cache_t *table, pcre *cpat,
   }
 
   node->pattern = shared_pattern;
+  node->compile_flags = compile_flags;
   node->compiled_pattern = cpat;
   node->size = sz;
 
   return 0;
 }
 
-static pcre *pcre_get_cached_pattern(struct pcre_cache_t *table, const char *pattern) {
+static pcre *pcre_get_cached_pattern(struct pcre_cache_t *table, const char *pattern, int compile_flags) {
   const auto *shared_pattern = make_shared_string(pattern);
-  unsigned int const bucket = HASH(BLOCK(shared_pattern)) % PCRE_CACHE_SIZE;
+  unsigned int const bucket = (HASH(BLOCK(shared_pattern)) ^ compile_flags) % PCRE_CACHE_SIZE;
   struct pcre_cache_bucket_t *node;
   struct pcre_cache_bucket_t *lnode = nullptr;
   node = table->buckets[bucket];
 
   while (node) {
-    if (shared_pattern == node->pattern) {
+    if (shared_pattern == node->pattern && node->compile_flags == compile_flags) {
       if (node != table->buckets[bucket]) {
         // not at the front, move it there, so the most used pattern is fastest
         lnode->next = node->next;
@@ -1010,7 +1095,11 @@ static mapping_t *pcre_get_cache() {
       node = pcre_cache.buckets[i];
 
       while (node) {
-        add_mapping_pair(ret, node->pattern, node->size);
+        size_t keylen = strlen(node->pattern) + 16;
+        char *key = (char *)DMALLOC(keylen, TAG_TEMPORARY, "pcre_cache key");
+        snprintf(key, keylen, "%s|0x%x", node->pattern, node->compile_flags);
+        add_mapping_pair(ret, key, node->size);
+        FREE(key);
         node = node->next;
       }
     }
@@ -1036,11 +1125,20 @@ void mark_pcre_cache() {
 void f_pcre_match_all() {
   array_t *v;
 
+  int pcre_flags = 0;
+  if (st_num_arg >= 3) {
+    if (sp->type != T_NUMBER) {
+      error("Bad argument 3 to pcre_match_all()\n");
+    }
+    pcre_flags = (sp--)->u.number;
+    st_num_arg--;
+  }
+
   const auto *pattern = (sp)->u.string;
   const auto *subject = (sp - 1)->u.string;
   auto subject_len = SVALUE_STRLEN(sp - 1);
 
-  auto matches = pcre_match_all(subject, subject_len, pattern);
+  auto matches = pcre_match_all(subject, subject_len, pattern, pcre_flags);
 
   pop_2_elems();
 

--- a/src/packages/pcre/pcre.h
+++ b/src/packages/pcre/pcre.h
@@ -27,6 +27,8 @@ typedef struct {
   int find_all;
   int namecount;
   int name_entry_size;
+  int compile_flags;
+  int exec_flags;
   int *ovector;
   int ovecsize;
   int rc;
@@ -36,6 +38,7 @@ typedef struct {
 struct pcre_cache_bucket_t {
   pcre *compiled_pattern;  // value1
   const char *pattern;     // key
+  int compile_flags;       // compile options used
   int size;                // size in bytes
   struct pcre_cache_bucket_t *next;
 };

--- a/src/packages/pcre/pcre.spec
+++ b/src/packages/pcre/pcre.spec
@@ -1,9 +1,9 @@
 
 string pcre_version(void);
-mixed pcre_match(string | string *, string, void | int);
-mixed pcre_match_all(string, string);
-mixed *pcre_assoc(string, string *, mixed *, mixed | void);
-string *pcre_extract(string, string, void | int);
-string pcre_replace(string, string, string *);
-string pcre_replace_callback(string, string, string | function, ...);
+mixed pcre_match(string | string *, string, void | int, void | int);
+mixed pcre_match_all(string, string, void | int);
+mixed *pcre_assoc(string, string *, mixed *, mixed | void, void | int);
+string *pcre_extract(string, string, void | int, void | int);
+string pcre_replace(string, string, string *, void | int);
+string pcre_replace_callback(string, string, string | function, ..., void | int);
 mapping pcre_cache(void);

--- a/testsuite/single/tests/efuns/pcre.c
+++ b/testsuite/single/tests/efuns/pcre.c
@@ -163,6 +163,29 @@ TEXT;
   ASSERT_EQ("c", optional_named[2]);
   ASSERT_EQ(([ ]), optional_named[3]);
 
-      tmp = "foobar";
-      ASSERT_EQ("foo->bar", pcre_replace_callback(tmp, "(foo)", (: $1 + "->" :)));
+  int flag_i = 1 << 16; // PCRE_I
+  ASSERT_EQ("xbc", pcre_replace("abc", "(A)", ({"x"}), flag_i));
+  ASSERT_EQ("a!bc", pcre_replace_callback("abc", "(A)", (: $1 + "!" :), flag_i));
+
+  // pcre_match with flags: case-insensitive and anchored.
+  ASSERT_EQ(1, pcre_match("abc", "ABC", flag_i));
+  int flag_anchored = (1 << 21); // PCRE_A
+  ASSERT_EQ(0, pcre_match("zabc", "abc", flag_anchored));
+
+  // pcre_match_all with flags: multiline
+  int flag_m = (1 << 17); // PCRE_M
+  mixed *ma = pcre_match_all("a\nb\nc", "^b", flag_m);
+  ASSERT_EQ(1, sizeof(ma));
+  ASSERT_EQ("b", ma[0][0]);
+
+  // pcre_extract with flags (case-insensitive)
+  mixed *ex = pcre_extract("HELLO", "(hello)", 0, flag_i);
+  ASSERT_EQ(({"HELLO"}), ex);
+
+  // pcre_assoc with flags: case-insensitive match
+  mixed *assoc_res = pcre_assoc("HelloWorld", ({"hello"}), ({1}), 0, flag_i);
+  ASSERT_EQ(({({"", "Hello", "World"}), ({0,1,0})}), assoc_res);
+
+  tmp = "foobar";
+  ASSERT_EQ("foo->bar", pcre_replace_callback(tmp, "(foo)", (: $1 + "->" :)));
 }


### PR DESCRIPTION
## Summary
- add optional PCRE flag arg (PCRE_I/M/S/U/X/A) to pcre_match, pcre_match_all, pcre_extract, pcre_assoc, pcre_replace, pcre_replace_callback
- add optional mapping return for named capture groups in pcre_extract (append mapping when include_named is set; mapping still empty if no named groups participate)
- introduce shared `src/include/pcre_flags.h`; cache now keys compiled patterns by flags
- update docs (EN + zh-CN) including new zh-CN pcre_match_all page; add tests covering flags and named-group behavior

## Notes
- grammar/autogen files left untouched
- tests not run in this environment