### PR TITLE
Fix ternary operator compilation without spaces (issue #1170)

### DIFF
--- a/src/compiler/internal/lex.cc
+++ b/src/compiler/internal/lex.cc
@@ -2126,6 +2126,7 @@ int yylex() {
       case ';':
       case ',':
       case '~':
+        return c;
 #ifndef USE_TRIGRAPHS
       case '?':
         /* Check for ?? and ??= operators */
@@ -2139,7 +2140,6 @@ int yylex() {
         }
         return c;
 #else
-        return c;
       /*
        * You're probably asking, what the heck are trigraphs?
        * The character set of C source is contained within seven-bit

--- a/testsuite/single/tests/compiler/conditional.c
+++ b/testsuite/single/tests/compiler/conditional.c
@@ -144,4 +144,41 @@ void do_tests() {
   maybe ??= counted(100);
   ASSERT_EQ(42, maybe);
   ASSERT_EQ(0, logical_assign_counter);
+
+  // Test ternary operator without spaces (issue #1170)
+  // These should all work without requiring spaces around ? and :
+  string icon;
+  icon = (1)?"yes":"no";
+  ASSERT_EQ("yes", icon);
+
+  icon = (0)?"yes":"no";
+  ASSERT_EQ("no", icon);
+
+  // Nested ternary without spaces
+  icon = (1)?"a":(0)?"b":"c";
+  ASSERT_EQ("a", icon);
+
+  icon = (0)?"a":(1)?"b":"c";
+  ASSERT_EQ("b", icon);
+
+  icon = (0)?"a":(0)?"b":"c";
+  ASSERT_EQ("c", icon);
+
+  // Mixed with and without spaces
+  icon = (1) ? "yes":"no";
+  ASSERT_EQ("yes", icon);
+
+  icon = (1)?"yes" : "no";
+  ASSERT_EQ("yes", icon);
+
+  // Test with other single-char tokens before ?
+  int num = 5;
+  icon = num>3?"big":"small";
+  ASSERT_EQ("big", icon);
+
+  icon = (num)?"yes":"no";
+  ASSERT_EQ("yes", icon);
+
+  icon = ({1,2,3})[0]?"yes":"no";
+  ASSERT_EQ("yes", icon);
 }


### PR DESCRIPTION
After PR #1149 added nullish coalescing operator (??), ternary operators
without spaces around ? and : failed to compile. Code like (1)?"yes":"no"
would produce "syntax error, unexpected ':'".

Root cause: In the lexer (lex.cc), the fall-through cases for single-char
tokens (')', '{', '}', '[', ']', ';', ',', '~') were falling into the
'case '?':' handler. When parsing something like ')?' from '(1)?"yes"',
the lexer would:
1. Read ')' into variable c
2. Match 'case ')':', fall through to 'case '?':'
3. Check if the NEXT character is '?' (it is!)
4. Consume the '?' and return L_QUESTION_QUESTION
5. The parser never received the ')' token

Fix: Add 'return c;' before the #ifndef USE_TRIGRAPHS directive to
prevent fall-through. Now each single-char token is properly returned
before checking for the ?? operator.

Tests: Added comprehensive test cases in conditional.c covering:
- Ternary operators without spaces: (1)?"yes":"no"
- Nested ternaries without spaces
- Mixed spacing patterns
- Various token combinations before '?'