### PR TITLE
fix-ternary-fallthrough

### DIFF
--- a/src/compiler/internal/lex.cc
+++ b/src/compiler/internal/lex.cc
@@ -2126,6 +2126,7 @@ int yylex() {
       case ';':
       case ',':
       case '~':
+      return c;
 #ifndef USE_TRIGRAPHS
       case '?':
         /* Check for ?? and ??= operators */


### PR DESCRIPTION
修复由 case 循环导致的三元运算符语法错误

问题：

缺少空格的 `?` 和 `:` 周围的三元运算符无法编译：

icon = (condition)?"value1":"value2";

错误：语法错误，意外的 ':'

根本原因：

在 src/compiler/internal/lex.cc 中，`case ')':` 会循环执行到 `case '?':`

当 `)'` 后紧跟 `?'`（例如，`)?"")`）时，词法分析器会检查

`if (*outp == '?')`，并错误地返回 `L_QUESTION_QUESTION` 而不是

`)` 标记，导致解析器期望的是一个空值合并表达式，

而不是三元运算符。

解决方案：

在 `case '~':` 后添加 `return c;` 以防止循环执行到 `case '?':`

这确保简单字符（包括 `)'）在到达 `??` 之前返回其标记。

运算符检查。

测试：

- 不含空格的三元运算符：(1)?a":"b" ✓


