### PR TITLE
Fix unguarded dump_trace() causing abort in Debug builds

### DIFF
--- a/src/vm/internal/simulate.cc
+++ b/src/vm/internal/simulate.cc
@@ -1931,7 +1931,9 @@ void _error_handler(char *err) {
   } else {
     debug_message("Error in mudlib error handler: ");
     debug_message_with_location(err);
-    dump_trace(CONFIG_INT(__RC_TRACE_CODE__));
+    if (num_mudlib_error == 1) {
+      dump_trace(CONFIG_INT(__RC_TRACE_CODE__));
+    }
     num_mudlib_error--;
   }
 exit:


### PR DESCRIPTION
## Summary
- Adds missing `num_mudlib_error == 1` recursion guard before `dump_trace()` at line 1934 in `error_handler()`
- Consistent with the same guards already present at lines 1793, 1806, and 1865 (added by commit 6e28a6e6)
- Fixes crasher test 750.c causing driver abort (exit code 134) in all Debug CI builds

## Problem
When `dump_trace()` formats objects via `object_name()` apply, objects like `750.c` that error during `name()` re-enter the error handler recursively. Without the guard, `num_mudlib_error` climbs until it triggers `fatal()`, which calls `abort()` immediately in Debug builds.

This breaks all Debug CI jobs (Ubuntu gcc/clang, macOS, clang+sanitizer).

## Test plan
- [ ] CI Debug builds pass (previously all failing on crasher/750.c)
- [ ] CI RelWithDebInfo builds continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)