### PR TITLE
Add template literals and %g format specifier

### DIFF
--- a/docs/efun/strings/sprintf.md
+++ b/docs/efun/strings/sprintf.md
@@ -83,6 +83,9 @@ title: strings / sprintf
 
     f       floating point number
 
+    g       floating point number, trailing zeros removed
+            (e.g. 3.14 instead of 3.140000, 100 instead of 100.000000)
+
 ### RETURN VALUES
 
     sprintf() returns the formatted string.

--- a/docs/lpc/types/strings.md
+++ b/docs/lpc/types/strings.md
@@ -4,6 +4,82 @@ title: types / strings
 ---
 # strings
 
+## Template Literals
+
+Template literals provide string interpolation using backtick delimiters and
+`${expression}` placeholders. The expression inside `${}` is evaluated and
+coerced to a string at runtime.
+
+### Syntax
+
+    string name = "Alice";
+    int count = 3;
+
+    `Hello, ${name}!`              // "Hello, Alice!"
+    `You have ${count} items.`     // "You have 3 items."
+    `Sum: ${1 + 2}`                // "Sum: 3"
+
+### Type Coercion
+
+Values are coerced to strings as follows:
+
+| Type    | Coercion                                            |
+|---------|-----------------------------------------------------|
+| string  | Used as-is                                          |
+| int     | Decimal representation                              |
+| float   | `%g` format (trailing zeros removed: 3.14 not 3.140000) |
+| other   | LPC literal representation (similar to `%O`)        |
+
+### Escape Sequences
+
+Template literals support the same escape sequences as regular strings
+(`\n`, `\t`, `\\`, `\xHH`, octal), plus:
+
+    \`      literal backtick
+    \$      literal dollar sign (prevents interpolation)
+
+### Newline Handling
+
+Newlines within a template literal are collapsed (removed):
+
+    `line one
+    line two`
+
+produces `"line oneline two"`.
+
+### Adjacent Concatenation
+
+Template literals can be placed adjacent to other template literals or
+regular strings to concatenate them, just like regular string literals:
+
+    `Hello, ${name}! ` `How are you?`
+    `Count: ${n}` " items"
+    "Hello, " `${name}!`
+
+### Examples
+
+    // Basic interpolation
+    string msg = `${this_body()->query_name()} says hi!`;
+
+    // Multiple expressions
+    string status = `${name} has ${count} items worth ${value} gold.`;
+
+    // Expressions
+    string info = `Total: ${price * quantity}`;
+
+    // Multiline with adjacent concat
+    string long_msg = `Dear ${name}, `
+                      `your order of ${count} items `
+                      `has been shipped.`;
+
+### SEE ALSO
+
+    sprintf(3)
+
+---
+
+## String Sub-Ranging
+
 string sub ranging - comments by Grey@TMI-2
 
 You can take a substring from a variable ( str ) buy using the substring

--- a/src/compiler/internal/grammar.autogen.cc
+++ b/src/compiler/internal/grammar.autogen.cc
@@ -186,139 +186,145 @@ enum yysymbol_kind_t
   YYSYMBOL_L_NEW = 51,                     /* L_NEW  */
   YYSYMBOL_L_PARAMETER = 52,               /* L_PARAMETER  */
   YYSYMBOL_L_TREE = 53,                    /* L_TREE  */
-  YYSYMBOL_L_PREPROCESSOR_COMMAND = 54,    /* L_PREPROCESSOR_COMMAND  */
-  YYSYMBOL_LOWER_THAN_ELSE = 55,           /* LOWER_THAN_ELSE  */
-  YYSYMBOL_56_ = 56,                       /* '?'  */
-  YYSYMBOL_57_ = 57,                       /* '|'  */
-  YYSYMBOL_58_ = 58,                       /* '^'  */
-  YYSYMBOL_59_ = 59,                       /* '&'  */
-  YYSYMBOL_L_EQ = 60,                      /* L_EQ  */
-  YYSYMBOL_L_NE = 61,                      /* L_NE  */
-  YYSYMBOL_62_ = 62,                       /* '<'  */
-  YYSYMBOL_63_ = 63,                       /* '+'  */
-  YYSYMBOL_64_ = 64,                       /* '-'  */
-  YYSYMBOL_65_ = 65,                       /* '*'  */
-  YYSYMBOL_66_ = 66,                       /* '%'  */
-  YYSYMBOL_67_ = 67,                       /* '/'  */
-  YYSYMBOL_68_ = 68,                       /* '~'  */
-  YYSYMBOL_69_ = 69,                       /* ';'  */
-  YYSYMBOL_70_ = 70,                       /* '('  */
-  YYSYMBOL_71_ = 71,                       /* ')'  */
-  YYSYMBOL_72_ = 72,                       /* ':'  */
-  YYSYMBOL_73_ = 73,                       /* ','  */
-  YYSYMBOL_74_ = 74,                       /* '{'  */
-  YYSYMBOL_75_ = 75,                       /* '}'  */
-  YYSYMBOL_76_ = 76,                       /* '$'  */
-  YYSYMBOL_77_ = 77,                       /* '['  */
-  YYSYMBOL_78_ = 78,                       /* ']'  */
-  YYSYMBOL_YYACCEPT = 79,                  /* $accept  */
-  YYSYMBOL_all = 80,                       /* all  */
-  YYSYMBOL_program = 81,                   /* program  */
-  YYSYMBOL_possible_semi_colon = 82,       /* possible_semi_colon  */
-  YYSYMBOL_inheritance = 83,               /* inheritance  */
-  YYSYMBOL_real = 84,                      /* real  */
-  YYSYMBOL_number = 85,                    /* number  */
-  YYSYMBOL_optional_star = 86,             /* optional_star  */
-  YYSYMBOL_block_or_semi = 87,             /* block_or_semi  */
-  YYSYMBOL_identifier = 88,                /* identifier  */
-  YYSYMBOL_function = 89,                  /* function  */
-  YYSYMBOL_90_1 = 90,                      /* $@1  */
-  YYSYMBOL_91_2 = 91,                      /* @2  */
-  YYSYMBOL_def = 92,                       /* def  */
-  YYSYMBOL_modifier_change = 93,           /* modifier_change  */
-  YYSYMBOL_member_name = 94,               /* member_name  */
-  YYSYMBOL_member_name_list = 95,          /* member_name_list  */
-  YYSYMBOL_member_list = 96,               /* member_list  */
-  YYSYMBOL_97_3 = 97,                      /* $@3  */
-  YYSYMBOL_type_decl = 98,                 /* type_decl  */
-  YYSYMBOL_99_4 = 99,                      /* @4  */
-  YYSYMBOL_new_local_name = 100,           /* new_local_name  */
-  YYSYMBOL_atomic_type = 101,              /* atomic_type  */
-  YYSYMBOL_opt_atomic_type = 102,          /* opt_atomic_type  */
-  YYSYMBOL_basic_type = 103,               /* basic_type  */
-  YYSYMBOL_arg_type = 104,                 /* arg_type  */
-  YYSYMBOL_optional_default_arg_value = 105, /* optional_default_arg_value  */
-  YYSYMBOL_new_arg = 106,                  /* new_arg  */
-  YYSYMBOL_argument = 107,                 /* argument  */
-  YYSYMBOL_argument_list = 108,            /* argument_list  */
-  YYSYMBOL_type_modifier_list = 109,       /* type_modifier_list  */
-  YYSYMBOL_type = 110,                     /* type  */
-  YYSYMBOL_cast = 111,                     /* cast  */
-  YYSYMBOL_opt_basic_type = 112,           /* opt_basic_type  */
-  YYSYMBOL_name_list = 113,                /* name_list  */
-  YYSYMBOL_new_name = 114,                 /* new_name  */
-  YYSYMBOL_block = 115,                    /* block  */
-  YYSYMBOL_116_5 = 116,                    /* @5  */
-  YYSYMBOL_decl_block = 117,               /* decl_block  */
-  YYSYMBOL_local_declarations = 118,       /* local_declarations  */
-  YYSYMBOL_119_6 = 119,                    /* $@6  */
-  YYSYMBOL_new_local_def = 120,            /* new_local_def  */
-  YYSYMBOL_single_new_local_def = 121,     /* single_new_local_def  */
-  YYSYMBOL_single_new_local_def_with_init = 122, /* single_new_local_def_with_init  */
-  YYSYMBOL_local_name_list = 123,          /* local_name_list  */
-  YYSYMBOL_local_declaration_statement = 124, /* local_declaration_statement  */
-  YYSYMBOL_125_7 = 125,                    /* $@7  */
-  YYSYMBOL_block_statements = 126,         /* block_statements  */
-  YYSYMBOL_statement = 127,                /* statement  */
-  YYSYMBOL_while = 128,                    /* while  */
-  YYSYMBOL_129_8 = 129,                    /* $@8  */
-  YYSYMBOL_do = 130,                       /* do  */
-  YYSYMBOL_131_9 = 131,                    /* $@9  */
-  YYSYMBOL_for = 132,                      /* for  */
-  YYSYMBOL_133_10 = 133,                   /* $@10  */
-  YYSYMBOL_foreach_var = 134,              /* foreach_var  */
-  YYSYMBOL_foreach_vars = 135,             /* foreach_vars  */
-  YYSYMBOL_foreach = 136,                  /* foreach  */
-  YYSYMBOL_137_11 = 137,                   /* $@11  */
-  YYSYMBOL_for_expr = 138,                 /* for_expr  */
-  YYSYMBOL_first_for_expr = 139,           /* first_for_expr  */
-  YYSYMBOL_switch = 140,                   /* switch  */
-  YYSYMBOL_141_12 = 141,                   /* $@12  */
-  YYSYMBOL_switch_block = 142,             /* switch_block  */
-  YYSYMBOL_case = 143,                     /* case  */
-  YYSYMBOL_case_label = 144,               /* case_label  */
-  YYSYMBOL_constant = 145,                 /* constant  */
-  YYSYMBOL_comma_expr = 146,               /* comma_expr  */
-  YYSYMBOL_ref = 147,                      /* ref  */
-  YYSYMBOL_expr0 = 148,                    /* expr0  */
-  YYSYMBOL_return = 149,                   /* return  */
-  YYSYMBOL_expr_list = 150,                /* expr_list  */
-  YYSYMBOL_expr_list_node = 151,           /* expr_list_node  */
-  YYSYMBOL_expr_list2 = 152,               /* expr_list2  */
-  YYSYMBOL_expr_list3 = 153,               /* expr_list3  */
-  YYSYMBOL_expr_list4 = 154,               /* expr_list4  */
-  YYSYMBOL_assoc_pair = 155,               /* assoc_pair  */
-  YYSYMBOL_lvalue = 156,                   /* lvalue  */
-  YYSYMBOL_l_new_function_open = 157,      /* l_new_function_open  */
-  YYSYMBOL_expr4 = 158,                    /* expr4  */
-  YYSYMBOL_159_13 = 159,                   /* @13  */
-  YYSYMBOL_160_14 = 160,                   /* @14  */
-  YYSYMBOL_expr_or_block = 161,            /* expr_or_block  */
-  YYSYMBOL_catch = 162,                    /* catch  */
-  YYSYMBOL_163_15 = 163,                   /* @15  */
-  YYSYMBOL_tree = 164,                     /* tree  */
-  YYSYMBOL_sscanf = 165,                   /* sscanf  */
-  YYSYMBOL_parse_command = 166,            /* parse_command  */
-  YYSYMBOL_time_expression = 167,          /* time_expression  */
-  YYSYMBOL_168_16 = 168,                   /* @16  */
-  YYSYMBOL_lvalue_list = 169,              /* lvalue_list  */
-  YYSYMBOL_string = 170,                   /* string  */
-  YYSYMBOL_string_con1 = 171,              /* string_con1  */
-  YYSYMBOL_string_con2 = 172,              /* string_con2  */
-  YYSYMBOL_class_init = 173,               /* class_init  */
-  YYSYMBOL_opt_class_init = 174,           /* opt_class_init  */
-  YYSYMBOL_function_call = 175,            /* function_call  */
-  YYSYMBOL_176_17 = 176,                   /* @17  */
-  YYSYMBOL_177_18 = 177,                   /* @18  */
-  YYSYMBOL_178_19 = 178,                   /* @19  */
-  YYSYMBOL_179_20 = 179,                   /* @20  */
-  YYSYMBOL_180_21 = 180,                   /* @21  */
-  YYSYMBOL_181_22 = 181,                   /* @22  */
-  YYSYMBOL_182_23 = 182,                   /* @23  */
-  YYSYMBOL_efun_override = 183,            /* efun_override  */
-  YYSYMBOL_function_name = 184,            /* function_name  */
-  YYSYMBOL_cond = 185,                     /* cond  */
-  YYSYMBOL_optional_else_part = 186        /* optional_else_part  */
+  YYSYMBOL_L_TEMPLATE_HEAD = 54,           /* L_TEMPLATE_HEAD  */
+  YYSYMBOL_L_TEMPLATE_MIDDLE = 55,         /* L_TEMPLATE_MIDDLE  */
+  YYSYMBOL_L_TEMPLATE_TAIL = 56,           /* L_TEMPLATE_TAIL  */
+  YYSYMBOL_L_PREPROCESSOR_COMMAND = 57,    /* L_PREPROCESSOR_COMMAND  */
+  YYSYMBOL_LOWER_THAN_ELSE = 58,           /* LOWER_THAN_ELSE  */
+  YYSYMBOL_59_ = 59,                       /* '?'  */
+  YYSYMBOL_60_ = 60,                       /* '|'  */
+  YYSYMBOL_61_ = 61,                       /* '^'  */
+  YYSYMBOL_62_ = 62,                       /* '&'  */
+  YYSYMBOL_L_EQ = 63,                      /* L_EQ  */
+  YYSYMBOL_L_NE = 64,                      /* L_NE  */
+  YYSYMBOL_65_ = 65,                       /* '<'  */
+  YYSYMBOL_66_ = 66,                       /* '+'  */
+  YYSYMBOL_67_ = 67,                       /* '-'  */
+  YYSYMBOL_68_ = 68,                       /* '*'  */
+  YYSYMBOL_69_ = 69,                       /* '%'  */
+  YYSYMBOL_70_ = 70,                       /* '/'  */
+  YYSYMBOL_71_ = 71,                       /* '~'  */
+  YYSYMBOL_72_ = 72,                       /* ';'  */
+  YYSYMBOL_73_ = 73,                       /* '('  */
+  YYSYMBOL_74_ = 74,                       /* ')'  */
+  YYSYMBOL_75_ = 75,                       /* ':'  */
+  YYSYMBOL_76_ = 76,                       /* ','  */
+  YYSYMBOL_77_ = 77,                       /* '{'  */
+  YYSYMBOL_78_ = 78,                       /* '}'  */
+  YYSYMBOL_79_ = 79,                       /* '$'  */
+  YYSYMBOL_80_ = 80,                       /* '['  */
+  YYSYMBOL_81_ = 81,                       /* ']'  */
+  YYSYMBOL_YYACCEPT = 82,                  /* $accept  */
+  YYSYMBOL_all = 83,                       /* all  */
+  YYSYMBOL_program = 84,                   /* program  */
+  YYSYMBOL_possible_semi_colon = 85,       /* possible_semi_colon  */
+  YYSYMBOL_inheritance = 86,               /* inheritance  */
+  YYSYMBOL_real = 87,                      /* real  */
+  YYSYMBOL_number = 88,                    /* number  */
+  YYSYMBOL_optional_star = 89,             /* optional_star  */
+  YYSYMBOL_block_or_semi = 90,             /* block_or_semi  */
+  YYSYMBOL_identifier = 91,                /* identifier  */
+  YYSYMBOL_function = 92,                  /* function  */
+  YYSYMBOL_93_1 = 93,                      /* $@1  */
+  YYSYMBOL_94_2 = 94,                      /* @2  */
+  YYSYMBOL_def = 95,                       /* def  */
+  YYSYMBOL_modifier_change = 96,           /* modifier_change  */
+  YYSYMBOL_member_name = 97,               /* member_name  */
+  YYSYMBOL_member_name_list = 98,          /* member_name_list  */
+  YYSYMBOL_member_list = 99,               /* member_list  */
+  YYSYMBOL_100_3 = 100,                    /* $@3  */
+  YYSYMBOL_type_decl = 101,                /* type_decl  */
+  YYSYMBOL_102_4 = 102,                    /* @4  */
+  YYSYMBOL_new_local_name = 103,           /* new_local_name  */
+  YYSYMBOL_atomic_type = 104,              /* atomic_type  */
+  YYSYMBOL_opt_atomic_type = 105,          /* opt_atomic_type  */
+  YYSYMBOL_basic_type = 106,               /* basic_type  */
+  YYSYMBOL_arg_type = 107,                 /* arg_type  */
+  YYSYMBOL_optional_default_arg_value = 108, /* optional_default_arg_value  */
+  YYSYMBOL_new_arg = 109,                  /* new_arg  */
+  YYSYMBOL_argument = 110,                 /* argument  */
+  YYSYMBOL_argument_list = 111,            /* argument_list  */
+  YYSYMBOL_type_modifier_list = 112,       /* type_modifier_list  */
+  YYSYMBOL_type = 113,                     /* type  */
+  YYSYMBOL_cast = 114,                     /* cast  */
+  YYSYMBOL_opt_basic_type = 115,           /* opt_basic_type  */
+  YYSYMBOL_name_list = 116,                /* name_list  */
+  YYSYMBOL_new_name = 117,                 /* new_name  */
+  YYSYMBOL_block = 118,                    /* block  */
+  YYSYMBOL_119_5 = 119,                    /* @5  */
+  YYSYMBOL_decl_block = 120,               /* decl_block  */
+  YYSYMBOL_local_declarations = 121,       /* local_declarations  */
+  YYSYMBOL_122_6 = 122,                    /* $@6  */
+  YYSYMBOL_new_local_def = 123,            /* new_local_def  */
+  YYSYMBOL_single_new_local_def = 124,     /* single_new_local_def  */
+  YYSYMBOL_single_new_local_def_with_init = 125, /* single_new_local_def_with_init  */
+  YYSYMBOL_local_name_list = 126,          /* local_name_list  */
+  YYSYMBOL_local_declaration_statement = 127, /* local_declaration_statement  */
+  YYSYMBOL_128_7 = 128,                    /* $@7  */
+  YYSYMBOL_block_statements = 129,         /* block_statements  */
+  YYSYMBOL_statement = 130,                /* statement  */
+  YYSYMBOL_while = 131,                    /* while  */
+  YYSYMBOL_132_8 = 132,                    /* $@8  */
+  YYSYMBOL_do = 133,                       /* do  */
+  YYSYMBOL_134_9 = 134,                    /* $@9  */
+  YYSYMBOL_for = 135,                      /* for  */
+  YYSYMBOL_136_10 = 136,                   /* $@10  */
+  YYSYMBOL_foreach_var = 137,              /* foreach_var  */
+  YYSYMBOL_foreach_vars = 138,             /* foreach_vars  */
+  YYSYMBOL_foreach = 139,                  /* foreach  */
+  YYSYMBOL_140_11 = 140,                   /* $@11  */
+  YYSYMBOL_for_expr = 141,                 /* for_expr  */
+  YYSYMBOL_first_for_expr = 142,           /* first_for_expr  */
+  YYSYMBOL_switch = 143,                   /* switch  */
+  YYSYMBOL_144_12 = 144,                   /* $@12  */
+  YYSYMBOL_switch_block = 145,             /* switch_block  */
+  YYSYMBOL_case = 146,                     /* case  */
+  YYSYMBOL_case_label = 147,               /* case_label  */
+  YYSYMBOL_constant = 148,                 /* constant  */
+  YYSYMBOL_comma_expr = 149,               /* comma_expr  */
+  YYSYMBOL_ref = 150,                      /* ref  */
+  YYSYMBOL_expr0 = 151,                    /* expr0  */
+  YYSYMBOL_return = 152,                   /* return  */
+  YYSYMBOL_expr_list = 153,                /* expr_list  */
+  YYSYMBOL_expr_list_node = 154,           /* expr_list_node  */
+  YYSYMBOL_expr_list2 = 155,               /* expr_list2  */
+  YYSYMBOL_expr_list3 = 156,               /* expr_list3  */
+  YYSYMBOL_expr_list4 = 157,               /* expr_list4  */
+  YYSYMBOL_assoc_pair = 158,               /* assoc_pair  */
+  YYSYMBOL_lvalue = 159,                   /* lvalue  */
+  YYSYMBOL_l_new_function_open = 160,      /* l_new_function_open  */
+  YYSYMBOL_expr4 = 161,                    /* expr4  */
+  YYSYMBOL_162_13 = 162,                   /* @13  */
+  YYSYMBOL_163_14 = 163,                   /* @14  */
+  YYSYMBOL_expr_or_block = 164,            /* expr_or_block  */
+  YYSYMBOL_catch = 165,                    /* catch  */
+  YYSYMBOL_166_15 = 166,                   /* @15  */
+  YYSYMBOL_tree = 167,                     /* tree  */
+  YYSYMBOL_sscanf = 168,                   /* sscanf  */
+  YYSYMBOL_parse_command = 169,            /* parse_command  */
+  YYSYMBOL_time_expression = 170,          /* time_expression  */
+  YYSYMBOL_171_16 = 171,                   /* @16  */
+  YYSYMBOL_lvalue_list = 172,              /* lvalue_list  */
+  YYSYMBOL_string = 173,                   /* string  */
+  YYSYMBOL_string_con1 = 174,              /* string_con1  */
+  YYSYMBOL_string_con2 = 175,              /* string_con2  */
+  YYSYMBOL_template_literal = 176,         /* template_literal  */
+  YYSYMBOL_template_parts = 177,           /* template_parts  */
+  YYSYMBOL_string_like = 178,              /* string_like  */
+  YYSYMBOL_class_init = 179,               /* class_init  */
+  YYSYMBOL_opt_class_init = 180,           /* opt_class_init  */
+  YYSYMBOL_function_call = 181,            /* function_call  */
+  YYSYMBOL_182_17 = 182,                   /* @17  */
+  YYSYMBOL_183_18 = 183,                   /* @18  */
+  YYSYMBOL_184_19 = 184,                   /* @19  */
+  YYSYMBOL_185_20 = 185,                   /* @20  */
+  YYSYMBOL_186_21 = 186,                   /* @21  */
+  YYSYMBOL_187_22 = 187,                   /* @22  */
+  YYSYMBOL_188_23 = 188,                   /* @23  */
+  YYSYMBOL_efun_override = 189,            /* efun_override  */
+  YYSYMBOL_function_name = 190,            /* function_name  */
+  YYSYMBOL_cond = 191,                     /* cond  */
+  YYSYMBOL_optional_else_part = 192        /* optional_else_part  */
 };
 typedef enum yysymbol_kind_t yysymbol_kind_t;
 
@@ -629,19 +635,19 @@ union yyalloc
 /* YYFINAL -- State number of the termination state.  */
 #define YYFINAL  3
 /* YYLAST -- Last index in YYTABLE.  */
-#define YYLAST   1756
+#define YYLAST   1839
 
 /* YYNTOKENS -- Number of terminals.  */
-#define YYNTOKENS  79
+#define YYNTOKENS  82
 /* YYNNTS -- Number of nonterminals.  */
-#define YYNNTS  108
+#define YYNNTS  111
 /* YYNRULES -- Number of rules.  */
-#define YYNRULES  271
+#define YYNRULES  278
 /* YYNSTATES -- Number of states.  */
-#define YYNSTATES  513
+#define YYNSTATES  524
 
 /* YYMAXUTOK -- Last valid token kind.  */
-#define YYMAXUTOK   312
+#define YYMAXUTOK   315
 
 
 /* YYTRANSLATE(TOKEN-NUM) -- Symbol number corresponding to TOKEN-NUM
@@ -658,16 +664,16 @@ static const yytype_int8 yytranslate[] =
        0,     2,     2,     2,     2,     2,     2,     2,     2,     2,
        2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
        2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
-       2,     2,     2,     2,     2,     2,    76,    66,    59,     2,
-      70,    71,    65,    63,    73,    64,     2,    67,     2,     2,
-       2,     2,     2,     2,     2,     2,     2,     2,    72,    69,
-      62,     2,     2,    56,     2,     2,     2,     2,     2,     2,
+       2,     2,     2,     2,     2,     2,    79,    69,    62,     2,
+      73,    74,    68,    66,    76,    67,     2,    70,     2,     2,
+       2,     2,     2,     2,     2,     2,     2,     2,    75,    72,
+      65,     2,     2,    59,     2,     2,     2,     2,     2,     2,
        2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
        2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
-       2,    77,     2,    78,    58,     2,     2,     2,     2,     2,
+       2,    80,     2,    81,    61,     2,     2,     2,     2,     2,
        2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
        2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
-       2,     2,     2,    74,    57,    75,    68,     2,     2,     2,
+       2,     2,     2,    77,    60,    78,    71,     2,     2,     2,
        2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
        2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
        2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
@@ -686,41 +692,41 @@ static const yytype_int8 yytranslate[] =
       25,    26,    27,    28,    29,    30,    31,    32,    33,    34,
       35,    36,    37,    38,    39,    40,    41,    42,    43,    44,
       45,    46,    47,    48,    49,    50,    51,    52,    53,    54,
-      55,    60,    61
+      55,    56,    57,    58,    63,    64
 };
 
 #if YYDEBUG
 /* YYRLINE[YYN] -- Source line where rule number YYN was defined.  */
 static const yytype_int16 yyrline[] =
 {
-       0,   219,   219,   223,   224,   227,   229,   233,   237,   241,
-     245,   246,   250,   257,   258,   262,   263,   267,   268,   267,
-     273,   274,   280,   281,   282,   286,   303,   316,   317,   320,
-     322,   322,   327,   327,   332,   333,   343,   344,   353,   361,
-     362,   366,   367,   371,   372,   376,   377,   398,   404,   412,
-     425,   429,   430,   448,   459,   473,   476,   493,   501,   508,
-     510,   516,   517,   521,   546,   602,   601,   610,   610,   610,
-     614,   619,   618,   637,   648,   682,   693,   725,   730,   741,
-     740,   755,   759,   766,   773,   781,   793,   794,   795,   796,
-     797,   798,   803,   807,   829,   842,   841,   855,   854,   868,
-     867,   892,   913,   923,   940,   945,   956,   955,   975,   978,
-     982,   987,   996,   995,  1034,  1040,  1047,  1053,  1060,  1074,
-    1088,  1101,  1117,  1131,  1146,  1150,  1154,  1158,  1162,  1166,
-    1174,  1178,  1182,  1186,  1190,  1194,  1198,  1202,  1206,  1210,
-    1214,  1218,  1222,  1229,  1233,  1240,  1244,  1271,  1311,  1316,
-    1340,  1346,  1352,  1358,  1383,  1387,  1410,  1432,  1446,  1490,
-    1527,  1531,  1535,  1705,  1799,  1879,  1883,  1978,  1999,  2020,
-    2042,  2051,  2062,  2086,  2108,  2129,  2130,  2131,  2132,  2133,
-    2134,  2138,  2144,  2165,  2168,  2172,  2179,  2183,  2190,  2195,
-    2208,  2212,  2216,  2223,  2233,  2251,  2258,  2374,  2375,  2382,
-    2383,  2456,  2474,  2479,  2478,  2508,  2532,  2556,  2567,  2571,
-    2578,  2585,  2589,  2593,  2638,  2694,  2695,  2699,  2700,  2702,
-    2701,  2758,  2796,  2891,  2914,  2923,  2935,  2939,  2947,  2946,
-    2959,  2966,  2976,  2985,  2996,  2995,  3009,  3014,  3028,  3036,
-    3037,  3041,  3048,  3049,  3056,  3067,  3070,  3079,  3078,  3092,
-    3091,  3122,  3157,  3176,  3175,  3311,  3310,  3379,  3378,  3430,
-    3429,  3481,  3480,  3511,  3531,  3547,  3548,  3562,  3577,  3592,
-    3626,  3630
+       0,   223,   223,   227,   228,   231,   233,   237,   241,   245,
+     249,   250,   254,   261,   262,   266,   267,   271,   272,   271,
+     277,   278,   284,   285,   286,   290,   307,   320,   321,   324,
+     326,   326,   331,   331,   336,   337,   347,   348,   357,   365,
+     366,   370,   371,   375,   376,   380,   381,   402,   408,   416,
+     429,   433,   434,   452,   463,   477,   480,   497,   505,   512,
+     514,   520,   521,   525,   550,   606,   605,   614,   614,   614,
+     618,   623,   622,   641,   652,   686,   697,   729,   734,   745,
+     744,   759,   763,   770,   777,   785,   797,   798,   799,   800,
+     801,   802,   807,   811,   833,   846,   845,   859,   858,   872,
+     871,   896,   917,   927,   944,   949,   960,   959,   979,   982,
+     986,   991,  1000,   999,  1038,  1044,  1051,  1057,  1064,  1078,
+    1092,  1105,  1121,  1135,  1150,  1154,  1158,  1162,  1166,  1170,
+    1178,  1182,  1186,  1190,  1194,  1198,  1202,  1206,  1210,  1214,
+    1218,  1222,  1226,  1233,  1237,  1244,  1248,  1275,  1315,  1320,
+    1344,  1350,  1356,  1362,  1387,  1391,  1414,  1436,  1450,  1494,
+    1531,  1535,  1539,  1709,  1803,  1883,  1887,  1982,  2003,  2024,
+    2046,  2055,  2066,  2090,  2112,  2133,  2134,  2135,  2136,  2137,
+    2138,  2142,  2148,  2169,  2172,  2176,  2183,  2187,  2194,  2199,
+    2212,  2216,  2220,  2227,  2237,  2255,  2262,  2378,  2379,  2386,
+    2387,  2460,  2478,  2483,  2482,  2512,  2536,  2560,  2571,  2575,
+    2582,  2589,  2593,  2597,  2642,  2698,  2699,  2703,  2704,  2706,
+    2705,  2762,  2800,  2895,  2918,  2927,  2939,  2943,  2951,  2950,
+    2963,  2970,  2980,  2989,  3000,  2999,  3013,  3018,  3032,  3040,
+    3041,  3045,  3052,  3053,  3060,  3072,  3077,  3089,  3090,  3091,
+    3095,  3102,  3113,  3116,  3125,  3124,  3138,  3137,  3168,  3203,
+    3222,  3221,  3357,  3356,  3425,  3424,  3476,  3475,  3527,  3526,
+    3557,  3577,  3593,  3594,  3608,  3623,  3638,  3672,  3676
 };
 #endif
 
@@ -747,10 +753,11 @@ yysymbol_name (yysymbol_kind_t yysymbol)
   "L_COLON_COLON", "L_ARRAY_OPEN", "L_MAPPING_OPEN", "L_FUNCTION_OPEN",
   "L_NEW_FUNCTION_OPEN", "L_SSCANF", "L_CATCH", "L_ARRAY", "L_REF",
   "L_PARSE_COMMAND", "L_TIME_EXPRESSION", "L_CLASS", "L_NEW",
-  "L_PARAMETER", "L_TREE", "L_PREPROCESSOR_COMMAND", "LOWER_THAN_ELSE",
-  "'?'", "'|'", "'^'", "'&'", "L_EQ", "L_NE", "'<'", "'+'", "'-'", "'*'",
-  "'%'", "'/'", "'~'", "';'", "'('", "')'", "':'", "','", "'{'", "'}'",
-  "'$'", "'['", "']'", "$accept", "all", "program", "possible_semi_colon",
+  "L_PARAMETER", "L_TREE", "L_TEMPLATE_HEAD", "L_TEMPLATE_MIDDLE",
+  "L_TEMPLATE_TAIL", "L_PREPROCESSOR_COMMAND", "LOWER_THAN_ELSE", "'?'",
+  "'|'", "'^'", "'&'", "L_EQ", "L_NE", "'<'", "'+'", "'-'", "'*'", "'%'",
+  "'/'", "'~'", "';'", "'('", "')'", "':'", "','", "'{'", "'}'", "'$'",
+  "'['", "']'", "$accept", "all", "program", "possible_semi_colon",
   "inheritance", "real", "number", "optional_star", "block_or_semi",
   "identifier", "function", "$@1", "@2", "def", "modifier_change",
   "member_name", "member_name_list", "member_list", "$@3", "type_decl",
@@ -768,7 +775,8 @@ yysymbol_name (yysymbol_kind_t yysymbol)
   "expr_list2", "expr_list3", "expr_list4", "assoc_pair", "lvalue",
   "l_new_function_open", "expr4", "@13", "@14", "expr_or_block", "catch",
   "@15", "tree", "sscanf", "parse_command", "time_expression", "@16",
-  "lvalue_list", "string", "string_con1", "string_con2", "class_init",
+  "lvalue_list", "string", "string_con1", "string_con2",
+  "template_literal", "template_parts", "string_like", "class_init",
   "opt_class_init", "function_call", "@17", "@18", "@19", "@20", "@21",
   "@22", "@23", "efun_override", "function_name", "cond",
   "optional_else_part", YY_NULLPTR
@@ -777,12 +785,12 @@ yysymbol_name (yysymbol_kind_t yysymbol)
 }
 #endif
 
-#define YYPACT_NINF (-388)
+#define YYPACT_NINF (-435)
 
 #define yypact_value_is_default(Yyn) \
   ((Yyn) == YYPACT_NINF)
 
-#define YYTABLE_NINF (-266)
+#define YYTABLE_NINF (-273)
 
 #define yytable_value_is_error(Yyn) \
   0
@@ -791,58 +799,59 @@ yysymbol_name (yysymbol_kind_t yysymbol)
    STATE-NUM.  */
 static const yytype_int16 yypact[] =
 {
-    -388,    34,    51,  -388,    30,  -388,  -388,    86,  -388,  -388,
-     162,   101,  -388,  -388,  -388,  -388,    24,   247,  -388,   146,
-     165,  -388,  -388,  -388,   297,   147,   133,  -388,    24,    -4,
-     227,   167,   175,   178,  -388,  -388,  -388,    25,  -388,   101,
-     -14,    24,  -388,  -388,  -388,  1565,   202,   297,  -388,  -388,
-    -388,  -388,   283,  -388,  -388,   289,    88,    99,   307,   915,
-     915,  1565,   297,  1045,   517,  1565,  -388,   248,  -388,  -388,
-     294,  -388,   306,  -388,   -20,  1565,  1565,   234,   316,  -388,
-    -388,   339,  1565,   915,  1457,   212,   266,   308,  -388,  -388,
-    -388,  -388,  -388,  -388,   227,  -388,   325,   333,   251,   394,
-      16,  1565,   297,   344,  -388,    35,  1121,  -388,     3,  -388,
-    -388,  -388,  1383,   214,  -388,   342,  1161,   338,   345,  -388,
-     298,  1457,   325,  1565,   144,  1565,   144,   367,  1565,  -388,
-    -388,  -388,  -388,   140,   366,  1565,   101,   107,  -388,   297,
-    -388,  -388,  1565,  1565,  1565,  1565,  1565,  1565,  1565,  1565,
-    1565,  1565,  1565,  1565,  1565,  1565,  1565,  1565,  1565,  1565,
-    -388,  -388,  1565,   349,  1565,   297,   297,  1195,  -388,  -388,
-    -388,  -388,  -388,   379,   101,  -388,   358,     2,  -388,  -388,
-    1457,  -388,   251,  1269,  -388,  -388,  -388,   360,   969,  1565,
-     363,   593,   365,  1565,   482,  1565,  -388,  -388,   558,  -388,
-     372,  1269,   160,   669,  -388,  -388,   190,   368,  -388,  1565,
-    -388,  1619,  1605,  1531,   250,   250,   108,  1235,   589,   741,
-     932,  1656,  1656,   108,    -3,    -3,  -388,  -388,  -388,  1457,
-    -388,   311,   373,  -388,  1565,    72,  1269,  1269,  -388,   385,
-    -388,  -388,    39,   101,   377,   383,  -388,  -388,  1457,  -388,
-    -388,  -388,  1457,  1565,   194,  1565,  -388,  -388,   386,  -388,
-       4,   388,   389,   390,  -388,   403,   404,   369,   387,  1343,
-    -388,  -388,  -388,  -388,   669,   400,   669,  -388,  -388,  -388,
-    -388,  -388,   153,  -388,  -388,   407,  -388,   219,  1565,   408,
-    1565,  -388,    74,   357,   417,   420,   424,   406,    19,  -388,
-     297,   429,   435,   432,  -388,  1010,  -388,  1086,   222,   252,
-    -388,   669,  1565,  1565,  1565,   821,   895,    70,  -388,  -388,
-    -388,   189,   101,  -388,  -388,  -388,  -388,  -388,  -388,  1457,
-    -388,  1269,   441,  -388,  1565,  -388,    66,  -388,  -388,  -388,
-     465,  -388,  -388,  -388,  -388,  -388,  -388,   101,  -388,  -388,
-     915,   437,  1565,  -388,   297,  -388,  -388,   253,   264,   276,
-     484,   101,   497,  -388,  -388,   444,   442,  -388,  -388,  -388,
-     443,   492,  -388,   385,   457,   445,  1269,   460,  1565,  -388,
-     104,   115,  -388,  1269,  1565,  -388,   459,  -388,  1010,   461,
-    -388,   821,  -388,  -388,   464,   385,  1565,  1417,    70,  1565,
-     522,   101,  -388,   479,  -388,   116,  -388,  -388,   480,   340,
-    -388,   481,  1565,   514,   489,   821,  1565,  -388,  1457,   485,
-    -388,  1309,  1565,  -388,  -388,  -388,  -388,   496,  -388,  1457,
-     821,  -388,  -388,  -388,   279,  1491,  -388,  1457,  -388,  -388,
-     159,   502,   507,   821,   137,   508,  -388,   745,  -388,  -388,
-    -388,  -388,   549,   183,   575,   578,   183,     5,  1630,   520,
-    -388,   101,   745,   509,   745,   821,  -388,   516,  -388,  -388,
-     405,    64,  -388,    67,    67,    67,    67,    67,    67,    67,
-      67,    67,    67,    67,    67,    67,    67,   521,  -388,  -388,
-    -388,  -388,  -388,  -388,  -388,   519,    67,   267,   267,   324,
-     665,   817,  1638,  1689,  1689,   324,   204,   204,  -388,  -388,
-    -388,  -388,  -388
+    -435,    36,   129,  -435,    51,  -435,  -435,    -3,  -435,  -435,
+      53,    74,  -435,  -435,  -435,  -435,    12,   271,  -435,   112,
+     123,  -435,  -435,  -435,   334,   109,   122,  -435,    12,   -26,
+     206,   144,   158,   161,  -435,  -435,  -435,    15,  -435,    74,
+     -17,    12,  -435,  -435,  -435,  1528,   133,   334,  -435,  -435,
+    -435,  -435,   216,  -435,  -435,   211,     0,   117,   235,   287,
+     287,  1528,   334,  1081,   574,  1528,  -435,   184,  -435,  -435,
+     215,  -435,   238,  -435,    -2,  1528,  1528,  1528,   894,   252,
+    -435,  -435,   259,  1528,   287,  1656,   241,   283,    43,  -435,
+    -435,  -435,  -435,  -435,  -435,   206,  -435,    40,  -435,   262,
+     288,   125,   228,    14,  1528,   334,   312,  -435,   204,  1135,
+    -435,    16,  -435,  -435,  -435,  1492,   266,  -435,   169,  1594,
+     275,   243,  -435,   294,  1656,   262,  1528,   155,  1528,   155,
+     353,  1528,  -435,  -435,  1309,  -435,  -435,   152,   338,  1528,
+      74,   172,  -435,   334,  -435,  -435,  1528,  1528,  1528,  1528,
+    1528,  1528,  1528,  1528,  1528,  1528,  1528,  1528,  1528,  1528,
+    1528,  1528,  1528,  1528,  -435,  -435,  1528,   217,  1528,   334,
+     334,  1189,  -435,  -435,  -435,  -435,  -435,  -435,  -435,   357,
+      74,  -435,   342,     5,  -435,  -435,  1656,  -435,   125,  1266,
+    -435,  -435,  -435,   344,  1002,  1528,   349,   628,   355,  1528,
+     457,  1528,  -435,  -435,   536,  -435,   369,  1266,   202,   682,
+    1528,  -435,  -435,  -435,  -435,   210,   363,  -435,  1528,  -435,
+    1721,  1691,  1667,   248,   248,   306,  1632,   332,   859,   200,
+     365,   365,   306,   191,   191,  -435,  -435,  -435,  1656,  -435,
+     304,   367,  -435,  1528,    21,  1266,  1266,  -435,   379,  -435,
+    -435,   165,    74,   364,   370,  -435,  -435,  1656,  -435,  -435,
+    -435,  1656,  1528,   213,  1528,  -435,  -435,   371,  -435,    29,
+     373,   374,   376,  -435,   377,   380,   382,   390,  1343,  -435,
+    -435,  -435,  -435,   682,   399,   682,  -435,  -435,  -435,  -435,
+    -435,   167,  -435,  -435,  1309,   405,  -435,   218,  1528,   406,
+    1528,  -435,   119,   416,   409,   410,   411,   404,    10,  -435,
+     334,   412,   414,   425,  -435,  1043,  -435,  1569,   225,   229,
+    -435,   682,  1528,  1528,  1528,   840,   948,   176,  -435,  -435,
+    -435,   168,    74,  -435,  -435,  -435,  -435,  -435,  -435,  -435,
+    1656,  -435,  1266,   495,  -435,  1528,  -435,   -31,  -435,  -435,
+    -435,   471,  -435,  -435,  -435,  -435,  -435,  -435,    74,  -435,
+    -435,   287,   440,  1528,  -435,   334,  -435,  -435,   233,   236,
+     246,   500,    74,   516,  -435,  -435,   458,   455,  -435,  -435,
+    -435,   456,   509,  -435,   379,   469,   484,  1266,   483,  1528,
+    -435,    -9,    62,  -435,  1266,  1528,  -435,   482,  -435,  1043,
+     486,  -435,   840,  -435,  -435,   490,   379,  1528,  1397,   176,
+    1528,   546,    74,  -435,   491,  -435,    78,  -435,  -435,   493,
+     314,  -435,   496,  1528,   542,   492,   840,  1528,  -435,  1656,
+     499,  -435,  1230,  1528,  -435,  -435,  -435,  -435,   498,  -435,
+    1656,   840,  -435,  -435,  -435,   257,  1451,  -435,  1656,  -435,
+    -435,   199,   501,   507,   840,   160,   512,  -435,   761,  -435,
+    -435,  -435,  -435,   584,   163,   585,   586,   163,    52,  1745,
+     525,  -435,    74,   761,   514,   761,   840,  -435,   518,  -435,
+    -435,   757,    73,  -435,   121,   121,   121,   121,   121,   121,
+     121,   121,   121,   121,   121,   121,   121,   121,   535,  -435,
+    -435,  -435,  -435,  -435,  -435,  -435,   545,   121,   442,   442,
+     424,   345,   913,   967,   591,   591,   424,   203,   203,  -435,
+    -435,  -435,  -435,  -435
 };
 
 /* YYDEFACT[STATE-NUM] -- Default reduction number in state STATE-NUM.
@@ -857,83 +866,86 @@ static const yytype_int16 yydefact[] =
        0,     0,     7,   243,    32,     0,     0,     0,    62,   240,
      241,    29,     0,     9,     8,   219,   200,   201,     0,     0,
        0,     0,     0,     0,     0,     0,   197,     0,   228,   145,
-       0,   234,     0,   202,     0,     0,     0,     0,     0,   180,
-     179,     0,     0,     0,    64,     0,     0,   175,   217,   218,
-     176,   177,   178,   215,   238,   199,     0,     0,    40,    63,
-      40,     0,     0,     0,   253,     0,     0,   168,   196,   169,
-     170,   266,   186,     0,   188,   184,     0,     0,   191,   193,
-       0,   143,   198,     0,     0,     0,     0,   249,     0,    65,
-     230,   172,   171,    36,     0,     0,    10,     0,   203,     0,
-     167,   146,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,   234,     0,   202,     0,     0,     0,     0,     0,     0,
+     180,   179,     0,     0,     0,    64,     0,     0,   175,   217,
+     218,   176,   177,   178,   247,   238,   248,   215,   199,     0,
+       0,    40,    63,    40,     0,     0,     0,   260,     0,     0,
+     168,   196,   169,   170,   273,   186,     0,   188,   184,     0,
+       0,   191,   193,     0,   143,   198,     0,     0,     0,     0,
+     256,     0,    65,   230,     0,   172,   171,    36,     0,     0,
+      10,     0,   203,     0,   167,   146,     0,     0,     0,     0,
        0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
-     173,   174,     0,     0,     0,     0,     0,     0,   247,   255,
-      35,    34,    49,    43,    10,    53,     0,    51,    33,    30,
-     148,   267,    40,     0,   264,   263,   187,     0,     0,     0,
-       0,     0,     0,     0,     0,     0,   226,   229,     0,   235,
-       0,     0,     0,     0,    37,    38,     0,     0,   216,     0,
-     268,   152,   151,   150,   160,   161,   158,     0,   153,   154,
-     155,   156,   157,   159,   162,   163,   164,   165,   166,   147,
-     221,     0,   205,   206,     0,     0,     0,     0,    44,    47,
-      18,    52,    40,    10,     0,     0,   225,   189,   195,   224,
-     194,   223,   144,     0,     0,     0,   245,   245,     0,   231,
-       0,     0,     0,     0,    97,     0,     0,     0,     0,     0,
-      92,    79,    67,    91,     0,     0,     0,    87,    88,    68,
-      69,    89,     0,    90,    86,     0,    58,     0,     0,     0,
-       0,   259,     0,     0,   214,     0,     0,    45,     0,    54,
-       0,    27,     0,     0,   254,   236,   227,     0,     0,     0,
-     250,     0,     0,     0,     0,     0,     0,    40,    93,    94,
-     181,     0,    10,    83,    66,    82,    85,   261,   204,   149,
-     222,     0,     0,   213,     0,   211,     0,   257,   248,   256,
-       0,    48,    14,    13,    19,    12,    26,    10,    31,   220,
-       0,     0,     0,   251,     0,   252,    84,     0,     0,     0,
-       0,    10,     0,   111,   110,     0,   109,   101,   103,   102,
-     104,     0,   182,     0,    77,     0,     0,     0,     0,   212,
-       0,     0,   207,     0,     0,    28,   236,   232,   236,     0,
-     246,     0,   112,    95,     0,     0,     0,     0,    40,     0,
-      73,    10,    80,     0,   260,     0,   208,   210,     0,     0,
-     237,     0,     0,   270,     0,     0,     0,    75,    76,     0,
-     105,     0,     0,    78,   262,   209,   258,     0,   233,   244,
-       0,   269,    70,    96,     0,     0,   106,    74,    46,   271,
-      40,     0,     0,     0,     0,     0,    71,     0,    98,    99,
-     107,   139,     0,     0,     0,     0,     0,     0,   122,   123,
-     121,    10,     0,     0,     0,     0,   141,     0,   140,   142,
-       0,     0,   117,     0,     0,     0,     0,     0,     0,     0,
-       0,     0,     0,     0,     0,     0,     0,     0,   115,   113,
-     114,   100,   120,   138,   119,     0,     0,   131,   132,   129,
-     124,   125,   126,   127,   128,   130,   133,   134,   135,   136,
-     137,    72,   118
+       0,     0,     0,     0,   173,   174,     0,     0,     0,     0,
+       0,     0,   249,   250,   254,   262,    35,    34,    49,    43,
+      10,    53,     0,    51,    33,    30,   148,   274,    40,     0,
+     271,   270,   187,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,   226,   229,     0,   235,     0,     0,     0,     0,
+       0,   245,   244,    37,    38,     0,     0,   216,     0,   275,
+     152,   151,   150,   160,   161,   158,     0,   153,   154,   155,
+     156,   157,   159,   162,   163,   164,   165,   166,   147,   221,
+       0,   205,   206,     0,     0,     0,     0,    44,    47,    18,
+      52,    40,    10,     0,     0,   225,   189,   195,   224,   194,
+     223,   144,     0,     0,     0,   252,   252,     0,   231,     0,
+       0,     0,     0,    97,     0,     0,     0,     0,     0,    92,
+      79,    67,    91,     0,     0,     0,    87,    88,    68,    69,
+      89,     0,    90,    86,     0,     0,    58,     0,     0,     0,
+       0,   266,     0,     0,   214,     0,     0,    45,     0,    54,
+       0,    27,     0,     0,   261,   236,   227,     0,     0,     0,
+     257,     0,     0,     0,     0,     0,     0,    40,    93,    94,
+     181,     0,    10,    83,    66,    82,    85,   246,   268,   204,
+     149,   222,     0,     0,   213,     0,   211,     0,   264,   255,
+     263,     0,    48,    14,    13,    19,    12,    26,    10,    31,
+     220,     0,     0,     0,   258,     0,   259,    84,     0,     0,
+       0,     0,    10,     0,   111,   110,     0,   109,   101,   103,
+     102,   104,     0,   182,     0,    77,     0,     0,     0,     0,
+     212,     0,     0,   207,     0,     0,    28,   236,   232,   236,
+       0,   253,     0,   112,    95,     0,     0,     0,     0,    40,
+       0,    73,    10,    80,     0,   267,     0,   208,   210,     0,
+       0,   237,     0,     0,   277,     0,     0,     0,    75,    76,
+       0,   105,     0,     0,    78,   269,   209,   265,     0,   233,
+     251,     0,   276,    70,    96,     0,     0,   106,    74,    46,
+     278,    40,     0,     0,     0,     0,     0,    71,     0,    98,
+      99,   107,   139,     0,     0,     0,     0,     0,     0,   122,
+     123,   121,    10,     0,     0,     0,     0,   141,     0,   140,
+     142,     0,     0,   117,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,   115,
+     113,   114,   100,   120,   138,   119,     0,     0,   131,   132,
+     129,   124,   125,   126,   127,   128,   130,   133,   134,   135,
+     136,   137,    72,   118
 };
 
 /* YYPGOTO[NTERM-NUM].  */
 static const yytype_int16 yypgoto[] =
 {
-    -388,  -388,  -388,  -388,  -388,  -388,  -388,    -7,  -388,    -6,
-    -388,  -388,  -388,  -388,  -388,  -388,   239,  -388,  -388,  -388,
-    -388,  -231,  -388,  -388,    -8,  -301,  -388,   347,   410,  -388,
-     596,  -388,  -388,  -388,   570,  -388,   -71,  -388,  -388,  -388,
-    -388,  -388,   295,  -388,  -387,  -388,  -388,  -120,  -245,  -388,
-    -388,  -388,  -388,  -388,  -388,   228,  -388,  -388,  -388,  -345,
-    -388,  -388,  -388,  -111,   170,  -272,  1253,    -5,   439,   -40,
-    -388,  -155,  -169,   463,  -388,  -388,   438,   -53,  -388,   -50,
-    -388,  -388,   504,  -388,  -388,  -388,  -388,  -388,  -388,  -388,
-     -31,  -388,   -15,   -16,  -388,   371,  -388,  -388,  -388,  -388,
-    -388,  -388,  -388,  -388,   574,  -388,  -388,  -388
+    -435,  -435,  -435,  -435,  -435,  -435,  -435,    -1,  -435,    27,
+    -435,  -435,  -435,  -435,  -435,  -435,   253,  -435,  -435,  -435,
+    -435,  -234,  -435,  -435,    -8,  -309,  -435,   384,   436,  -435,
+     626,  -435,  -435,  -435,   603,  -435,   -66,  -435,  -435,  -435,
+    -435,  -435,   317,  -435,  -389,  -435,  -435,  -134,  -265,  -435,
+    -435,  -435,  -435,  -435,  -435,   237,  -435,  -435,  -435,  -230,
+    -435,  -435,  -435,  -139,   193,  -434,  1332,   -41,   470,   -42,
+    -435,  -180,  -178,   494,  -435,  -435,   453,   -55,  -435,   -53,
+    -435,  -435,   522,  -435,  -435,  -435,  -435,  -435,  -435,  -435,
+     -44,   555,   -15,   -16,   557,   372,  -435,  -435,   397,  -435,
+    -435,  -435,  -435,  -435,  -435,  -435,  -435,   599,  -435,  -435,
+    -435
 };
 
 /* YYDEFGOTO[NTERM-NUM].  */
 static const yytype_int16 yydefgoto[] =
 {
-       0,     1,     2,    14,     5,    79,    80,   373,   344,    81,
-       6,    46,   298,     7,     8,   301,   302,   100,   243,     9,
-      51,   172,    19,    20,   173,   174,   341,   175,   176,   177,
-      10,    11,    82,    22,    25,    26,   272,   203,   273,   440,
-     461,   374,   369,   363,   375,   274,   322,   275,   276,   277,
-     415,   278,   315,   279,   465,   370,   371,   280,   443,   364,
-     365,   281,   414,   463,   464,   457,   458,   282,    83,   121,
-     283,   113,   114,   115,   117,   118,   119,    85,    86,    87,
-     209,   103,   197,    88,   124,    89,    90,    91,    92,   126,
-     351,    93,   459,    94,   390,   308,    95,   236,   201,   183,
-     237,   383,   331,   376,    96,    97,   284,   431
+       0,     1,     2,    14,     5,    80,    81,   384,   355,    82,
+       6,    46,   308,     7,     8,   311,   312,   103,   252,     9,
+      51,   178,    19,    20,   179,   180,   352,   181,   182,   183,
+      10,    11,    83,    22,    25,    26,   281,   209,   282,   451,
+     472,   385,   380,   374,   386,   283,   332,   284,   285,   286,
+     426,   287,   325,   288,   476,   381,   382,   289,   454,   375,
+     376,   290,   425,   474,   475,   468,   469,   291,    84,   124,
+     292,   116,   117,   118,   120,   121,   122,    86,    87,    88,
+     218,   106,   203,    89,   127,    90,    91,    92,    93,   129,
+     362,    94,   470,    95,    96,   212,    97,   401,   318,    98,
+     245,   207,   189,   246,   394,   342,   387,    99,   100,   293,
+     442
 };
 
 /* YYTABLE[YYPACT[STATE-NUM]] -- What to do in state STATE-NUM.  If
@@ -941,453 +953,470 @@ static const yytype_int16 yydefgoto[] =
    number is the opposite.  If YYTABLE_NINF, syntax error.  */
 static const yytype_int16 yytable[] =
 {
-      30,    29,    21,   130,    24,    84,   107,   109,   297,   108,
-     108,    33,    30,    40,   423,   361,   361,   101,    37,   247,
-     342,   110,    15,   112,   116,    30,    50,    27,   245,   241,
-     141,   471,    47,   108,     3,   131,   132,     4,    45,   165,
-     166,    99,   140,    35,    36,    15,   258,   170,   171,    41,
-     128,    -2,   419,   196,   129,   196,   111,    49,     4,    41,
-     120,   180,   157,   158,   159,    42,   134,    27,   451,   136,
-     360,   451,   137,   311,   487,   242,    15,   472,   367,   368,
-     167,   295,   296,   194,   452,   198,   184,   452,   343,   134,
-     442,   178,   179,   129,    28,   -17,   181,   361,   293,   185,
-     332,   137,   211,   212,   213,   214,   215,   216,   217,   218,
-     219,   220,   221,   222,   223,   224,   225,   226,   227,   228,
-     134,   247,   229,   202,   112,   145,   146,   -15,   454,   207,
-     206,   454,   455,   210,   456,   455,   494,   496,   -16,   193,
-      27,   451,   400,   112,   382,   193,   413,   193,   112,   248,
-     294,   116,   333,   252,   323,    13,   325,   452,   104,   232,
-     233,   112,   235,   453,   417,    15,    23,   239,    15,  -265,
-     433,   155,   156,   157,   158,   159,   377,   193,   208,   102,
-     193,   467,   406,   444,   445,   439,    27,   451,   193,   193,
-     254,   356,   -39,   407,   425,   271,   112,   112,   450,   495,
-      16,   454,   462,   452,   287,   455,    39,   456,   -40,   134,
-    -219,    34,    17,   305,   195,   307,    38,   462,   129,   462,
-     491,   403,   326,   160,   161,   162,   193,   345,   408,   292,
-      43,   259,   349,   193,    18,    52,   300,    27,    53,    54,
-     133,   -15,    56,    57,    58,    59,    60,   454,   329,   -16,
-     112,   455,    44,   456,    61,    31,    32,    15,   372,   170,
-     171,   285,   193,   193,   321,   306,   271,   193,   271,   484,
-     485,   486,    98,    62,    63,    64,    65,    66,    67,    68,
-     -40,    69,    70,    71,   134,    72,    73,    74,   336,   187,
-     328,   112,   193,   353,   346,   354,   101,   386,    75,   135,
-     108,   134,    76,   271,    77,    35,    36,   357,   358,   359,
-      78,   366,   388,   155,   156,   157,   158,   159,   123,  -196,
-    -196,  -196,   -50,   355,   391,   354,   193,   380,   102,   381,
-     482,   483,   484,   485,   486,   392,   112,   193,   163,   164,
-     300,   473,   474,   112,   165,   166,   105,   393,   389,   193,
-     441,   488,   193,   490,   395,   410,   418,   411,    52,   421,
-      27,    53,    54,    55,   125,    56,    57,    58,    59,    60,
-     192,   193,   429,   405,   204,   205,   127,    61,   139,   409,
-     256,   257,   437,   289,   290,   167,   138,   482,   483,   484,
-     485,   486,   366,   170,   171,   168,    62,    63,    64,    65,
-      66,    67,    68,   169,    69,    70,    71,    45,    72,    73,
-      74,   434,   427,   193,   182,   188,   190,   200,   191,   334,
-     230,    75,   473,   474,   475,    76,    69,    77,    30,   240,
-     366,   246,   446,    78,   249,   335,   251,    30,   318,   286,
-      30,    40,    52,   291,    27,    53,    54,    55,   303,    56,
-      57,    58,    59,    60,   304,    30,   319,   310,   312,   313,
-     314,    61,   476,   477,   478,   479,   480,   481,   482,   483,
-     484,   485,   486,   316,   317,   324,   493,   327,   340,   330,
-      62,    63,    64,    65,    66,    67,    68,   337,    69,    70,
-      71,   338,    72,    73,    74,   339,   142,   143,   144,   145,
-     146,   147,   347,   378,   348,    75,   129,   384,   387,    76,
-     396,    77,   394,   397,   402,   193,   398,    78,    52,   379,
-      27,    53,    54,    55,   399,    56,    57,    58,    59,    60,
-     401,   404,   350,   412,   416,   422,   430,    61,   148,   149,
-     150,   151,   152,   153,   154,   155,   156,   157,   158,   159,
-     424,   426,   428,   466,   435,   253,    62,    63,    64,    65,
-      66,    67,    68,   432,    69,    70,    71,   438,    72,    73,
-      74,   448,   142,   143,   144,   145,   146,   147,   449,   468,
-     460,    75,   469,    41,   489,    76,   385,    77,   492,   299,
-     511,   512,   244,    78,    52,  -190,    27,    53,    54,    55,
-      12,    56,    57,    58,    59,    60,   145,   146,   147,    48,
-     447,   362,   238,    61,   148,   149,   150,   151,   152,   153,
-     154,   155,   156,   157,   158,   159,   420,   231,   309,   250,
-     199,   255,    62,    63,    64,    65,    66,    67,    68,   122,
-      69,    70,    71,     0,    72,    73,    74,   150,   151,   152,
-     153,   154,   155,   156,   157,   158,   159,    75,     0,     0,
-       0,    76,     0,    77,     0,     0,     0,     0,     0,    78,
-     260,  -192,    27,    53,    54,   133,     0,    56,    57,    58,
-      59,    60,   473,   474,   475,     0,     0,     0,     0,    61,
-     261,     0,   262,     0,     0,     0,     0,   263,   264,   265,
-     266,     0,   267,   268,   269,     0,     0,     0,    62,    63,
-      64,    65,    66,    67,    68,   -40,    69,    70,    71,   134,
-      72,    73,    74,   477,   478,   479,   480,   481,   482,   483,
-     484,   485,   486,    75,     0,     0,     0,    76,   270,    77,
-       0,     0,     0,   129,   -81,    78,    52,     0,    27,    53,
-      54,    55,     0,    56,    57,    58,    59,    60,   145,   146,
-     147,     0,     0,     0,     0,    61,   261,     0,   262,   444,
-     445,     0,     0,   263,   264,   265,   266,     0,   267,   268,
-     269,     0,     0,     0,    62,    63,    64,    65,    66,    67,
-      68,     0,    69,    70,    71,     0,    72,    73,    74,     0,
-     151,   152,   153,   154,   155,   156,   157,   158,   159,    75,
-       0,     0,     0,    76,   270,    77,     0,     0,     0,   129,
-    -116,    78,    52,     0,    27,    53,    54,    55,     0,    56,
-      57,    58,    59,    60,   473,   474,   475,     0,     0,     0,
-       0,    61,   261,     0,   262,     0,     0,     0,     0,   263,
-     264,   265,   266,     0,   267,   268,   269,     0,     0,     0,
+      30,    29,    21,    85,   110,   112,   111,   111,   133,   254,
+      24,   353,    30,    40,   307,    27,   256,   372,   372,   113,
+      15,   115,   119,   434,   123,    30,    50,   267,    45,   145,
+     478,   111,   250,   134,   135,   136,     3,   141,    47,   -15,
+      41,   144,   104,    27,    33,   199,    42,   303,   506,    41,
+     393,    37,   169,   170,  -196,  -196,  -196,    49,     4,    15,
+     371,   202,   186,   202,   138,   305,   306,   199,   141,    13,
+     140,   131,   417,   107,   102,   132,    27,   462,   482,   169,
+     170,   251,   354,   498,   200,    28,   204,   132,   -17,   114,
+     208,    16,   184,   463,    75,   185,   171,   199,   215,   -40,
+     372,   321,   304,    17,   220,   221,   222,   223,   224,   225,
+     226,   227,   228,   229,   230,   231,   232,   233,   234,   235,
+     236,   237,   256,   171,   238,   462,   115,   483,    18,    -2,
+     244,    15,   187,   176,   177,   191,     4,   424,   199,   216,
+     465,   463,    23,   418,   466,   343,   467,   115,   505,   333,
+     411,   335,   115,   257,   199,   119,   -16,   261,   -39,   436,
+     263,   444,   388,    27,   462,   115,    27,   462,   294,    34,
+     219,    15,   428,   176,   177,   138,   450,   297,   430,   248,
+     463,    38,    15,   463,   378,   379,   464,   367,   465,   461,
+    -272,   105,   466,   473,   507,   199,   241,   242,    39,   -50,
+     344,   280,   302,   115,   115,    15,   101,   414,   473,    43,
+     473,   502,    35,    36,   419,   138,   453,   149,   150,   151,
+     315,   -15,   317,   455,   456,  -219,   138,   465,   201,   104,
+     465,   466,   132,   467,   466,   -16,   467,   331,    44,   336,
+     383,    45,   356,   199,   199,   194,   217,   360,   199,   138,
+     105,   310,   164,   165,   166,   190,   340,   126,   115,   161,
+     162,   163,   347,   156,   157,   158,   159,   160,   161,   162,
+     163,   495,   496,   497,   108,   280,   268,   280,   199,    31,
+      32,   368,   369,   370,   295,   377,   199,   316,   128,   199,
+      27,   239,   339,    55,   199,    56,    57,    58,   143,   364,
+     115,   365,   391,   366,   392,   365,   397,   402,   111,   199,
+     403,   130,   199,   280,   159,   160,   161,   162,   163,   197,
+     404,   399,   199,   149,   150,   142,    62,    63,    64,    65,
+      66,   452,    68,   199,   499,   174,   501,   357,    72,    73,
+      74,    75,    35,    36,   193,   115,   213,   214,   416,   149,
+     150,   151,   115,   421,   420,   422,   196,   310,   167,   168,
+     109,   175,   484,   485,   486,   429,    79,   377,   432,   198,
+     199,   406,   159,   160,   161,   162,   163,   265,   266,   299,
+     300,   440,   149,   150,   151,   188,   445,   176,   177,   438,
+     199,   448,   400,   154,   155,   156,   157,   158,   159,   160,
+     161,   162,   163,   206,    69,   377,   488,   489,   490,   491,
+     492,   493,   494,   495,   496,   497,   249,    52,   255,    27,
+      53,    54,    55,   258,    56,    57,    58,    59,    60,   260,
+     158,   159,   160,   161,   162,   163,    61,   296,   313,    30,
+     301,   484,   485,   457,   314,   320,   322,   323,    30,   324,
+     326,    30,    40,   327,   328,    62,    63,    64,    65,    66,
+      67,    68,   329,    69,    70,    71,    30,    72,    73,    74,
+      75,   146,   147,   148,   149,   150,   151,   334,   338,   351,
+     341,   345,   348,    76,   349,   350,   359,    77,   358,    78,
+     493,   494,   495,   496,   497,    79,    52,   346,    27,    53,
+      54,    55,   132,    56,    57,    58,    59,    60,   493,   494,
+     495,   496,   497,   395,   398,    61,   152,   153,   154,   155,
+     156,   157,   158,   159,   160,   161,   162,   163,   405,   407,
+     408,   199,   409,   262,    62,    63,    64,    65,    66,    67,
+      68,   410,    69,    70,    71,   412,    72,    73,    74,    75,
+     146,   147,   148,   149,   150,   151,   413,   415,   361,   433,
+     389,   423,    76,   427,   441,   435,    77,   437,    78,   443,
+     439,   446,   449,   459,    79,    52,   390,    27,    53,    54,
+      55,   460,    56,    57,    58,    59,    60,   471,   477,   479,
+     480,    41,   500,   503,    61,   152,   153,   154,   155,   156,
+     157,   158,   159,   160,   161,   162,   163,   522,   484,   485,
+     486,   396,   264,    62,    63,    64,    65,    66,    67,    68,
+     523,    69,    70,    71,   253,    72,    73,    74,    75,    52,
+      12,    27,    53,    54,    55,   309,    56,    57,    58,    59,
+      60,    76,    48,   373,   458,    77,   431,    78,    61,   247,
+     259,   205,   172,    79,   173,  -190,   492,   493,   494,   495,
+     496,   497,   240,   319,   125,     0,   337,    62,    63,    64,
+      65,    66,    67,    68,     0,    69,    70,    71,     0,    72,
+      73,    74,    75,   269,     0,    27,    53,    54,   137,     0,
+      56,    57,    58,    59,    60,    76,     0,     0,     0,    77,
+       0,    78,    61,   270,     0,   271,     0,    79,     0,  -192,
+     272,   273,   274,   275,     0,   276,   277,   278,     0,     0,
+       0,    62,    63,    64,    65,    66,    67,    68,   -40,    69,
+      70,    71,   138,    72,    73,    74,    75,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,    76,
+       0,     0,     0,    77,   279,    78,     0,     0,     0,   132,
+     -81,    79,    52,     0,    27,    53,    54,    55,     0,    56,
+      57,    58,    59,    60,   484,   485,   486,     0,     0,     0,
+       0,    61,   270,     0,   271,   455,   456,     0,     0,   272,
+     273,   274,   275,     0,   276,   277,   278,     0,     0,     0,
       62,    63,    64,    65,    66,    67,    68,     0,    69,    70,
-      71,     0,    72,    73,    74,     0,   478,   479,   480,   481,
-     482,   483,   484,   485,   486,    75,     0,     0,     0,    76,
-     270,    77,     0,     0,     0,   129,    52,    78,    27,    53,
-      54,   133,     0,    56,    57,    58,    59,    60,     0,     0,
-       0,     0,     0,     0,     0,    61,     0,     0,    27,     0,
-       0,    55,     0,    56,    57,    58,     0,     0,     0,     0,
+      71,     0,    72,    73,    74,    75,     0,   487,   488,   489,
+     490,   491,   492,   493,   494,   495,   496,   497,    76,     0,
+       0,   504,    77,   279,    78,     0,     0,     0,   132,  -116,
+      79,    52,     0,    27,    53,    54,    55,     0,    56,    57,
+      58,    59,    60,     0,     0,     0,     0,     0,     0,     0,
+      61,   270,     0,   271,     0,     0,     0,     0,   272,   273,
+     274,   275,     0,   276,   277,   278,   149,   150,   151,    62,
+      63,    64,    65,    66,    67,    68,     0,    69,    70,    71,
+       0,    72,    73,    74,    75,    52,     0,    27,    53,    54,
+     137,     0,    56,    57,    58,    59,    60,    76,     0,     0,
+       0,    77,   279,    78,    61,     0,     0,   132,     0,    79,
+       0,   155,   156,   157,   158,   159,   160,   161,   162,   163,
+     484,   485,   486,    62,    63,    64,    65,    66,    67,    68,
+     -40,    69,    70,    71,   138,    72,    73,    74,    75,    52,
+       0,    27,    53,    54,   137,     0,    56,    57,    58,    59,
+      60,    76,   139,     0,     0,    77,     0,    78,    61,     0,
+       0,     0,     0,    79,     0,   489,   490,   491,   492,   493,
+     494,   495,   496,   497,   484,   485,   486,    62,    63,    64,
+      65,    66,    67,    68,   -40,    69,    70,    71,   138,    72,
+      73,    74,    75,    52,     0,    27,    53,    54,    55,     0,
+      56,    57,    58,    59,    60,    76,     0,     0,     0,    77,
+    -108,    78,    61,     0,     0,     0,     0,    79,     0,     0,
+     490,   491,   492,   493,   494,   495,   496,   497,     0,     0,
+       0,    62,    63,    64,    65,    66,    67,    68,     0,    69,
+      70,    71,     0,    72,    73,    74,    75,   146,   147,   148,
+     149,   150,   151,     0,     0,     0,     0,     0,     0,    76,
+       0,     0,     0,    77,     0,    78,  -185,     0,     0,     0,
+    -185,    79,    52,     0,    27,    53,    54,    55,     0,    56,
+      57,    58,    59,    60,     0,     0,     0,     0,     0,     0,
+       0,    61,   152,   153,   154,   155,   156,   157,   158,   159,
+     160,   161,   162,   163,     0,     0,     0,     0,     0,   361,
+      62,    63,    64,    65,    66,    67,    68,     0,    69,    70,
+      71,     0,    72,    73,    74,    75,    52,     0,    27,    53,
+      54,    55,     0,    56,    57,    58,    59,    60,    76,     0,
+       0,     0,    77,     0,    78,    61,     0,     0,     0,  -183,
+      79,     0,     0,     0,     0,     0,     0,     0,     0,     0,
        0,     0,     0,     0,    62,    63,    64,    65,    66,    67,
-      68,   -40,    69,    70,    71,   134,    72,    73,    74,   145,
-     146,   147,     0,     0,    62,    63,    64,    65,    66,    75,
-      68,     0,     0,    76,  -108,    77,    72,    73,    74,     0,
-      52,    78,    27,    53,    54,    55,     0,    56,    57,    58,
-      59,    60,     0,     0,     0,   106,     0,     0,     0,    61,
-       0,    78,   152,   153,   154,   155,   156,   157,   158,   159,
+      68,     0,    69,    70,    71,     0,    72,    73,    74,    75,
+      52,     0,    27,    53,    54,    55,     0,    56,    57,    58,
+      59,    60,    76,   139,     0,     0,    77,     0,    78,    61,
+       0,     0,     0,     0,    79,     0,     0,     0,     0,     0,
        0,     0,     0,     0,     0,     0,     0,     0,    62,    63,
       64,    65,    66,    67,    68,     0,    69,    70,    71,     0,
-      72,    73,    74,     0,   142,   143,   144,   145,   146,   147,
-       0,     0,     0,    75,     0,     0,     0,    76,     0,    77,
-    -185,     0,     0,     0,  -185,    78,    52,     0,    27,    53,
-      54,    55,     0,    56,    57,    58,    59,    60,     0,     0,
-       0,     0,     0,     0,     0,    61,   148,   149,   150,   151,
-     152,   153,   154,   155,   156,   157,   158,   159,     0,     0,
-       0,     0,     0,   350,    62,    63,    64,    65,    66,    67,
-      68,     0,    69,    70,    71,     0,    72,    73,    74,     0,
-     142,   143,   144,   145,   146,   147,     0,     0,     0,    75,
-       0,     0,     0,    76,     0,    77,     0,     0,     0,     0,
-    -183,    78,    52,     0,    27,    53,    54,    55,     0,    56,
-      57,    58,    59,    60,     0,     0,     0,     0,     0,     0,
-       0,    61,   148,   149,   150,   151,   152,   153,   154,   155,
-     156,   157,   158,   159,     0,     0,     0,     0,     0,   352,
-      62,    63,    64,    65,    66,    67,    68,     0,    69,    70,
-      71,     0,    72,    73,    74,   142,   143,   144,   145,   146,
-     147,     0,     0,     0,     0,    75,   135,     0,     0,    76,
-       0,    77,     0,     0,     0,     0,    52,    78,    27,    53,
-      54,    55,     0,    56,    57,    58,    59,    60,     0,     0,
-       0,     0,     0,     0,     0,    61,     0,   148,   149,   150,
-     151,   152,   153,   154,   155,   156,   157,   158,   159,     0,
-       0,     0,     0,   189,    62,    63,    64,    65,    66,    67,
-      68,     0,    69,    70,    71,     0,    72,    73,    74,   142,
-     143,   144,   145,   146,   147,     0,     0,   234,     0,    75,
-       0,     0,     0,    76,     0,    77,     0,     0,     0,     0,
-      52,    78,    27,    53,    54,    55,     0,    56,    57,    58,
-      59,    60,     0,     0,     0,     0,     0,     0,     0,    61,
-       0,   148,   149,   150,   151,   152,   153,   154,   155,   156,
-     157,   158,   159,     0,     0,     0,     0,   288,    62,    63,
-      64,    65,    66,    67,    68,     0,    69,    70,    71,     0,
-      72,    73,    74,   142,   143,   144,   145,   146,   147,     0,
-       0,     0,     0,    75,     0,     0,     0,    76,     0,    77,
-    -183,     0,     0,     0,    52,    78,    27,    53,    54,    55,
+      72,    73,    74,    75,   146,   147,   148,   149,   150,   151,
+       0,     0,     0,     0,   243,     0,    76,     0,     0,     0,
+      77,     0,    78,     0,     0,     0,     0,    52,    79,    27,
+      53,    54,    55,     0,    56,    57,    58,    59,    60,     0,
+       0,     0,     0,     0,     0,     0,    61,     0,     0,   152,
+     153,   154,   155,   156,   157,   158,   159,   160,   161,   162,
+     163,     0,     0,     0,   447,    62,    63,    64,    65,    66,
+      67,    68,     0,    69,    70,    71,     0,    72,    73,    74,
+      75,     0,     0,   146,   147,   148,   149,   150,   151,     0,
+       0,     0,     0,    76,     0,     0,     0,    77,     0,    78,
+    -183,     0,     0,     0,    52,    79,    27,    53,    54,    55,
        0,    56,    57,    58,    59,    60,     0,     0,     0,     0,
-       0,     0,     0,    61,     0,   148,   149,   150,   151,   152,
-     153,   154,   155,   156,   157,   158,   159,     0,     0,     0,
-     436,     0,    62,    63,    64,    65,    66,    67,    68,     0,
-      69,    70,    71,     0,    72,    73,    74,   142,   143,   144,
-     145,   146,   147,     0,     0,     0,     0,    75,     0,     0,
-     186,    76,   320,    77,     0,     0,     0,     0,    52,    78,
+       0,     0,     0,    61,   210,   211,     0,     0,   152,   153,
+     154,   155,   156,   157,   158,   159,   160,   161,   162,   163,
+       0,     0,    62,    63,    64,    65,    66,    67,    68,     0,
+      69,    70,    71,     0,    72,    73,    74,    75,    52,     0,
       27,    53,    54,    55,     0,    56,    57,    58,    59,    60,
-       0,     0,     0,     0,     0,     0,     0,    61,     0,   148,
-     149,   150,   151,   152,   153,   154,   155,   156,   157,   158,
-     159,     0,     0,     0,     0,     0,    62,    63,    64,    65,
+      76,     0,     0,     0,    77,   330,    78,    61,     0,     0,
+       0,     0,    79,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,    62,    63,    64,    65,
       66,    67,    68,     0,    69,    70,    71,     0,    72,    73,
-      74,   142,   143,   144,   145,   146,   147,     0,     0,     0,
-       0,    75,     0,     0,     0,    76,  -108,    77,     0,     0,
-       0,     0,    52,    78,    27,    53,    54,    55,     0,    56,
-      57,    58,    59,    60,     0,     0,     0,     0,     0,     0,
-       0,    61,     0,   148,   149,   150,   151,   152,   153,   154,
-     155,   156,   157,   158,   159,     0,     0,     0,     0,     0,
+      74,    75,    52,     0,    27,    53,    54,    55,     0,    56,
+      57,    58,    59,    60,    76,     0,     0,     0,    77,  -108,
+      78,    61,     0,     0,     0,     0,    79,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
       62,    63,    64,    65,    66,    67,    68,     0,    69,    70,
-      71,     0,    72,    73,    74,   142,   143,     0,   145,   146,
-     147,     0,     0,     0,     0,    75,     0,     0,     0,    76,
-       0,    77,  -108,     0,     0,     0,    52,    78,    27,    53,
-      54,    55,     0,    56,    57,    58,    59,    60,     0,     0,
-       0,     0,     0,     0,     0,    61,     0,     0,   149,   150,
-     151,   152,   153,   154,   155,   156,   157,   158,   159,     0,
-       0,     0,     0,     0,    62,    63,    64,    65,    66,    67,
-      68,     0,    69,    70,    71,     0,    72,    73,    74,   142,
-       0,     0,   145,   146,   147,     0,     0,     0,     0,    75,
-       0,     0,     0,    76,     0,    77,   145,   146,   147,     0,
-       0,    78,     0,     0,     0,     0,     0,   473,   474,   475,
-       0,     0,     0,     0,     0,   473,   474,   475,     0,     0,
-       0,     0,   149,   150,   151,   152,   153,   154,   155,   156,
-     157,   158,   159,   145,   146,   147,   149,   150,   151,   152,
-     153,   154,   155,   156,   157,   158,   159,   476,   477,   478,
-     479,   480,   481,   482,   483,   484,   485,   486,   479,   480,
-     481,   482,   483,   484,   485,   486,   473,   474,   475,   470,
-       0,     0,     0,     0,     0,     0,     0,     0,   154,   155,
-     156,   157,   158,   159,     0,     0,   497,   498,   499,   500,
-     501,   502,   503,   504,   505,   506,   507,   508,   509,   510,
-       0,     0,     0,     0,     0,     0,     0,     0,     0,   470,
-       0,   481,   482,   483,   484,   485,   486
+      71,     0,    72,    73,    74,    75,   146,   147,   148,   149,
+     150,   151,     0,     0,     0,     0,     0,     0,    76,   192,
+       0,     0,    77,     0,    78,  -108,     0,     0,     0,    52,
+      79,    27,    53,    54,    55,     0,    56,    57,    58,    59,
+      60,     0,     0,     0,     0,     0,     0,     0,    61,     0,
+       0,   152,   153,   154,   155,   156,   157,   158,   159,   160,
+     161,   162,   163,     0,     0,     0,     0,    62,    63,    64,
+      65,    66,    67,    68,     0,    69,    70,    71,     0,    72,
+      73,    74,    75,   146,   147,   148,   149,   150,   151,     0,
+       0,     0,     0,     0,     0,    76,     0,     0,     0,    77,
+       0,    78,     0,     0,     0,     0,     0,    79,   146,   147,
+     148,   149,   150,   151,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,   152,   153,
+     154,   155,   156,   157,   158,   159,   160,   161,   162,   163,
+       0,     0,     0,     0,     0,   363,   146,   147,   148,   149,
+     150,   151,     0,   152,   153,   154,   155,   156,   157,   158,
+     159,   160,   161,   162,   163,     0,     0,     0,     0,   195,
+     146,   147,   148,   149,   150,   151,     0,     0,     0,     0,
+       0,   146,   147,     0,   149,   150,   151,     0,     0,     0,
+       0,   152,   153,   154,   155,   156,   157,   158,   159,   160,
+     161,   162,   163,     0,     0,   146,     0,   298,   149,   150,
+     151,     0,     0,     0,     0,   152,   153,   154,   155,   156,
+     157,   158,   159,   160,   161,   162,   163,   153,   154,   155,
+     156,   157,   158,   159,   160,   161,   162,   163,   149,   150,
+     151,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,   153,   154,   155,   156,   157,   158,   159,   160,   161,
+     162,   163,   484,   485,   486,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,   153,   154,   155,   156,   157,   158,   159,   160,   161,
+     162,   163,     0,     0,     0,     0,     0,     0,     0,   481,
+       0,     0,     0,     0,     0,   487,   488,   489,   490,   491,
+     492,   493,   494,   495,   496,   497,   508,   509,   510,   511,
+     512,   513,   514,   515,   516,   517,   518,   519,   520,   521,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,   481
 };
 
 static const yytype_int16 yycheck[] =
 {
-      16,    16,    10,    74,    11,    45,    59,    60,   239,    59,
-      60,    17,    28,    28,   401,   316,   317,    13,    24,   188,
-       1,    61,     6,    63,    64,    41,    41,     3,   183,    27,
-      83,    26,    39,    83,     0,    75,    76,     7,    13,    36,
-      37,    47,    82,     8,     9,     6,   201,     8,     9,    63,
-      70,     0,   397,   124,    74,   126,    62,    71,     7,    63,
-      65,   101,    65,    66,    67,    69,    50,     3,     4,    77,
-     315,     4,    77,    69,   461,    73,     6,    72,     8,     9,
-      77,   236,   237,   123,    20,   125,    51,    20,    69,    50,
-     435,    75,   100,    74,    70,    70,   102,   398,    26,   105,
-      26,   106,   142,   143,   144,   145,   146,   147,   148,   149,
-     150,   151,   152,   153,   154,   155,   156,   157,   158,   159,
-      50,   290,   162,   128,   164,    17,    18,    39,    64,   136,
-     135,    64,    68,   139,    70,    68,    72,    70,    39,    73,
-       3,     4,   373,   183,    78,    73,   391,    73,   188,   189,
-      78,   191,    78,   193,   274,    69,   276,    20,    70,   165,
-     166,   201,   167,    26,   395,     6,    65,   174,     6,    70,
-     415,    63,    64,    65,    66,    67,   331,    73,    71,    39,
-      73,   453,    78,    24,    25,   430,     3,     4,    73,    73,
-     195,   311,    46,    78,    78,   203,   236,   237,   443,   471,
-      38,    64,   447,    20,   209,    68,    73,    70,    46,    50,
-      70,    46,    50,   253,    70,   255,    69,   462,    74,   464,
-     465,   376,    69,    11,    12,    13,    73,   298,   383,   234,
-       3,    71,   303,    73,    72,     1,   243,     3,     4,     5,
-       6,    74,     8,     9,    10,    11,    12,    64,   288,    74,
-     290,    68,    74,    70,    20,     8,     9,     6,    69,     8,
-       9,    71,    73,    73,   269,    71,   274,    73,   276,    65,
-      66,    67,    70,    39,    40,    41,    42,    43,    44,    45,
-      46,    47,    48,    49,    50,    51,    52,    53,   293,    75,
-      71,   331,    73,    71,   300,    73,    13,   350,    64,    65,
-     350,    50,    68,   311,    70,     8,     9,   312,   313,   314,
-      76,   316,   352,    63,    64,    65,    66,    67,    70,    11,
-      12,    13,    71,    71,    71,    73,    73,   332,    39,   334,
-      63,    64,    65,    66,    67,    71,   376,    73,    72,    73,
-     347,    17,    18,   383,    36,    37,    39,    71,   354,    73,
-      71,   462,    73,   464,   361,   386,   396,   388,     1,   399,
-       3,     4,     5,     6,    70,     8,     9,    10,    11,    12,
-      72,    73,   412,   378,     8,     9,    70,    20,    39,   384,
-       8,     9,   422,    72,    73,    77,    70,    63,    64,    65,
-      66,    67,   397,     8,     9,    70,    39,    40,    41,    42,
-      43,    44,    45,    70,    47,    48,    49,    13,    51,    52,
-      53,   416,    72,    73,    70,    73,    78,    50,    73,    62,
-      71,    64,    17,    18,    19,    68,    47,    70,   444,    71,
-     435,    71,   440,    76,    71,    78,    71,   453,    69,    71,
-     456,   456,     1,    70,     3,     4,     5,     6,    71,     8,
-       9,    10,    11,    12,    71,   471,    69,    71,    70,    70,
-      70,    20,    57,    58,    59,    60,    61,    62,    63,    64,
-      65,    66,    67,    70,    70,    75,    71,    70,    72,    71,
-      39,    40,    41,    42,    43,    44,    45,    70,    47,    48,
-      49,    71,    51,    52,    53,    71,    14,    15,    16,    17,
-      18,    19,    73,    62,    69,    64,    74,    42,    71,    68,
-      13,    70,    28,    69,    69,    73,    73,    76,     1,    78,
-       3,     4,     5,     6,    32,     8,     9,    10,    11,    12,
-      73,    71,    73,    72,    70,    13,    22,    20,    56,    57,
-      58,    59,    60,    61,    62,    63,    64,    65,    66,    67,
-      71,    71,    71,     4,    69,    73,    39,    40,    41,    42,
-      43,    44,    45,    74,    47,    48,    49,    71,    51,    52,
-      53,    69,    14,    15,    16,    17,    18,    19,    71,     4,
-      72,    64,     4,    63,    75,    68,   347,    70,    72,   242,
-      69,    72,   182,    76,     1,    78,     3,     4,     5,     6,
-       4,     8,     9,    10,    11,    12,    17,    18,    19,    39,
-     440,   316,   173,    20,    56,    57,    58,    59,    60,    61,
-      62,    63,    64,    65,    66,    67,   398,   164,   257,   191,
-     126,    73,    39,    40,    41,    42,    43,    44,    45,    65,
-      47,    48,    49,    -1,    51,    52,    53,    58,    59,    60,
-      61,    62,    63,    64,    65,    66,    67,    64,    -1,    -1,
-      -1,    68,    -1,    70,    -1,    -1,    -1,    -1,    -1,    76,
-       1,    78,     3,     4,     5,     6,    -1,     8,     9,    10,
-      11,    12,    17,    18,    19,    -1,    -1,    -1,    -1,    20,
-      21,    -1,    23,    -1,    -1,    -1,    -1,    28,    29,    30,
-      31,    -1,    33,    34,    35,    -1,    -1,    -1,    39,    40,
-      41,    42,    43,    44,    45,    46,    47,    48,    49,    50,
-      51,    52,    53,    58,    59,    60,    61,    62,    63,    64,
-      65,    66,    67,    64,    -1,    -1,    -1,    68,    69,    70,
-      -1,    -1,    -1,    74,    75,    76,     1,    -1,     3,     4,
-       5,     6,    -1,     8,     9,    10,    11,    12,    17,    18,
-      19,    -1,    -1,    -1,    -1,    20,    21,    -1,    23,    24,
-      25,    -1,    -1,    28,    29,    30,    31,    -1,    33,    34,
-      35,    -1,    -1,    -1,    39,    40,    41,    42,    43,    44,
-      45,    -1,    47,    48,    49,    -1,    51,    52,    53,    -1,
-      59,    60,    61,    62,    63,    64,    65,    66,    67,    64,
-      -1,    -1,    -1,    68,    69,    70,    -1,    -1,    -1,    74,
-      75,    76,     1,    -1,     3,     4,     5,     6,    -1,     8,
+      16,    16,    10,    45,    59,    60,    59,    60,    74,   189,
+      11,     1,    28,    28,   248,     3,   194,   326,   327,    61,
+       6,    63,    64,   412,    65,    41,    41,   207,    13,    84,
+     464,    84,    27,    75,    76,    77,     0,    78,    39,    39,
+      66,    83,    13,     3,    17,    76,    72,    26,   482,    66,
+      81,    24,    36,    37,    11,    12,    13,    74,     7,     6,
+     325,   127,   104,   129,    50,   245,   246,    76,   109,    72,
+      78,    73,    81,    73,    47,    77,     3,     4,    26,    36,
+      37,    76,    72,   472,   126,    73,   128,    77,    73,    62,
+     131,    38,    78,    20,    54,   103,    80,    76,   139,    46,
+     409,    72,    81,    50,   146,   147,   148,   149,   150,   151,
+     152,   153,   154,   155,   156,   157,   158,   159,   160,   161,
+     162,   163,   300,    80,   166,     4,   168,    75,    75,     0,
+     171,     6,   105,     8,     9,   108,     7,   402,    76,   140,
+      67,    20,    68,    81,    71,    26,    73,   189,    75,   283,
+     384,   285,   194,   195,    76,   197,    39,   199,    46,    81,
+     201,   426,   342,     3,     4,   207,     3,     4,   210,    46,
+     143,     6,   406,     8,     9,    50,   441,   218,   408,   180,
+      20,    72,     6,    20,     8,     9,    26,   321,    67,   454,
+      73,    39,    71,   458,    73,    76,   169,   170,    76,    74,
+      81,   209,   243,   245,   246,     6,    73,   387,   473,     3,
+     475,   476,     8,     9,   394,    50,   446,    17,    18,    19,
+     262,    77,   264,    24,    25,    73,    50,    67,    73,    13,
+      67,    71,    77,    73,    71,    77,    73,   278,    77,    72,
+      72,    13,   308,    76,    76,    76,    74,   313,    76,    50,
+      39,   252,    11,    12,    13,    51,   298,    73,   300,    68,
+      69,    70,   303,    63,    64,    65,    66,    67,    68,    69,
+      70,    68,    69,    70,    39,   283,    74,   285,    76,     8,
+       9,   322,   323,   324,    74,   326,    76,    74,    73,    76,
+       3,    74,    74,     6,    76,     8,     9,    10,    39,    74,
+     342,    76,   343,    74,   345,    76,   361,    74,   361,    76,
+      74,    73,    76,   321,    66,    67,    68,    69,    70,    76,
+      74,   363,    76,    17,    18,    73,    39,    40,    41,    42,
+      43,    74,    45,    76,   473,    73,   475,   310,    51,    52,
+      53,    54,     8,     9,    78,   387,     8,     9,   389,    17,
+      18,    19,   394,   397,   395,   399,    81,   358,    75,    76,
+      73,    73,    17,    18,    19,   407,    79,   408,   410,    75,
+      76,   372,    66,    67,    68,    69,    70,     8,     9,    75,
+      76,   423,    17,    18,    19,    73,   427,     8,     9,    75,
+      76,   433,   365,    61,    62,    63,    64,    65,    66,    67,
+      68,    69,    70,    50,    47,   446,    61,    62,    63,    64,
+      65,    66,    67,    68,    69,    70,    74,     1,    74,     3,
+       4,     5,     6,    74,     8,     9,    10,    11,    12,    74,
+      65,    66,    67,    68,    69,    70,    20,    74,    74,   455,
+      73,    17,    18,   451,    74,    74,    73,    73,   464,    73,
+      73,   467,   467,    73,    72,    39,    40,    41,    42,    43,
+      44,    45,    72,    47,    48,    49,   482,    51,    52,    53,
+      54,    14,    15,    16,    17,    18,    19,    78,    73,    75,
+      74,    65,    73,    67,    74,    74,    72,    71,    76,    73,
+      66,    67,    68,    69,    70,    79,     1,    81,     3,     4,
+       5,     6,    77,     8,     9,    10,    11,    12,    66,    67,
+      68,    69,    70,    42,    74,    20,    59,    60,    61,    62,
+      63,    64,    65,    66,    67,    68,    69,    70,    28,    13,
+      72,    76,    76,    76,    39,    40,    41,    42,    43,    44,
+      45,    32,    47,    48,    49,    76,    51,    52,    53,    54,
+      14,    15,    16,    17,    18,    19,    72,    74,    76,    13,
+      65,    75,    67,    73,    22,    74,    71,    74,    73,    77,
+      74,    72,    74,    72,    79,     1,    81,     3,     4,     5,
+       6,    74,     8,     9,    10,    11,    12,    75,     4,     4,
+       4,    66,    78,    75,    20,    59,    60,    61,    62,    63,
+      64,    65,    66,    67,    68,    69,    70,    72,    17,    18,
+      19,   358,    76,    39,    40,    41,    42,    43,    44,    45,
+      75,    47,    48,    49,   188,    51,    52,    53,    54,     1,
+       4,     3,     4,     5,     6,   251,     8,     9,    10,    11,
+      12,    67,    39,   326,   451,    71,   409,    73,    20,   179,
+     197,   129,    97,    79,    97,    81,    65,    66,    67,    68,
+      69,    70,   168,   266,    65,    -1,   294,    39,    40,    41,
+      42,    43,    44,    45,    -1,    47,    48,    49,    -1,    51,
+      52,    53,    54,     1,    -1,     3,     4,     5,     6,    -1,
+       8,     9,    10,    11,    12,    67,    -1,    -1,    -1,    71,
+      -1,    73,    20,    21,    -1,    23,    -1,    79,    -1,    81,
+      28,    29,    30,    31,    -1,    33,    34,    35,    -1,    -1,
+      -1,    39,    40,    41,    42,    43,    44,    45,    46,    47,
+      48,    49,    50,    51,    52,    53,    54,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    67,
+      -1,    -1,    -1,    71,    72,    73,    -1,    -1,    -1,    77,
+      78,    79,     1,    -1,     3,     4,     5,     6,    -1,     8,
        9,    10,    11,    12,    17,    18,    19,    -1,    -1,    -1,
-      -1,    20,    21,    -1,    23,    -1,    -1,    -1,    -1,    28,
+      -1,    20,    21,    -1,    23,    24,    25,    -1,    -1,    28,
       29,    30,    31,    -1,    33,    34,    35,    -1,    -1,    -1,
       39,    40,    41,    42,    43,    44,    45,    -1,    47,    48,
-      49,    -1,    51,    52,    53,    -1,    59,    60,    61,    62,
-      63,    64,    65,    66,    67,    64,    -1,    -1,    -1,    68,
-      69,    70,    -1,    -1,    -1,    74,     1,    76,     3,     4,
-       5,     6,    -1,     8,     9,    10,    11,    12,    -1,    -1,
-      -1,    -1,    -1,    -1,    -1,    20,    -1,    -1,     3,    -1,
-      -1,     6,    -1,     8,     9,    10,    -1,    -1,    -1,    -1,
+      49,    -1,    51,    52,    53,    54,    -1,    60,    61,    62,
+      63,    64,    65,    66,    67,    68,    69,    70,    67,    -1,
+      -1,    74,    71,    72,    73,    -1,    -1,    -1,    77,    78,
+      79,     1,    -1,     3,     4,     5,     6,    -1,     8,     9,
+      10,    11,    12,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      20,    21,    -1,    23,    -1,    -1,    -1,    -1,    28,    29,
+      30,    31,    -1,    33,    34,    35,    17,    18,    19,    39,
+      40,    41,    42,    43,    44,    45,    -1,    47,    48,    49,
+      -1,    51,    52,    53,    54,     1,    -1,     3,     4,     5,
+       6,    -1,     8,     9,    10,    11,    12,    67,    -1,    -1,
+      -1,    71,    72,    73,    20,    -1,    -1,    77,    -1,    79,
+      -1,    62,    63,    64,    65,    66,    67,    68,    69,    70,
+      17,    18,    19,    39,    40,    41,    42,    43,    44,    45,
+      46,    47,    48,    49,    50,    51,    52,    53,    54,     1,
+      -1,     3,     4,     5,     6,    -1,     8,     9,    10,    11,
+      12,    67,    68,    -1,    -1,    71,    -1,    73,    20,    -1,
+      -1,    -1,    -1,    79,    -1,    62,    63,    64,    65,    66,
+      67,    68,    69,    70,    17,    18,    19,    39,    40,    41,
+      42,    43,    44,    45,    46,    47,    48,    49,    50,    51,
+      52,    53,    54,     1,    -1,     3,     4,     5,     6,    -1,
+       8,     9,    10,    11,    12,    67,    -1,    -1,    -1,    71,
+      72,    73,    20,    -1,    -1,    -1,    -1,    79,    -1,    -1,
+      63,    64,    65,    66,    67,    68,    69,    70,    -1,    -1,
+      -1,    39,    40,    41,    42,    43,    44,    45,    -1,    47,
+      48,    49,    -1,    51,    52,    53,    54,    14,    15,    16,
+      17,    18,    19,    -1,    -1,    -1,    -1,    -1,    -1,    67,
+      -1,    -1,    -1,    71,    -1,    73,    74,    -1,    -1,    -1,
+      78,    79,     1,    -1,     3,     4,     5,     6,    -1,     8,
+       9,    10,    11,    12,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    20,    59,    60,    61,    62,    63,    64,    65,    66,
+      67,    68,    69,    70,    -1,    -1,    -1,    -1,    -1,    76,
+      39,    40,    41,    42,    43,    44,    45,    -1,    47,    48,
+      49,    -1,    51,    52,    53,    54,     1,    -1,     3,     4,
+       5,     6,    -1,     8,     9,    10,    11,    12,    67,    -1,
+      -1,    -1,    71,    -1,    73,    20,    -1,    -1,    -1,    78,
+      79,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
       -1,    -1,    -1,    -1,    39,    40,    41,    42,    43,    44,
-      45,    46,    47,    48,    49,    50,    51,    52,    53,    17,
-      18,    19,    -1,    -1,    39,    40,    41,    42,    43,    64,
-      45,    -1,    -1,    68,    69,    70,    51,    52,    53,    -1,
-       1,    76,     3,     4,     5,     6,    -1,     8,     9,    10,
-      11,    12,    -1,    -1,    -1,    70,    -1,    -1,    -1,    20,
-      -1,    76,    60,    61,    62,    63,    64,    65,    66,    67,
+      45,    -1,    47,    48,    49,    -1,    51,    52,    53,    54,
+       1,    -1,     3,     4,     5,     6,    -1,     8,     9,    10,
+      11,    12,    67,    68,    -1,    -1,    71,    -1,    73,    20,
+      -1,    -1,    -1,    -1,    79,    -1,    -1,    -1,    -1,    -1,
       -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    39,    40,
       41,    42,    43,    44,    45,    -1,    47,    48,    49,    -1,
-      51,    52,    53,    -1,    14,    15,    16,    17,    18,    19,
-      -1,    -1,    -1,    64,    -1,    -1,    -1,    68,    -1,    70,
-      71,    -1,    -1,    -1,    75,    76,     1,    -1,     3,     4,
-       5,     6,    -1,     8,     9,    10,    11,    12,    -1,    -1,
-      -1,    -1,    -1,    -1,    -1,    20,    56,    57,    58,    59,
-      60,    61,    62,    63,    64,    65,    66,    67,    -1,    -1,
-      -1,    -1,    -1,    73,    39,    40,    41,    42,    43,    44,
-      45,    -1,    47,    48,    49,    -1,    51,    52,    53,    -1,
-      14,    15,    16,    17,    18,    19,    -1,    -1,    -1,    64,
-      -1,    -1,    -1,    68,    -1,    70,    -1,    -1,    -1,    -1,
-      75,    76,     1,    -1,     3,     4,     5,     6,    -1,     8,
-       9,    10,    11,    12,    -1,    -1,    -1,    -1,    -1,    -1,
-      -1,    20,    56,    57,    58,    59,    60,    61,    62,    63,
-      64,    65,    66,    67,    -1,    -1,    -1,    -1,    -1,    73,
-      39,    40,    41,    42,    43,    44,    45,    -1,    47,    48,
-      49,    -1,    51,    52,    53,    14,    15,    16,    17,    18,
-      19,    -1,    -1,    -1,    -1,    64,    65,    -1,    -1,    68,
-      -1,    70,    -1,    -1,    -1,    -1,     1,    76,     3,     4,
-       5,     6,    -1,     8,     9,    10,    11,    12,    -1,    -1,
-      -1,    -1,    -1,    -1,    -1,    20,    -1,    56,    57,    58,
-      59,    60,    61,    62,    63,    64,    65,    66,    67,    -1,
-      -1,    -1,    -1,    72,    39,    40,    41,    42,    43,    44,
-      45,    -1,    47,    48,    49,    -1,    51,    52,    53,    14,
-      15,    16,    17,    18,    19,    -1,    -1,    62,    -1,    64,
-      -1,    -1,    -1,    68,    -1,    70,    -1,    -1,    -1,    -1,
-       1,    76,     3,     4,     5,     6,    -1,     8,     9,    10,
-      11,    12,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    20,
-      -1,    56,    57,    58,    59,    60,    61,    62,    63,    64,
-      65,    66,    67,    -1,    -1,    -1,    -1,    72,    39,    40,
-      41,    42,    43,    44,    45,    -1,    47,    48,    49,    -1,
-      51,    52,    53,    14,    15,    16,    17,    18,    19,    -1,
-      -1,    -1,    -1,    64,    -1,    -1,    -1,    68,    -1,    70,
-      71,    -1,    -1,    -1,     1,    76,     3,     4,     5,     6,
+      51,    52,    53,    54,    14,    15,    16,    17,    18,    19,
+      -1,    -1,    -1,    -1,    65,    -1,    67,    -1,    -1,    -1,
+      71,    -1,    73,    -1,    -1,    -1,    -1,     1,    79,     3,
+       4,     5,     6,    -1,     8,     9,    10,    11,    12,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    20,    -1,    -1,    59,
+      60,    61,    62,    63,    64,    65,    66,    67,    68,    69,
+      70,    -1,    -1,    -1,    74,    39,    40,    41,    42,    43,
+      44,    45,    -1,    47,    48,    49,    -1,    51,    52,    53,
+      54,    -1,    -1,    14,    15,    16,    17,    18,    19,    -1,
+      -1,    -1,    -1,    67,    -1,    -1,    -1,    71,    -1,    73,
+      74,    -1,    -1,    -1,     1,    79,     3,     4,     5,     6,
       -1,     8,     9,    10,    11,    12,    -1,    -1,    -1,    -1,
-      -1,    -1,    -1,    20,    -1,    56,    57,    58,    59,    60,
-      61,    62,    63,    64,    65,    66,    67,    -1,    -1,    -1,
-      71,    -1,    39,    40,    41,    42,    43,    44,    45,    -1,
-      47,    48,    49,    -1,    51,    52,    53,    14,    15,    16,
-      17,    18,    19,    -1,    -1,    -1,    -1,    64,    -1,    -1,
-      27,    68,    69,    70,    -1,    -1,    -1,    -1,     1,    76,
+      -1,    -1,    -1,    20,    55,    56,    -1,    -1,    59,    60,
+      61,    62,    63,    64,    65,    66,    67,    68,    69,    70,
+      -1,    -1,    39,    40,    41,    42,    43,    44,    45,    -1,
+      47,    48,    49,    -1,    51,    52,    53,    54,     1,    -1,
        3,     4,     5,     6,    -1,     8,     9,    10,    11,    12,
-      -1,    -1,    -1,    -1,    -1,    -1,    -1,    20,    -1,    56,
-      57,    58,    59,    60,    61,    62,    63,    64,    65,    66,
-      67,    -1,    -1,    -1,    -1,    -1,    39,    40,    41,    42,
+      67,    -1,    -1,    -1,    71,    72,    73,    20,    -1,    -1,
+      -1,    -1,    79,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    39,    40,    41,    42,
       43,    44,    45,    -1,    47,    48,    49,    -1,    51,    52,
-      53,    14,    15,    16,    17,    18,    19,    -1,    -1,    -1,
-      -1,    64,    -1,    -1,    -1,    68,    69,    70,    -1,    -1,
-      -1,    -1,     1,    76,     3,     4,     5,     6,    -1,     8,
-       9,    10,    11,    12,    -1,    -1,    -1,    -1,    -1,    -1,
-      -1,    20,    -1,    56,    57,    58,    59,    60,    61,    62,
-      63,    64,    65,    66,    67,    -1,    -1,    -1,    -1,    -1,
+      53,    54,     1,    -1,     3,     4,     5,     6,    -1,     8,
+       9,    10,    11,    12,    67,    -1,    -1,    -1,    71,    72,
+      73,    20,    -1,    -1,    -1,    -1,    79,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
       39,    40,    41,    42,    43,    44,    45,    -1,    47,    48,
-      49,    -1,    51,    52,    53,    14,    15,    -1,    17,    18,
-      19,    -1,    -1,    -1,    -1,    64,    -1,    -1,    -1,    68,
-      -1,    70,    71,    -1,    -1,    -1,     1,    76,     3,     4,
-       5,     6,    -1,     8,     9,    10,    11,    12,    -1,    -1,
-      -1,    -1,    -1,    -1,    -1,    20,    -1,    -1,    57,    58,
-      59,    60,    61,    62,    63,    64,    65,    66,    67,    -1,
-      -1,    -1,    -1,    -1,    39,    40,    41,    42,    43,    44,
-      45,    -1,    47,    48,    49,    -1,    51,    52,    53,    14,
-      -1,    -1,    17,    18,    19,    -1,    -1,    -1,    -1,    64,
-      -1,    -1,    -1,    68,    -1,    70,    17,    18,    19,    -1,
-      -1,    76,    -1,    -1,    -1,    -1,    -1,    17,    18,    19,
-      -1,    -1,    -1,    -1,    -1,    17,    18,    19,    -1,    -1,
-      -1,    -1,    57,    58,    59,    60,    61,    62,    63,    64,
-      65,    66,    67,    17,    18,    19,    57,    58,    59,    60,
-      61,    62,    63,    64,    65,    66,    67,    57,    58,    59,
-      60,    61,    62,    63,    64,    65,    66,    67,    60,    61,
-      62,    63,    64,    65,    66,    67,    17,    18,    19,   456,
-      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    62,    63,
-      64,    65,    66,    67,    -1,    -1,   473,   474,   475,   476,
-     477,   478,   479,   480,   481,   482,   483,   484,   485,   486,
-      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,   496,
-      -1,    62,    63,    64,    65,    66,    67
+      49,    -1,    51,    52,    53,    54,    14,    15,    16,    17,
+      18,    19,    -1,    -1,    -1,    -1,    -1,    -1,    67,    27,
+      -1,    -1,    71,    -1,    73,    74,    -1,    -1,    -1,     1,
+      79,     3,     4,     5,     6,    -1,     8,     9,    10,    11,
+      12,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    20,    -1,
+      -1,    59,    60,    61,    62,    63,    64,    65,    66,    67,
+      68,    69,    70,    -1,    -1,    -1,    -1,    39,    40,    41,
+      42,    43,    44,    45,    -1,    47,    48,    49,    -1,    51,
+      52,    53,    54,    14,    15,    16,    17,    18,    19,    -1,
+      -1,    -1,    -1,    -1,    -1,    67,    -1,    -1,    -1,    71,
+      -1,    73,    -1,    -1,    -1,    -1,    -1,    79,    14,    15,
+      16,    17,    18,    19,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    59,    60,
+      61,    62,    63,    64,    65,    66,    67,    68,    69,    70,
+      -1,    -1,    -1,    -1,    -1,    76,    14,    15,    16,    17,
+      18,    19,    -1,    59,    60,    61,    62,    63,    64,    65,
+      66,    67,    68,    69,    70,    -1,    -1,    -1,    -1,    75,
+      14,    15,    16,    17,    18,    19,    -1,    -1,    -1,    -1,
+      -1,    14,    15,    -1,    17,    18,    19,    -1,    -1,    -1,
+      -1,    59,    60,    61,    62,    63,    64,    65,    66,    67,
+      68,    69,    70,    -1,    -1,    14,    -1,    75,    17,    18,
+      19,    -1,    -1,    -1,    -1,    59,    60,    61,    62,    63,
+      64,    65,    66,    67,    68,    69,    70,    60,    61,    62,
+      63,    64,    65,    66,    67,    68,    69,    70,    17,    18,
+      19,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    60,    61,    62,    63,    64,    65,    66,    67,    68,
+      69,    70,    17,    18,    19,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    60,    61,    62,    63,    64,    65,    66,    67,    68,
+      69,    70,    -1,    -1,    -1,    -1,    -1,    -1,    -1,   467,
+      -1,    -1,    -1,    -1,    -1,    60,    61,    62,    63,    64,
+      65,    66,    67,    68,    69,    70,   484,   485,   486,   487,
+     488,   489,   490,   491,   492,   493,   494,   495,   496,   497,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,   507
 };
 
 /* YYSTOS[STATE-NUM] -- The symbol kind of the accessing symbol of
    state STATE-NUM.  */
 static const yytype_uint8 yystos[] =
 {
-       0,    80,    81,     0,     7,    83,    89,    92,    93,    98,
-     109,   110,   109,    69,    82,     6,    38,    50,    72,   101,
-     102,   103,   112,    65,    86,   113,   114,     3,    70,   171,
-     172,     8,     9,    88,    46,     8,     9,    88,    69,    73,
-     171,    63,    69,     3,    74,    13,    90,    86,   113,    71,
-     171,    99,     1,     4,     5,     6,     8,     9,    10,    11,
+       0,    83,    84,     0,     7,    86,    92,    95,    96,   101,
+     112,   113,   112,    72,    85,     6,    38,    50,    75,   104,
+     105,   106,   115,    68,    89,   116,   117,     3,    73,   174,
+     175,     8,     9,    91,    46,     8,     9,    91,    72,    76,
+     174,    66,    72,     3,    77,    13,    93,    89,   116,    74,
+     174,   102,     1,     4,     5,     6,     8,     9,    10,    11,
       12,    20,    39,    40,    41,    42,    43,    44,    45,    47,
-      48,    49,    51,    52,    53,    64,    68,    70,    76,    84,
-      85,    88,   111,   147,   148,   156,   157,   158,   162,   164,
-     165,   166,   167,   170,   172,   175,   183,   184,    70,    88,
-      96,    13,    39,   160,    70,    39,    70,   156,   158,   156,
-     148,    88,   148,   150,   151,   152,   148,   153,   154,   155,
-     146,   148,   183,    70,   163,    70,   168,    70,    70,    74,
-     115,   148,   148,     6,    50,    65,   103,   146,    70,    39,
-     148,   156,    14,    15,    16,    17,    18,    19,    56,    57,
-      58,    59,    60,    61,    62,    63,    64,    65,    66,    67,
-      11,    12,    13,    72,    73,    36,    37,    77,    70,    70,
-       8,     9,   100,   103,   104,   106,   107,   108,    75,   103,
-     148,    88,    70,   178,    51,    88,    27,    75,    73,    72,
-      78,    73,    72,    73,   148,    70,   115,   161,   148,   161,
-      50,   177,   146,   116,     8,     9,   146,    86,    71,   159,
-      88,   148,   148,   148,   148,   148,   148,   148,   148,   148,
+      48,    49,    51,    52,    53,    54,    67,    71,    73,    79,
+      87,    88,    91,   114,   150,   151,   159,   160,   161,   165,
+     167,   168,   169,   170,   173,   175,   176,   178,   181,   189,
+     190,    73,    91,    99,    13,    39,   163,    73,    39,    73,
+     159,   161,   159,   151,    91,   151,   153,   154,   155,   151,
+     156,   157,   158,   149,   151,   189,    73,   166,    73,   171,
+      73,    73,    77,   118,   151,   151,   151,     6,    50,    68,
+     106,   149,    73,    39,   151,   159,    14,    15,    16,    17,
+      18,    19,    59,    60,    61,    62,    63,    64,    65,    66,
+      67,    68,    69,    70,    11,    12,    13,    75,    76,    36,
+      37,    80,   173,   176,    73,    73,     8,     9,   103,   106,
+     107,   109,   110,   111,    78,   106,   151,    91,    73,   184,
+      51,    91,    27,    78,    76,    75,    81,    76,    75,    76,
+     151,    73,   118,   164,   151,   164,    50,   183,   149,   119,
+      55,    56,   177,     8,     9,   149,    89,    74,   162,    91,
+     151,   151,   151,   151,   151,   151,   151,   151,   151,   151,
+     151,   151,   151,   151,   151,   151,   151,   151,   151,    74,
+     155,    91,    91,    65,   149,   182,   185,   150,    89,    74,
+      27,    76,   100,   110,   153,    74,   154,   151,    74,   158,
+      74,   151,    76,   149,    76,     8,     9,   153,    74,     1,
+      21,    23,    28,    29,    30,    31,    33,    34,    35,    72,
+     106,   118,   120,   127,   129,   130,   131,   133,   135,   139,
+     143,   149,   152,   191,   151,    74,    74,   149,    75,    75,
+      76,    73,   149,    26,    81,   153,   153,   103,    94,   109,
+      89,    97,    98,    74,    74,   151,    74,   151,   180,   180,
+      74,    72,    73,    73,    73,   134,    73,    73,    72,    72,
+      72,   149,   128,   129,    78,   129,    72,   177,    73,    74,
+     151,    74,   187,    26,    81,    65,    81,   149,    73,    74,
+      74,    75,   108,     1,    72,    90,   118,    91,    76,    72,
+     118,    76,   172,    76,    74,    76,    74,   129,   149,   149,
+     149,   130,   107,   124,   125,   141,   142,   149,     8,     9,
+     124,   137,   138,    72,    89,   123,   126,   188,   153,    65,
+      81,   149,   149,    81,   186,    42,    98,   159,    74,   151,
+      91,   179,    74,    74,    74,    28,    89,    13,    72,    76,
+      32,   103,    76,    72,   153,    74,   149,    81,    81,   153,
+     149,   172,   172,    75,   130,   144,   132,    73,   103,   151,
+     141,   137,   151,    13,   126,    74,    81,    74,    75,    74,
+     151,    22,   192,    77,   130,   149,    72,    74,   151,    74,
+     130,   121,    74,   141,   140,    24,    25,   106,   146,    72,
+      74,   130,     4,    20,    26,    67,    71,    73,   147,   148,
+     174,    75,   122,   130,   145,   146,   136,     4,   147,     4,
+       4,   148,    26,    75,    17,    18,    19,    60,    61,    62,
+      63,    64,    65,    66,    67,    68,    69,    70,   126,   145,
+      78,   145,   130,    75,    74,    75,   147,    73,   148,   148,
      148,   148,   148,   148,   148,   148,   148,   148,   148,   148,
-      71,   152,    88,    88,    62,   146,   176,   179,   147,    86,
-      71,    27,    73,    97,   107,   150,    71,   151,   148,    71,
-     155,    71,   148,    73,   146,    73,     8,     9,   150,    71,
-       1,    21,    23,    28,    29,    30,    31,    33,    34,    35,
-      69,   103,   115,   117,   124,   126,   127,   128,   130,   132,
-     136,   140,   146,   149,   185,    71,    71,   146,    72,    72,
-      73,    70,   146,    26,    78,   150,   150,   100,    91,   106,
-      86,    94,    95,    71,    71,   148,    71,   148,   174,   174,
-      71,    69,    70,    70,    70,   131,    70,    70,    69,    69,
-      69,   146,   125,   126,    75,   126,    69,    70,    71,   148,
-      71,   181,    26,    78,    62,    78,   146,    70,    71,    71,
-      72,   105,     1,    69,    87,   115,    88,    73,    69,   115,
-      73,   169,    73,    71,    73,    71,   126,   146,   146,   146,
-     127,   104,   121,   122,   138,   139,   146,     8,     9,   121,
-     134,   135,    69,    86,   120,   123,   182,   150,    62,    78,
-     146,   146,    78,   180,    42,    95,   156,    71,   148,    88,
-     173,    71,    71,    71,    28,    86,    13,    69,    73,    32,
-     100,    73,    69,   150,    71,   146,    78,    78,   150,   146,
-     169,   169,    72,   127,   141,   129,    70,   100,   148,   138,
-     134,   148,    13,   123,    71,    78,    71,    72,    71,   148,
-      22,   186,    74,   127,   146,    69,    71,   148,    71,   127,
-     118,    71,   138,   137,    24,    25,   103,   143,    69,    71,
-     127,     4,    20,    26,    64,    68,    70,   144,   145,   171,
-      72,   119,   127,   142,   143,   133,     4,   144,     4,     4,
-     145,    26,    72,    17,    18,    19,    57,    58,    59,    60,
-      61,    62,    63,    64,    65,    66,    67,   123,   142,    75,
-     142,   127,    72,    71,    72,   144,    70,   145,   145,   145,
-     145,   145,   145,   145,   145,   145,   145,   145,   145,   145,
-     145,    69,    72
+     148,   148,    72,    75
 };
 
 /* YYR1[RULE-NUM] -- Symbol kind of the left-hand side of rule RULE-NUM.  */
 static const yytype_uint8 yyr1[] =
 {
-       0,    79,    80,    81,    81,    82,    82,    83,    84,    85,
-      86,    86,    87,    87,    87,    88,    88,    90,    91,    89,
-      92,    92,    92,    92,    92,    93,    94,    95,    95,    96,
-      97,    96,    99,    98,   100,   100,   101,   101,   101,   102,
-     102,   103,   103,   104,   104,   105,   105,   106,   106,   106,
-     107,   107,   107,   108,   108,   109,   109,   110,   111,   112,
-     112,   113,   113,   114,   114,   116,   115,   117,   117,   117,
-     118,   119,   118,   120,   120,   121,   122,   123,   123,   125,
-     124,   126,   126,   126,   126,   127,   127,   127,   127,   127,
-     127,   127,   127,   127,   127,   129,   128,   131,   130,   133,
-     132,   134,   134,   134,   135,   135,   137,   136,   138,   138,
-     139,   139,   141,   140,   142,   142,   142,   143,   143,   143,
-     143,   143,   144,   144,   145,   145,   145,   145,   145,   145,
-     145,   145,   145,   145,   145,   145,   145,   145,   145,   145,
-     145,   145,   145,   146,   146,   147,   148,   148,   148,   148,
+       0,    82,    83,    84,    84,    85,    85,    86,    87,    88,
+      89,    89,    90,    90,    90,    91,    91,    93,    94,    92,
+      95,    95,    95,    95,    95,    96,    97,    98,    98,    99,
+     100,    99,   102,   101,   103,   103,   104,   104,   104,   105,
+     105,   106,   106,   107,   107,   108,   108,   109,   109,   109,
+     110,   110,   110,   111,   111,   112,   112,   113,   114,   115,
+     115,   116,   116,   117,   117,   119,   118,   120,   120,   120,
+     121,   122,   121,   123,   123,   124,   125,   126,   126,   128,
+     127,   129,   129,   129,   129,   130,   130,   130,   130,   130,
+     130,   130,   130,   130,   130,   132,   131,   134,   133,   136,
+     135,   137,   137,   137,   138,   138,   140,   139,   141,   141,
+     142,   142,   144,   143,   145,   145,   145,   146,   146,   146,
+     146,   146,   147,   147,   148,   148,   148,   148,   148,   148,
      148,   148,   148,   148,   148,   148,   148,   148,   148,   148,
-     148,   148,   148,   148,   148,   148,   148,   148,   148,   148,
-     148,   148,   148,   148,   148,   148,   148,   148,   148,   148,
-     148,   149,   149,   150,   150,   150,   151,   151,   152,   152,
-     153,   153,   153,   154,   154,   155,   156,   157,   157,   158,
-     158,   158,   158,   159,   158,   158,   158,   158,   158,   158,
-     158,   158,   158,   158,   158,   158,   158,   158,   158,   160,
-     158,   158,   158,   158,   158,   158,   161,   161,   163,   162,
-     164,   164,   165,   166,   168,   167,   169,   169,   170,   171,
-     171,   171,   172,   172,   173,   174,   174,   176,   175,   177,
-     175,   175,   175,   178,   175,   179,   175,   180,   175,   181,
-     175,   182,   175,   183,   183,   184,   184,   184,   184,   185,
-     186,   186
+     148,   148,   148,   149,   149,   150,   151,   151,   151,   151,
+     151,   151,   151,   151,   151,   151,   151,   151,   151,   151,
+     151,   151,   151,   151,   151,   151,   151,   151,   151,   151,
+     151,   151,   151,   151,   151,   151,   151,   151,   151,   151,
+     151,   152,   152,   153,   153,   153,   154,   154,   155,   155,
+     156,   156,   156,   157,   157,   158,   159,   160,   160,   161,
+     161,   161,   161,   162,   161,   161,   161,   161,   161,   161,
+     161,   161,   161,   161,   161,   161,   161,   161,   161,   163,
+     161,   161,   161,   161,   161,   161,   164,   164,   166,   165,
+     167,   167,   168,   169,   171,   170,   172,   172,   173,   174,
+     174,   174,   175,   175,   176,   177,   177,   178,   178,   178,
+     178,   179,   180,   180,   182,   181,   183,   181,   181,   181,
+     184,   181,   185,   181,   186,   181,   187,   181,   188,   181,
+     189,   189,   190,   190,   190,   190,   191,   192,   192
 };
 
 /* YYR2[RULE-NUM] -- Number of symbols on the right-hand side of rule RULE-NUM.  */
@@ -1417,10 +1446,10 @@ static const yytype_int8 yyr2[] =
        7,     5,     6,     5,     4,     1,     3,     1,     1,     0,
        6,     3,     5,     4,     4,     4,     1,     3,     0,     3,
        2,     4,     7,     9,     0,     3,     0,     3,     1,     1,
-       3,     3,     1,     2,     3,     0,     3,     0,     5,     0,
-       5,     6,     6,     0,     5,     0,     5,     0,     8,     0,
-       7,     0,     8,     3,     3,     1,     2,     3,     3,     6,
-       0,     2
+       3,     3,     1,     2,     3,     1,     3,     1,     1,     2,
+       2,     3,     0,     3,     0,     5,     0,     5,     6,     6,
+       0,     5,     0,     5,     0,     8,     0,     7,     0,     8,
+       3,     3,     1,     2,     3,     3,     6,     0,     2
 };
 
 
@@ -2365,118 +2394,118 @@ yyreduce:
     switch (yyn)
       {
   case 2: /* all: program  */
-#line 219 "/projects/git/fluffos/src/compiler/internal/grammar.y"
+#line 223 "/projects/git/fluffos/src/compiler/internal/grammar.y"
           { rule_program((yyval.node)); }
-#line 2371 "/projects/git/fluffos/build/src/grammar.autogen.cc"
+#line 2400 "/projects/git/fluffos/build/src/grammar.autogen.cc"
     break;
 
   case 3: /* program: program def possible_semi_colon  */
-#line 223 "/projects/git/fluffos/src/compiler/internal/grammar.y"
+#line 227 "/projects/git/fluffos/src/compiler/internal/grammar.y"
                                   { CREATE_TWO_VALUES((yyval.node), 0, (yyvsp[-2].node), (yyvsp[-1].node)); }
-#line 2377 "/projects/git/fluffos/build/src/grammar.autogen.cc"
+#line 2406 "/projects/git/fluffos/build/src/grammar.autogen.cc"
     break;
 
   case 4: /* program: %empty  */
-#line 224 "/projects/git/fluffos/src/compiler/internal/grammar.y"
+#line 228 "/projects/git/fluffos/src/compiler/internal/grammar.y"
                         { (yyval.node) = 0; }
-#line 2383 "/projects/git/fluffos/build/src/grammar.autogen.cc"
+#line 2412 "/projects/git/fluffos/build/src/grammar.autogen.cc"
     break;
 
   case 6: /* possible_semi_colon: ';'  */
-#line 229 "/projects/git/fluffos/src/compiler/internal/grammar.y"
+#line 233 "/projects/git/fluffos/src/compiler/internal/grammar.y"
         { yywarn("Extra ';'. Ignored."); }
-#line 2389 "/projects/git/fluffos/build/src/grammar.autogen.cc"
+#line 2418 "/projects/git/fluffos/build/src/grammar.autogen.cc"
     break;
 
   case 7: /* inheritance: type_modifier_list L_INHERIT string_con1 ';'  */
-#line 233 "/projects/git/fluffos/src/compiler/internal/grammar.y"
+#line 237 "/projects/git/fluffos/src/compiler/internal/grammar.y"
                                                { if (rule_inheritence(&(yyval.node), (yyvsp[-3].number), (yyvsp[-1].string))) { YYACCEPT; } }
-#line 2395 "/projects/git/fluffos/build/src/grammar.autogen.cc"
+#line 2424 "/projects/git/fluffos/build/src/grammar.autogen.cc"
     break;
 
   case 8: /* real: L_REAL  */
-#line 237 "/projects/git/fluffos/src/compiler/internal/grammar.y"
+#line 241 "/projects/git/fluffos/src/compiler/internal/grammar.y"
          { CREATE_REAL((yyval.node), (yyvsp[0].real)); }
-#line 2401 "/projects/git/fluffos/build/src/grammar.autogen.cc"
+#line 2430 "/projects/git/fluffos/build/src/grammar.autogen.cc"
     break;
 
   case 9: /* number: L_NUMBER  */
-#line 241 "/projects/git/fluffos/src/compiler/internal/grammar.y"
+#line 245 "/projects/git/fluffos/src/compiler/internal/grammar.y"
            { CREATE_NUMBER((yyval.node), (yyvsp[0].number)); }
-#line 2407 "/projects/git/fluffos/build/src/grammar.autogen.cc"
+#line 2436 "/projects/git/fluffos/build/src/grammar.autogen.cc"
     break;
 
   case 10: /* optional_star: %empty  */
-#line 245 "/projects/git/fluffos/src/compiler/internal/grammar.y"
+#line 249 "/projects/git/fluffos/src/compiler/internal/grammar.y"
                         { (yyval.number) = 0; }
-#line 2413 "/projects/git/fluffos/build/src/grammar.autogen.cc"
+#line 2442 "/projects/git/fluffos/build/src/grammar.autogen.cc"
     break;
 
   case 11: /* optional_star: '*'  */
-#line 246 "/projects/git/fluffos/src/compiler/internal/grammar.y"
+#line 250 "/projects/git/fluffos/src/compiler/internal/grammar.y"
                 { (yyval.number) = TYPE_MOD_ARRAY; }
-#line 2419 "/projects/git/fluffos/build/src/grammar.autogen.cc"
+#line 2448 "/projects/git/fluffos/build/src/grammar.autogen.cc"
     break;
 
   case 12: /* block_or_semi: block  */
-#line 251 "/projects/git/fluffos/src/compiler/internal/grammar.y"
+#line 255 "/projects/git/fluffos/src/compiler/internal/grammar.y"
           {
             (yyval.node) = (yyvsp[0].decl).node;
             if (!(yyval.node)) {
               CREATE_RETURN((yyval.node), 0);
             }
           }
-#line 2430 "/projects/git/fluffos/build/src/grammar.autogen.cc"
+#line 2459 "/projects/git/fluffos/build/src/grammar.autogen.cc"
     break;
 
   case 13: /* block_or_semi: ';'  */
-#line 257 "/projects/git/fluffos/src/compiler/internal/grammar.y"
+#line 261 "/projects/git/fluffos/src/compiler/internal/grammar.y"
           { (yyval.node) = 0; }
-#line 2436 "/projects/git/fluffos/build/src/grammar.autogen.cc"
+#line 2465 "/projects/git/fluffos/build/src/grammar.autogen.cc"
     break;
 
   case 14: /* block_or_semi: error  */
-#line 258 "/projects/git/fluffos/src/compiler/internal/grammar.y"
+#line 262 "/projects/git/fluffos/src/compiler/internal/grammar.y"
           { (yyval.node) = 0; }
-#line 2442 "/projects/git/fluffos/build/src/grammar.autogen.cc"
+#line 2471 "/projects/git/fluffos/build/src/grammar.autogen.cc"
     break;
 
   case 15: /* identifier: L_DEFINED_NAME  */
-#line 262 "/projects/git/fluffos/src/compiler/internal/grammar.y"
+#line 266 "/projects/git/fluffos/src/compiler/internal/grammar.y"
                                   { (yyval.string) = scratch_copy((yyvsp[0].ihe)->name); }
-#line 2448 "/projects/git/fluffos/build/src/grammar.autogen.cc"
+#line 2477 "/projects/git/fluffos/build/src/grammar.autogen.cc"
     break;
 
   case 17: /* $@1: %empty  */
-#line 267 "/projects/git/fluffos/src/compiler/internal/grammar.y"
+#line 271 "/projects/git/fluffos/src/compiler/internal/grammar.y"
                                   { (yyvsp[-2].number) = rule_func_type((yyvsp[-2].number), (yyvsp[-1].number), (yyvsp[0].string)); }
-#line 2454 "/projects/git/fluffos/build/src/grammar.autogen.cc"
+#line 2483 "/projects/git/fluffos/build/src/grammar.autogen.cc"
     break;
 
   case 18: /* @2: %empty  */
-#line 268 "/projects/git/fluffos/src/compiler/internal/grammar.y"
+#line 272 "/projects/git/fluffos/src/compiler/internal/grammar.y"
                                   { (yyval.number) = rule_func_proto((yyvsp[-6].number), (yyvsp[-5].number), &(yyvsp[-4].string), (yyvsp[-1].argument)); }
-#line 2460 "/projects/git/fluffos/build/src/grammar.autogen.cc"
+#line 2489 "/projects/git/fluffos/build/src/grammar.autogen.cc"
     break;
 
   case 19: /* function: type optional_star identifier $@1 '(' argument ')' @2 block_or_semi  */
-#line 269 "/projects/git/fluffos/src/compiler/internal/grammar.y"
+#line 273 "/projects/git/fluffos/src/compiler/internal/grammar.y"
                                   { rule_func(&(yyval.node), (yyvsp[-8].number), (yyvsp[-7].number), (yyvsp[-6].string), (yyvsp[-3].argument), &(yyvsp[-1].number), &(yyvsp[0].node)); }
-#line 2466 "/projects/git/fluffos/build/src/grammar.autogen.cc"
+#line 2495 "/projects/git/fluffos/build/src/grammar.autogen.cc"
     break;
 
   case 21: /* def: type name_list ';'  */
-#line 275 "/projects/git/fluffos/src/compiler/internal/grammar.y"
+#line 279 "/projects/git/fluffos/src/compiler/internal/grammar.y"
                                   {
                                     if (!((yyvsp[-2].number) & ~(DECL_MODS)) && (pragmas & PRAGMA_STRICT_TYPES))
                                       yyerror("Missing type for global variable declaration");
                                     (yyval.node) = 0;
                                   }
-#line 2476 "/projects/git/fluffos/build/src/grammar.autogen.cc"
+#line 2505 "/projects/git/fluffos/build/src/grammar.autogen.cc"
     break;
 
   case 25: /* modifier_change: type_modifier_list ':'  */
-#line 287 "/projects/git/fluffos/src/compiler/internal/grammar.y"
+#line 291 "/projects/git/fluffos/src/compiler/internal/grammar.y"
                                   {
                                     if (!(yyvsp[-1].number))
                                       yyerror("modifier list may not be empty.");
@@ -2490,11 +2519,11 @@ yyreduce:
                                     global_modifiers = (yyvsp[-1].number);
                                     (yyval.node) = 0;
                                   }
-#line 2494 "/projects/git/fluffos/build/src/grammar.autogen.cc"
+#line 2523 "/projects/git/fluffos/build/src/grammar.autogen.cc"
     break;
 
   case 26: /* member_name: optional_star identifier  */
-#line 304 "/projects/git/fluffos/src/compiler/internal/grammar.y"
+#line 308 "/projects/git/fluffos/src/compiler/internal/grammar.y"
                                   {
                                     /* At this point, the current_type here is only a basic_type */
                                     /* and cannot be unused yet - Sym */
@@ -2504,40 +2533,40 @@ yyreduce:
                                     add_local_name((yyvsp[0].string), current_type | (yyvsp[-1].number));
                                     scratch_free((yyvsp[0].string));
                                   }
-#line 2508 "/projects/git/fluffos/build/src/grammar.autogen.cc"
+#line 2537 "/projects/git/fluffos/build/src/grammar.autogen.cc"
     break;
 
   case 30: /* $@3: %empty  */
-#line 322 "/projects/git/fluffos/src/compiler/internal/grammar.y"
+#line 326 "/projects/git/fluffos/src/compiler/internal/grammar.y"
                            { current_type = (yyvsp[0].number); }
-#line 2514 "/projects/git/fluffos/build/src/grammar.autogen.cc"
+#line 2543 "/projects/git/fluffos/build/src/grammar.autogen.cc"
     break;
 
   case 32: /* @4: %empty  */
-#line 327 "/projects/git/fluffos/src/compiler/internal/grammar.y"
+#line 331 "/projects/git/fluffos/src/compiler/internal/grammar.y"
                                              { (yyvsp[-2].ihe) = rule_define_class(&(yyval.number), (yyvsp[-1].string)); }
-#line 2520 "/projects/git/fluffos/build/src/grammar.autogen.cc"
+#line 2549 "/projects/git/fluffos/build/src/grammar.autogen.cc"
     break;
 
   case 33: /* type_decl: type_modifier_list L_CLASS identifier '{' @4 member_list '}'  */
-#line 328 "/projects/git/fluffos/src/compiler/internal/grammar.y"
+#line 332 "/projects/git/fluffos/src/compiler/internal/grammar.y"
                                              { rule_define_class_members((yyvsp[-5].ihe), (yyvsp[-2].number)); (yyval.node) = 0; }
-#line 2526 "/projects/git/fluffos/build/src/grammar.autogen.cc"
+#line 2555 "/projects/git/fluffos/build/src/grammar.autogen.cc"
     break;
 
   case 35: /* new_local_name: L_DEFINED_NAME  */
-#line 334 "/projects/git/fluffos/src/compiler/internal/grammar.y"
+#line 338 "/projects/git/fluffos/src/compiler/internal/grammar.y"
                                             {
                                               if ((yyvsp[0].ihe)->dn.local_num != -1) {
                                                 yyerror("Illegal to redeclare local name '%s'", (yyvsp[0].ihe)->name);
                                               }
                                               (yyval.string) = scratch_copy((yyvsp[0].ihe)->name);
                                             }
-#line 2537 "/projects/git/fluffos/build/src/grammar.autogen.cc"
+#line 2566 "/projects/git/fluffos/build/src/grammar.autogen.cc"
     break;
 
   case 37: /* atomic_type: L_CLASS L_DEFINED_NAME  */
-#line 345 "/projects/git/fluffos/src/compiler/internal/grammar.y"
+#line 349 "/projects/git/fluffos/src/compiler/internal/grammar.y"
                                             {
                                               if ((yyvsp[0].ihe)->dn.class_num == -1) {
                                                 yyerror("Undefined class '%s'", (yyvsp[0].ihe)->name);
@@ -2546,44 +2575,44 @@ yyreduce:
                                                 (yyval.number) = (yyvsp[0].ihe)->dn.class_num | TYPE_MOD_CLASS;
                                               }
                                             }
-#line 2550 "/projects/git/fluffos/build/src/grammar.autogen.cc"
+#line 2579 "/projects/git/fluffos/build/src/grammar.autogen.cc"
     break;
 
   case 38: /* atomic_type: L_CLASS L_IDENTIFIER  */
-#line 354 "/projects/git/fluffos/src/compiler/internal/grammar.y"
+#line 358 "/projects/git/fluffos/src/compiler/internal/grammar.y"
                                             {
                                               yyerror("Undefined class '%s'", (yyvsp[0].string));
                                               (yyval.number) = TYPE_ANY;
                                             }
-#line 2559 "/projects/git/fluffos/build/src/grammar.autogen.cc"
+#line 2588 "/projects/git/fluffos/build/src/grammar.autogen.cc"
     break;
 
   case 40: /* opt_atomic_type: %empty  */
-#line 362 "/projects/git/fluffos/src/compiler/internal/grammar.y"
+#line 366 "/projects/git/fluffos/src/compiler/internal/grammar.y"
                         { (yyval.number) = TYPE_ANY; }
-#line 2565 "/projects/git/fluffos/build/src/grammar.autogen.cc"
+#line 2594 "/projects/git/fluffos/build/src/grammar.autogen.cc"
     break;
 
   case 42: /* basic_type: opt_atomic_type L_ARRAY  */
-#line 367 "/projects/git/fluffos/src/compiler/internal/grammar.y"
+#line 371 "/projects/git/fluffos/src/compiler/internal/grammar.y"
                             { (yyval.number) = (yyvsp[-1].number) | TYPE_MOD_ARRAY; }
-#line 2571 "/projects/git/fluffos/build/src/grammar.autogen.cc"
+#line 2600 "/projects/git/fluffos/build/src/grammar.autogen.cc"
     break;
 
   case 44: /* arg_type: basic_type ref  */
-#line 372 "/projects/git/fluffos/src/compiler/internal/grammar.y"
+#line 376 "/projects/git/fluffos/src/compiler/internal/grammar.y"
                    { (yyval.number) = (yyvsp[-1].number) | LOCAL_MOD_REF; }
-#line 2577 "/projects/git/fluffos/build/src/grammar.autogen.cc"
+#line 2606 "/projects/git/fluffos/build/src/grammar.autogen.cc"
     break;
 
   case 45: /* optional_default_arg_value: %empty  */
-#line 376 "/projects/git/fluffos/src/compiler/internal/grammar.y"
+#line 380 "/projects/git/fluffos/src/compiler/internal/grammar.y"
          { (yyval.node) = 0; }
-#line 2583 "/projects/git/fluffos/build/src/grammar.autogen.cc"
+#line 2612 "/projects/git/fluffos/build/src/grammar.autogen.cc"
     break;
 
   case 46: /* optional_default_arg_value: ':' L_FUNCTION_OPEN comma_expr ':' ')'  */
-#line 377 "/projects/git/fluffos/src/compiler/internal/grammar.y"
+#line 381 "/projects/git/fluffos/src/compiler/internal/grammar.y"
                                           {
     if (CONFIG_INT(__RC_WOMBLES__)) {
         if(*(outp-2) != ':') {
@@ -2603,21 +2632,21 @@ yyreduce:
     (yyval.node)->v.number = FP_FUNCTIONAL + 0 /* args */;
     pop_function_context();
 }
-#line 2607 "/projects/git/fluffos/build/src/grammar.autogen.cc"
+#line 2636 "/projects/git/fluffos/build/src/grammar.autogen.cc"
     break;
 
   case 47: /* new_arg: arg_type optional_star  */
-#line 399 "/projects/git/fluffos/src/compiler/internal/grammar.y"
+#line 403 "/projects/git/fluffos/src/compiler/internal/grammar.y"
                                               {
                                                 (yyval.number) = (yyvsp[-1].number) | (yyvsp[0].number);
                                                 if ((yyvsp[-1].number) != TYPE_VOID)
                                                   add_local_name("", (yyvsp[-1].number) | (yyvsp[0].number));
                                               }
-#line 2617 "/projects/git/fluffos/build/src/grammar.autogen.cc"
+#line 2646 "/projects/git/fluffos/build/src/grammar.autogen.cc"
     break;
 
   case 48: /* new_arg: arg_type optional_star new_local_name optional_default_arg_value  */
-#line 405 "/projects/git/fluffos/src/compiler/internal/grammar.y"
+#line 409 "/projects/git/fluffos/src/compiler/internal/grammar.y"
                                               {
                                                 if ((yyvsp[-3].number) == TYPE_VOID)
                                                   yyerror("Illegal to declare argument of type void.");
@@ -2625,11 +2654,11 @@ yyreduce:
                                                 scratch_free((yyvsp[-1].string));
                                                 (yyval.number) = (yyvsp[-3].number) | (yyvsp[-2].number);
                                               }
-#line 2629 "/projects/git/fluffos/build/src/grammar.autogen.cc"
+#line 2658 "/projects/git/fluffos/build/src/grammar.autogen.cc"
     break;
 
   case 49: /* new_arg: new_local_name  */
-#line 413 "/projects/git/fluffos/src/compiler/internal/grammar.y"
+#line 417 "/projects/git/fluffos/src/compiler/internal/grammar.y"
                                               {
                                                 if (exact_types) {
                                                   yyerror("Missing type for argument");
@@ -2638,20 +2667,20 @@ yyreduce:
                                                 scratch_free((yyvsp[0].string));
                                                 (yyval.number) = TYPE_ANY;
                                               }
-#line 2642 "/projects/git/fluffos/build/src/grammar.autogen.cc"
+#line 2671 "/projects/git/fluffos/build/src/grammar.autogen.cc"
     break;
 
   case 50: /* argument: %empty  */
-#line 425 "/projects/git/fluffos/src/compiler/internal/grammar.y"
+#line 429 "/projects/git/fluffos/src/compiler/internal/grammar.y"
             {
       (yyval.argument).num_arg = 0;
       (yyval.argument).flags = 0;
     }
-#line 2651 "/projects/git/fluffos/build/src/grammar.autogen.cc"
+#line 2680 "/projects/git/fluffos/build/src/grammar.autogen.cc"
     break;
 
   case 52: /* argument: argument_list L_DOT_DOT_DOT  */
-#line 431 "/projects/git/fluffos/src/compiler/internal/grammar.y"
+#line 435 "/projects/git/fluffos/src/compiler/internal/grammar.y"
     {
       int x = type_of_locals_ptr[max_num_locals-1];
       int lt = x & ~LOCAL_MODS;
@@ -2666,11 +2695,11 @@ yyreduce:
       if (lt != TYPE_ANY && !(lt & TYPE_MOD_ARRAY))
         yywarn("Variable to hold remainder of arguments should be an array.");
     }
-#line 2670 "/projects/git/fluffos/build/src/grammar.autogen.cc"
+#line 2699 "/projects/git/fluffos/build/src/grammar.autogen.cc"
     break;
 
   case 53: /* argument_list: new_arg  */
-#line 449 "/projects/git/fluffos/src/compiler/internal/grammar.y"
+#line 453 "/projects/git/fluffos/src/compiler/internal/grammar.y"
     {
       if (((yyvsp[0].number) & TYPE_MASK) == TYPE_VOID && !((yyvsp[0].number) & TYPE_MOD_CLASS)) {
         if ((yyvsp[0].number) & ~TYPE_MASK)
@@ -2681,11 +2710,11 @@ yyreduce:
       }
       (yyval.argument).flags = 0;
     }
-#line 2685 "/projects/git/fluffos/build/src/grammar.autogen.cc"
+#line 2714 "/projects/git/fluffos/build/src/grammar.autogen.cc"
     break;
 
   case 54: /* argument_list: argument_list ',' new_arg  */
-#line 460 "/projects/git/fluffos/src/compiler/internal/grammar.y"
+#line 464 "/projects/git/fluffos/src/compiler/internal/grammar.y"
     {
       if (!(yyval.argument).num_arg)    /* first arg was void w/no name */
         yyerror("argument of type void must be the only argument.");
@@ -2695,19 +2724,19 @@ yyreduce:
       (yyval.argument) = (yyvsp[-2].argument);
       (yyval.argument).num_arg++;
     }
-#line 2699 "/projects/git/fluffos/build/src/grammar.autogen.cc"
+#line 2728 "/projects/git/fluffos/build/src/grammar.autogen.cc"
     break;
 
   case 55: /* type_modifier_list: %empty  */
-#line 473 "/projects/git/fluffos/src/compiler/internal/grammar.y"
+#line 477 "/projects/git/fluffos/src/compiler/internal/grammar.y"
             {
       (yyval.number) = 0;
     }
-#line 2707 "/projects/git/fluffos/build/src/grammar.autogen.cc"
+#line 2736 "/projects/git/fluffos/build/src/grammar.autogen.cc"
     break;
 
   case 56: /* type_modifier_list: L_TYPE_MODIFIER type_modifier_list  */
-#line 477 "/projects/git/fluffos/src/compiler/internal/grammar.y"
+#line 481 "/projects/git/fluffos/src/compiler/internal/grammar.y"
     {
       (yyval.number) = (yyvsp[-1].number) | (yyvsp[0].number);
       int acc_mod = (yyval.number) & DECL_ACCESS;
@@ -2721,36 +2750,36 @@ yyreduce:
       }
 #endif
     }
-#line 2725 "/projects/git/fluffos/build/src/grammar.autogen.cc"
+#line 2754 "/projects/git/fluffos/build/src/grammar.autogen.cc"
     break;
 
   case 57: /* type: type_modifier_list opt_basic_type  */
-#line 494 "/projects/git/fluffos/src/compiler/internal/grammar.y"
+#line 498 "/projects/git/fluffos/src/compiler/internal/grammar.y"
     {
       (yyval.number) = ((yyvsp[-1].number) << 16) | (yyvsp[0].number);
       current_type = (yyval.number);
     }
-#line 2734 "/projects/git/fluffos/build/src/grammar.autogen.cc"
+#line 2763 "/projects/git/fluffos/build/src/grammar.autogen.cc"
     break;
 
   case 58: /* cast: '(' basic_type optional_star ')'  */
-#line 502 "/projects/git/fluffos/src/compiler/internal/grammar.y"
+#line 506 "/projects/git/fluffos/src/compiler/internal/grammar.y"
     {
       (yyval.number) = (yyvsp[-2].number) | (yyvsp[-1].number);
     }
-#line 2742 "/projects/git/fluffos/build/src/grammar.autogen.cc"
+#line 2771 "/projects/git/fluffos/build/src/grammar.autogen.cc"
     break;
 
   case 60: /* opt_basic_type: %empty  */
-#line 510 "/projects/git/fluffos/src/compiler/internal/grammar.y"
+#line 514 "/projects/git/fluffos/src/compiler/internal/grammar.y"
             {
       (yyval.number) = TYPE_UNKNOWN;
     }
-#line 2750 "/projects/git/fluffos/build/src/grammar.autogen.cc"
+#line 2779 "/projects/git/fluffos/build/src/grammar.autogen.cc"
     break;
 
   case 63: /* new_name: optional_star identifier  */
-#line 522 "/projects/git/fluffos/src/compiler/internal/grammar.y"
+#line 526 "/projects/git/fluffos/src/compiler/internal/grammar.y"
     {
       if (current_type & (FUNC_VARARGS << 16)){
         yyerror("Illegal to declare varargs variable.");
@@ -2775,11 +2804,11 @@ yyreduce:
       define_new_variable((yyvsp[0].string), current_type | (yyvsp[-1].number));
       scratch_free((yyvsp[0].string));
     }
-#line 2779 "/projects/git/fluffos/build/src/grammar.autogen.cc"
+#line 2808 "/projects/git/fluffos/build/src/grammar.autogen.cc"
     break;
 
   case 64: /* new_name: optional_star identifier L_ASSIGN expr0  */
-#line 547 "/projects/git/fluffos/src/compiler/internal/grammar.y"
+#line 551 "/projects/git/fluffos/src/compiler/internal/grammar.y"
     {
       parse_node_t *expr, *newnode;
       int type;
@@ -2831,35 +2860,35 @@ yyreduce:
           newnode, expr);
       scratch_free((yyvsp[-2].string));
     }
-#line 2835 "/projects/git/fluffos/build/src/grammar.autogen.cc"
+#line 2864 "/projects/git/fluffos/build/src/grammar.autogen.cc"
     break;
 
   case 65: /* @5: %empty  */
-#line 602 "/projects/git/fluffos/src/compiler/internal/grammar.y"
+#line 606 "/projects/git/fluffos/src/compiler/internal/grammar.y"
     { (yyval.number) = current_number_of_locals; }
-#line 2841 "/projects/git/fluffos/build/src/grammar.autogen.cc"
+#line 2870 "/projects/git/fluffos/build/src/grammar.autogen.cc"
     break;
 
   case 66: /* block: '{' @5 block_statements '}'  */
-#line 604 "/projects/git/fluffos/src/compiler/internal/grammar.y"
+#line 608 "/projects/git/fluffos/src/compiler/internal/grammar.y"
     {
       (yyval.decl).node = (yyvsp[-1].decl).node;
       (yyval.decl).num = current_number_of_locals - (yyvsp[-2].number);  /* calculate locals declared in this block */
     }
-#line 2850 "/projects/git/fluffos/build/src/grammar.autogen.cc"
+#line 2879 "/projects/git/fluffos/build/src/grammar.autogen.cc"
     break;
 
   case 70: /* local_declarations: %empty  */
-#line 614 "/projects/git/fluffos/src/compiler/internal/grammar.y"
+#line 618 "/projects/git/fluffos/src/compiler/internal/grammar.y"
             {
       (yyval.decl).node = 0;
       (yyval.decl).num = 0;
     }
-#line 2859 "/projects/git/fluffos/build/src/grammar.autogen.cc"
+#line 2888 "/projects/git/fluffos/build/src/grammar.autogen.cc"
     break;
 
   case 71: /* $@6: %empty  */
-#line 619 "/projects/git/fluffos/src/compiler/internal/grammar.y"
+#line 623 "/projects/git/fluffos/src/compiler/internal/grammar.y"
     {
       if ((yyvsp[0].number) == TYPE_VOID)
         yyerror("Illegal to declare local variable of type void.");
@@ -2868,22 +2897,22 @@ yyreduce:
        */
       current_type = (yyvsp[0].number);
     }
-#line 2872 "/projects/git/fluffos/build/src/grammar.autogen.cc"
+#line 2901 "/projects/git/fluffos/build/src/grammar.autogen.cc"
     break;
 
   case 72: /* local_declarations: local_declarations basic_type $@6 local_name_list ';'  */
-#line 628 "/projects/git/fluffos/src/compiler/internal/grammar.y"
+#line 632 "/projects/git/fluffos/src/compiler/internal/grammar.y"
     {
       if ((yyvsp[-4].decl).node && (yyvsp[-1].decl).node) {
         CREATE_STATEMENTS((yyval.decl).node, (yyvsp[-4].decl).node, (yyvsp[-1].decl).node);
       } else (yyval.decl).node = ((yyvsp[-4].decl).node ? (yyvsp[-4].decl).node : (yyvsp[-1].decl).node);
       (yyval.decl).num = (yyvsp[-4].decl).num + (yyvsp[-1].decl).num;
     }
-#line 2883 "/projects/git/fluffos/build/src/grammar.autogen.cc"
+#line 2912 "/projects/git/fluffos/build/src/grammar.autogen.cc"
     break;
 
   case 73: /* new_local_def: optional_star new_local_name  */
-#line 638 "/projects/git/fluffos/src/compiler/internal/grammar.y"
+#line 642 "/projects/git/fluffos/src/compiler/internal/grammar.y"
     {
       if (current_type & LOCAL_MOD_REF) {
         yyerror("Illegal to declare local variable as reference");
@@ -2894,11 +2923,11 @@ yyreduce:
       scratch_free((yyvsp[0].string));
       (yyval.node) = 0;
     }
-#line 2898 "/projects/git/fluffos/build/src/grammar.autogen.cc"
+#line 2927 "/projects/git/fluffos/build/src/grammar.autogen.cc"
     break;
 
   case 74: /* new_local_def: optional_star new_local_name L_ASSIGN expr0  */
-#line 649 "/projects/git/fluffos/src/compiler/internal/grammar.y"
+#line 653 "/projects/git/fluffos/src/compiler/internal/grammar.y"
     {
       int type = (current_type | (yyvsp[-3].number)) & ~DECL_MODS;
 
@@ -2929,11 +2958,11 @@ yyreduce:
           add_local_name((yyvsp[-2].string), current_type | (yyvsp[-3].number) | LOCAL_MOD_UNUSED));
       scratch_free((yyvsp[-2].string));
     }
-#line 2933 "/projects/git/fluffos/build/src/grammar.autogen.cc"
+#line 2962 "/projects/git/fluffos/build/src/grammar.autogen.cc"
     break;
 
   case 75: /* single_new_local_def: arg_type optional_star new_local_name  */
-#line 683 "/projects/git/fluffos/src/compiler/internal/grammar.y"
+#line 687 "/projects/git/fluffos/src/compiler/internal/grammar.y"
     {
       if ((yyvsp[-2].number) == TYPE_VOID)
         yyerror("Illegal to declare local variable of type void.");
@@ -2941,11 +2970,11 @@ yyreduce:
       (yyval.number) = add_local_name((yyvsp[0].string), (yyvsp[-2].number) | (yyvsp[-1].number));
       scratch_free((yyvsp[0].string));
     }
-#line 2945 "/projects/git/fluffos/build/src/grammar.autogen.cc"
+#line 2974 "/projects/git/fluffos/build/src/grammar.autogen.cc"
     break;
 
   case 76: /* single_new_local_def_with_init: single_new_local_def L_ASSIGN expr0  */
-#line 694 "/projects/git/fluffos/src/compiler/internal/grammar.y"
+#line 698 "/projects/git/fluffos/src/compiler/internal/grammar.y"
     {
       int type = type_of_locals_ptr[(yyvsp[-2].number)];
 
@@ -2974,90 +3003,90 @@ yyreduce:
       CREATE_BINARY_OP((yyval.node), F_ASSIGN, 0, (yyvsp[0].node), 0);
       CREATE_OPCODE_1((yyval.node)->r.expr, F_LOCAL_LVALUE, 0, (yyvsp[-2].number));
     }
-#line 2978 "/projects/git/fluffos/build/src/grammar.autogen.cc"
+#line 3007 "/projects/git/fluffos/build/src/grammar.autogen.cc"
     break;
 
   case 77: /* local_name_list: new_local_def  */
-#line 726 "/projects/git/fluffos/src/compiler/internal/grammar.y"
+#line 730 "/projects/git/fluffos/src/compiler/internal/grammar.y"
     {
       (yyval.decl).node = (yyvsp[0].node);
       (yyval.decl).num = 1;
     }
-#line 2987 "/projects/git/fluffos/build/src/grammar.autogen.cc"
+#line 3016 "/projects/git/fluffos/build/src/grammar.autogen.cc"
     break;
 
   case 78: /* local_name_list: new_local_def ',' local_name_list  */
-#line 731 "/projects/git/fluffos/src/compiler/internal/grammar.y"
+#line 735 "/projects/git/fluffos/src/compiler/internal/grammar.y"
     {
       if ((yyvsp[-2].node) && (yyvsp[0].decl).node) {
         CREATE_STATEMENTS((yyval.decl).node, (yyvsp[-2].node), (yyvsp[0].decl).node);
       } else (yyval.decl).node = ((yyvsp[-2].node) ? (yyvsp[-2].node) : (yyvsp[0].decl).node);
       (yyval.decl).num = 1 + (yyvsp[0].decl).num;
     }
-#line 2998 "/projects/git/fluffos/build/src/grammar.autogen.cc"
+#line 3027 "/projects/git/fluffos/build/src/grammar.autogen.cc"
     break;
 
   case 79: /* $@7: %empty  */
-#line 741 "/projects/git/fluffos/src/compiler/internal/grammar.y"
+#line 745 "/projects/git/fluffos/src/compiler/internal/grammar.y"
     {
       if ((yyvsp[0].number) == TYPE_VOID)
         yyerror("Illegal to declare local variable of type void.");
       current_type = (yyvsp[0].number);
     }
-#line 3008 "/projects/git/fluffos/build/src/grammar.autogen.cc"
+#line 3037 "/projects/git/fluffos/build/src/grammar.autogen.cc"
     break;
 
   case 80: /* local_declaration_statement: basic_type $@7 local_name_list ';'  */
-#line 747 "/projects/git/fluffos/src/compiler/internal/grammar.y"
+#line 751 "/projects/git/fluffos/src/compiler/internal/grammar.y"
     {
       (yyval.decl).node = (yyvsp[-1].decl).node;
       (yyval.decl).num = (yyvsp[-1].decl).num;
     }
-#line 3017 "/projects/git/fluffos/build/src/grammar.autogen.cc"
+#line 3046 "/projects/git/fluffos/build/src/grammar.autogen.cc"
     break;
 
   case 81: /* block_statements: %empty  */
-#line 755 "/projects/git/fluffos/src/compiler/internal/grammar.y"
+#line 759 "/projects/git/fluffos/src/compiler/internal/grammar.y"
             {
       (yyval.decl).node = 0;
       (yyval.decl).num = 0;
     }
-#line 3026 "/projects/git/fluffos/build/src/grammar.autogen.cc"
+#line 3055 "/projects/git/fluffos/build/src/grammar.autogen.cc"
     break;
 
   case 82: /* block_statements: statement block_statements  */
-#line 760 "/projects/git/fluffos/src/compiler/internal/grammar.y"
+#line 764 "/projects/git/fluffos/src/compiler/internal/grammar.y"
     {
       if ((yyvsp[-1].node) && (yyvsp[0].decl).node) {
         CREATE_STATEMENTS((yyval.decl).node, (yyvsp[-1].node), (yyvsp[0].decl).node);
       } else (yyval.decl).node = ((yyvsp[-1].node) ? (yyvsp[-1].node) : (yyvsp[0].decl).node);
       (yyval.decl).num = (yyvsp[0].decl).num;
     }
-#line 3037 "/projects/git/fluffos/build/src/grammar.autogen.cc"
+#line 3066 "/projects/git/fluffos/build/src/grammar.autogen.cc"
     break;
 
   case 83: /* block_statements: local_declaration_statement block_statements  */
-#line 767 "/projects/git/fluffos/src/compiler/internal/grammar.y"
+#line 771 "/projects/git/fluffos/src/compiler/internal/grammar.y"
     {
       if ((yyvsp[-1].decl).node && (yyvsp[0].decl).node) {
         CREATE_STATEMENTS((yyval.decl).node, (yyvsp[-1].decl).node, (yyvsp[0].decl).node);
       } else (yyval.decl).node = ((yyvsp[-1].decl).node ? (yyvsp[-1].decl).node : (yyvsp[0].decl).node);
       (yyval.decl).num = (yyvsp[-1].decl).num + (yyvsp[0].decl).num;
     }
-#line 3048 "/projects/git/fluffos/build/src/grammar.autogen.cc"
+#line 3077 "/projects/git/fluffos/build/src/grammar.autogen.cc"
     break;
 
   case 84: /* block_statements: error ';' block_statements  */
-#line 774 "/projects/git/fluffos/src/compiler/internal/grammar.y"
+#line 778 "/projects/git/fluffos/src/compiler/internal/grammar.y"
     {
       (yyval.decl).node = (yyvsp[0].decl).node;
       (yyval.decl).num = (yyvsp[0].decl).num;
     }
-#line 3057 "/projects/git/fluffos/build/src/grammar.autogen.cc"
+#line 3086 "/projects/git/fluffos/build/src/grammar.autogen.cc"
     break;
 
   case 85: /* statement: comma_expr ';'  */
-#line 782 "/projects/git/fluffos/src/compiler/internal/grammar.y"
+#line 786 "/projects/git/fluffos/src/compiler/internal/grammar.y"
     {
       (yyval.node) = pop_value((yyvsp[-1].node));
 #ifdef DEBUG
@@ -3069,28 +3098,28 @@ yyreduce:
       }
 #endif
     }
-#line 3073 "/projects/git/fluffos/build/src/grammar.autogen.cc"
+#line 3102 "/projects/git/fluffos/build/src/grammar.autogen.cc"
     break;
 
   case 91: /* statement: decl_block  */
-#line 799 "/projects/git/fluffos/src/compiler/internal/grammar.y"
+#line 803 "/projects/git/fluffos/src/compiler/internal/grammar.y"
     {
       (yyval.node) = (yyvsp[0].decl).node;
       pop_n_locals((yyvsp[0].decl).num);
     }
-#line 3082 "/projects/git/fluffos/build/src/grammar.autogen.cc"
+#line 3111 "/projects/git/fluffos/build/src/grammar.autogen.cc"
     break;
 
   case 92: /* statement: ';'  */
-#line 804 "/projects/git/fluffos/src/compiler/internal/grammar.y"
+#line 808 "/projects/git/fluffos/src/compiler/internal/grammar.y"
     {
       (yyval.node) = 0;
     }
-#line 3090 "/projects/git/fluffos/build/src/grammar.autogen.cc"
+#line 3119 "/projects/git/fluffos/build/src/grammar.autogen.cc"
     break;
 
   case 93: /* statement: L_BREAK ';'  */
-#line 808 "/projects/git/fluffos/src/compiler/internal/grammar.y"
+#line 812 "/projects/git/fluffos/src/compiler/internal/grammar.y"
     {
       if (context & SPECIAL_CONTEXT) {
         yyerror("Cannot break out of catch { } or time_expression { }");
@@ -3112,11 +3141,11 @@ yyreduce:
             (yyval.node) = 0;
           }
     }
-#line 3116 "/projects/git/fluffos/build/src/grammar.autogen.cc"
+#line 3145 "/projects/git/fluffos/build/src/grammar.autogen.cc"
     break;
 
   case 94: /* statement: L_CONTINUE ';'  */
-#line 830 "/projects/git/fluffos/src/compiler/internal/grammar.y"
+#line 834 "/projects/git/fluffos/src/compiler/internal/grammar.y"
     {
       if (context & SPECIAL_CONTEXT)
         yyerror("Cannot continue out of catch { } or time_expression { }");
@@ -3125,57 +3154,57 @@ yyreduce:
           yyerror("continue statement outside loop");
       CREATE_CONTROL_JUMP((yyval.node), CJ_CONTINUE);
     }
-#line 3129 "/projects/git/fluffos/build/src/grammar.autogen.cc"
+#line 3158 "/projects/git/fluffos/build/src/grammar.autogen.cc"
     break;
 
   case 95: /* $@8: %empty  */
-#line 842 "/projects/git/fluffos/src/compiler/internal/grammar.y"
+#line 846 "/projects/git/fluffos/src/compiler/internal/grammar.y"
     {
       (yyvsp[-3].number) = context;
       context = LOOP_CONTEXT;
     }
-#line 3138 "/projects/git/fluffos/build/src/grammar.autogen.cc"
+#line 3167 "/projects/git/fluffos/build/src/grammar.autogen.cc"
     break;
 
   case 96: /* while: L_WHILE '(' comma_expr ')' $@8 statement  */
-#line 847 "/projects/git/fluffos/src/compiler/internal/grammar.y"
+#line 851 "/projects/git/fluffos/src/compiler/internal/grammar.y"
     {
       CREATE_LOOP((yyval.node), 1, (yyvsp[0].node), 0, optimize_loop_test((yyvsp[-3].node)));
       context = (yyvsp[-5].number);
     }
-#line 3147 "/projects/git/fluffos/build/src/grammar.autogen.cc"
+#line 3176 "/projects/git/fluffos/build/src/grammar.autogen.cc"
     break;
 
   case 97: /* $@9: %empty  */
-#line 855 "/projects/git/fluffos/src/compiler/internal/grammar.y"
+#line 859 "/projects/git/fluffos/src/compiler/internal/grammar.y"
     {
       (yyvsp[0].number) = context;
       context = LOOP_CONTEXT;
     }
-#line 3156 "/projects/git/fluffos/build/src/grammar.autogen.cc"
+#line 3185 "/projects/git/fluffos/build/src/grammar.autogen.cc"
     break;
 
   case 98: /* do: L_DO $@9 statement L_WHILE '(' comma_expr ')' ';'  */
-#line 860 "/projects/git/fluffos/src/compiler/internal/grammar.y"
+#line 864 "/projects/git/fluffos/src/compiler/internal/grammar.y"
     {
       CREATE_LOOP((yyval.node), 0, (yyvsp[-5].node), 0, optimize_loop_test((yyvsp[-2].node)));
       context = (yyvsp[-7].number);
     }
-#line 3165 "/projects/git/fluffos/build/src/grammar.autogen.cc"
+#line 3194 "/projects/git/fluffos/build/src/grammar.autogen.cc"
     break;
 
   case 99: /* $@10: %empty  */
-#line 868 "/projects/git/fluffos/src/compiler/internal/grammar.y"
+#line 872 "/projects/git/fluffos/src/compiler/internal/grammar.y"
     {
       (yyvsp[-5].decl).node = pop_value((yyvsp[-5].decl).node);
       (yyvsp[-7].number) = context;
       context = LOOP_CONTEXT;
     }
-#line 3175 "/projects/git/fluffos/build/src/grammar.autogen.cc"
+#line 3204 "/projects/git/fluffos/build/src/grammar.autogen.cc"
     break;
 
   case 100: /* for: L_FOR '(' first_for_expr ';' for_expr ';' for_expr ')' $@10 statement  */
-#line 874 "/projects/git/fluffos/src/compiler/internal/grammar.y"
+#line 878 "/projects/git/fluffos/src/compiler/internal/grammar.y"
     {
       (yyval.decl).num = (yyvsp[-7].decl).num; /* number of declarations (0/1) */
 
@@ -3191,11 +3220,11 @@ yyreduce:
 
       context = (yyvsp[-9].number);
     }
-#line 3195 "/projects/git/fluffos/build/src/grammar.autogen.cc"
+#line 3224 "/projects/git/fluffos/build/src/grammar.autogen.cc"
     break;
 
   case 101: /* foreach_var: L_DEFINED_NAME  */
-#line 893 "/projects/git/fluffos/src/compiler/internal/grammar.y"
+#line 897 "/projects/git/fluffos/src/compiler/internal/grammar.y"
     {
       if ((yyvsp[0].ihe)->dn.local_num != -1) {
         CREATE_OPCODE_1((yyval.decl).node, F_LOCAL_LVALUE, 0, (yyvsp[0].ihe)->dn.local_num);
@@ -3216,11 +3245,11 @@ yyreduce:
         }
       (yyval.decl).num = 0;
     }
-#line 3220 "/projects/git/fluffos/build/src/grammar.autogen.cc"
+#line 3249 "/projects/git/fluffos/build/src/grammar.autogen.cc"
     break;
 
   case 102: /* foreach_var: single_new_local_def  */
-#line 914 "/projects/git/fluffos/src/compiler/internal/grammar.y"
+#line 918 "/projects/git/fluffos/src/compiler/internal/grammar.y"
     {
       if (type_of_locals_ptr[(yyvsp[0].number)] & LOCAL_MOD_REF) {
         CREATE_OPCODE_1((yyval.decl).node, F_REF_LVALUE, 0, (yyvsp[0].number));
@@ -3230,11 +3259,11 @@ yyreduce:
       }
       (yyval.decl).num = 1;
     }
-#line 3234 "/projects/git/fluffos/build/src/grammar.autogen.cc"
+#line 3263 "/projects/git/fluffos/build/src/grammar.autogen.cc"
     break;
 
   case 103: /* foreach_var: L_IDENTIFIER  */
-#line 924 "/projects/git/fluffos/src/compiler/internal/grammar.y"
+#line 928 "/projects/git/fluffos/src/compiler/internal/grammar.y"
     {
       char buf[256];
       char *end = EndOf(buf);
@@ -3248,41 +3277,41 @@ yyreduce:
       scratch_free((yyvsp[0].string));
       (yyval.decl).num = 0;
     }
-#line 3252 "/projects/git/fluffos/build/src/grammar.autogen.cc"
+#line 3281 "/projects/git/fluffos/build/src/grammar.autogen.cc"
     break;
 
   case 104: /* foreach_vars: foreach_var  */
-#line 941 "/projects/git/fluffos/src/compiler/internal/grammar.y"
+#line 945 "/projects/git/fluffos/src/compiler/internal/grammar.y"
     {
       CREATE_FOREACH((yyval.decl).node, (yyvsp[0].decl).node, 0);
       (yyval.decl).num = (yyvsp[0].decl).num;
     }
-#line 3261 "/projects/git/fluffos/build/src/grammar.autogen.cc"
+#line 3290 "/projects/git/fluffos/build/src/grammar.autogen.cc"
     break;
 
   case 105: /* foreach_vars: foreach_var ',' foreach_var  */
-#line 946 "/projects/git/fluffos/src/compiler/internal/grammar.y"
+#line 950 "/projects/git/fluffos/src/compiler/internal/grammar.y"
     {
       CREATE_FOREACH((yyval.decl).node, (yyvsp[-2].decl).node, (yyvsp[0].decl).node);
       (yyval.decl).num = (yyvsp[-2].decl).num + (yyvsp[0].decl).num;
       if ((yyvsp[-2].decl).node->v.number == F_REF_LVALUE)
         yyerror("Mapping key may not be a reference in foreach()");
     }
-#line 3272 "/projects/git/fluffos/build/src/grammar.autogen.cc"
+#line 3301 "/projects/git/fluffos/build/src/grammar.autogen.cc"
     break;
 
   case 106: /* $@11: %empty  */
-#line 956 "/projects/git/fluffos/src/compiler/internal/grammar.y"
+#line 960 "/projects/git/fluffos/src/compiler/internal/grammar.y"
     {
       (yyvsp[-3].decl).node->v.expr = (yyvsp[-1].node);
       (yyvsp[-5].number) = context;
       context = LOOP_CONTEXT | LOOP_FOREACH;
     }
-#line 3282 "/projects/git/fluffos/build/src/grammar.autogen.cc"
+#line 3311 "/projects/git/fluffos/build/src/grammar.autogen.cc"
     break;
 
   case 107: /* foreach: L_FOREACH '(' foreach_vars L_IN expr0 ')' $@11 statement  */
-#line 962 "/projects/git/fluffos/src/compiler/internal/grammar.y"
+#line 966 "/projects/git/fluffos/src/compiler/internal/grammar.y"
     {
       (yyval.decl).num = (yyvsp[-5].decl).num;
 
@@ -3292,48 +3321,48 @@ yyreduce:
 
       context = (yyvsp[-7].number);
     }
-#line 3296 "/projects/git/fluffos/build/src/grammar.autogen.cc"
+#line 3325 "/projects/git/fluffos/build/src/grammar.autogen.cc"
     break;
 
   case 108: /* for_expr: %empty  */
-#line 975 "/projects/git/fluffos/src/compiler/internal/grammar.y"
+#line 979 "/projects/git/fluffos/src/compiler/internal/grammar.y"
             {
       (yyval.node) = 0;
     }
-#line 3304 "/projects/git/fluffos/build/src/grammar.autogen.cc"
+#line 3333 "/projects/git/fluffos/build/src/grammar.autogen.cc"
     break;
 
   case 110: /* first_for_expr: for_expr  */
-#line 983 "/projects/git/fluffos/src/compiler/internal/grammar.y"
+#line 987 "/projects/git/fluffos/src/compiler/internal/grammar.y"
     {
       (yyval.decl).node = (yyvsp[0].node);
       (yyval.decl).num = 0;
     }
-#line 3313 "/projects/git/fluffos/build/src/grammar.autogen.cc"
+#line 3342 "/projects/git/fluffos/build/src/grammar.autogen.cc"
     break;
 
   case 111: /* first_for_expr: single_new_local_def_with_init  */
-#line 988 "/projects/git/fluffos/src/compiler/internal/grammar.y"
+#line 992 "/projects/git/fluffos/src/compiler/internal/grammar.y"
     {
       (yyval.decl).node = (yyvsp[0].node);
       (yyval.decl).num = 1;
     }
-#line 3322 "/projects/git/fluffos/build/src/grammar.autogen.cc"
+#line 3351 "/projects/git/fluffos/build/src/grammar.autogen.cc"
     break;
 
   case 112: /* $@12: %empty  */
-#line 996 "/projects/git/fluffos/src/compiler/internal/grammar.y"
+#line 1000 "/projects/git/fluffos/src/compiler/internal/grammar.y"
     {
       (yyvsp[-3].number) = context;
       context &= LOOP_CONTEXT;
       context |= SWITCH_CONTEXT;
       (yyvsp[-2].number) = mem_block[A_CASES].current_size;
     }
-#line 3333 "/projects/git/fluffos/build/src/grammar.autogen.cc"
+#line 3362 "/projects/git/fluffos/build/src/grammar.autogen.cc"
     break;
 
   case 113: /* switch: L_SWITCH '(' comma_expr ')' $@12 '{' local_declarations case switch_block '}'  */
-#line 1003 "/projects/git/fluffos/src/compiler/internal/grammar.y"
+#line 1007 "/projects/git/fluffos/src/compiler/internal/grammar.y"
       {
         parse_node_t *node1, *node2;
 
@@ -3362,50 +3391,50 @@ yyreduce:
         (yyval.node) = node2;
         pop_n_locals((yyvsp[-3].decl).num);
       }
-#line 3366 "/projects/git/fluffos/build/src/grammar.autogen.cc"
+#line 3395 "/projects/git/fluffos/build/src/grammar.autogen.cc"
     break;
 
   case 114: /* switch_block: case switch_block  */
-#line 1035 "/projects/git/fluffos/src/compiler/internal/grammar.y"
+#line 1039 "/projects/git/fluffos/src/compiler/internal/grammar.y"
     {
       if ((yyvsp[0].node)){
         CREATE_STATEMENTS((yyval.node), (yyvsp[-1].node), (yyvsp[0].node));
       } else (yyval.node) = (yyvsp[-1].node);
     }
-#line 3376 "/projects/git/fluffos/build/src/grammar.autogen.cc"
+#line 3405 "/projects/git/fluffos/build/src/grammar.autogen.cc"
     break;
 
   case 115: /* switch_block: statement switch_block  */
-#line 1041 "/projects/git/fluffos/src/compiler/internal/grammar.y"
+#line 1045 "/projects/git/fluffos/src/compiler/internal/grammar.y"
     {
       if ((yyvsp[0].node)){
         CREATE_STATEMENTS((yyval.node), (yyvsp[-1].node), (yyvsp[0].node));
       } else (yyval.node) = (yyvsp[-1].node);
     }
-#line 3386 "/projects/git/fluffos/build/src/grammar.autogen.cc"
+#line 3415 "/projects/git/fluffos/build/src/grammar.autogen.cc"
     break;
 
   case 116: /* switch_block: %empty  */
-#line 1047 "/projects/git/fluffos/src/compiler/internal/grammar.y"
+#line 1051 "/projects/git/fluffos/src/compiler/internal/grammar.y"
             {
       (yyval.node) = 0;
     }
-#line 3394 "/projects/git/fluffos/build/src/grammar.autogen.cc"
+#line 3423 "/projects/git/fluffos/build/src/grammar.autogen.cc"
     break;
 
   case 117: /* case: L_CASE case_label ':'  */
-#line 1054 "/projects/git/fluffos/src/compiler/internal/grammar.y"
+#line 1058 "/projects/git/fluffos/src/compiler/internal/grammar.y"
     {
       (yyval.node) = (yyvsp[-1].node);
       (yyval.node)->v.expr = 0;
 
       add_to_mem_block(A_CASES, (char *)&((yyvsp[-1].node)), sizeof((yyvsp[-1].node)));
     }
-#line 3405 "/projects/git/fluffos/build/src/grammar.autogen.cc"
+#line 3434 "/projects/git/fluffos/build/src/grammar.autogen.cc"
     break;
 
   case 118: /* case: L_CASE case_label L_RANGE case_label ':'  */
-#line 1061 "/projects/git/fluffos/src/compiler/internal/grammar.y"
+#line 1065 "/projects/git/fluffos/src/compiler/internal/grammar.y"
     {
       if ( (yyvsp[-3].node)->kind != NODE_CASE_NUMBER
           || (yyvsp[-1].node)->kind != NODE_CASE_NUMBER )
@@ -3419,11 +3448,11 @@ yyreduce:
 
       add_to_mem_block(A_CASES, (char *)&((yyvsp[-3].node)), sizeof((yyvsp[-3].node)));
     }
-#line 3423 "/projects/git/fluffos/build/src/grammar.autogen.cc"
+#line 3452 "/projects/git/fluffos/build/src/grammar.autogen.cc"
     break;
 
   case 119: /* case: L_CASE case_label L_RANGE ':'  */
-#line 1075 "/projects/git/fluffos/src/compiler/internal/grammar.y"
+#line 1079 "/projects/git/fluffos/src/compiler/internal/grammar.y"
     {
       if ( (yyvsp[-2].node)->kind != NODE_CASE_NUMBER )
         yyerror("String case labels not allowed as range bounds");
@@ -3437,11 +3466,11 @@ yyreduce:
 
       add_to_mem_block(A_CASES, (char *)&((yyvsp[-2].node)), sizeof((yyvsp[-2].node)));
     }
-#line 3441 "/projects/git/fluffos/build/src/grammar.autogen.cc"
+#line 3470 "/projects/git/fluffos/build/src/grammar.autogen.cc"
     break;
 
   case 120: /* case: L_CASE L_RANGE case_label ':'  */
-#line 1089 "/projects/git/fluffos/src/compiler/internal/grammar.y"
+#line 1093 "/projects/git/fluffos/src/compiler/internal/grammar.y"
     {
       if ( (yyvsp[-1].node)->kind != NODE_CASE_NUMBER )
         yyerror("String case labels not allowed as range bounds");
@@ -3454,11 +3483,11 @@ yyreduce:
 
       add_to_mem_block(A_CASES, (char *)&((yyval.node)), sizeof((yyval.node)));
     }
-#line 3458 "/projects/git/fluffos/build/src/grammar.autogen.cc"
+#line 3487 "/projects/git/fluffos/build/src/grammar.autogen.cc"
     break;
 
   case 121: /* case: L_DEFAULT ':'  */
-#line 1102 "/projects/git/fluffos/src/compiler/internal/grammar.y"
+#line 1106 "/projects/git/fluffos/src/compiler/internal/grammar.y"
     {
       if (context & SWITCH_DEFAULT) {
         yyerror("Duplicate default");
@@ -3471,11 +3500,11 @@ yyreduce:
       add_to_mem_block(A_CASES, (char *)&((yyval.node)), sizeof((yyval.node)));
       context |= SWITCH_DEFAULT;
     }
-#line 3475 "/projects/git/fluffos/build/src/grammar.autogen.cc"
+#line 3504 "/projects/git/fluffos/build/src/grammar.autogen.cc"
     break;
 
   case 122: /* case_label: constant  */
-#line 1118 "/projects/git/fluffos/src/compiler/internal/grammar.y"
+#line 1122 "/projects/git/fluffos/src/compiler/internal/grammar.y"
     {
       if ((context & SWITCH_STRINGS) && (yyvsp[0].number))
         yyerror("Mixed case label list not allowed");
@@ -3489,11 +3518,11 @@ yyreduce:
       (yyval.node)->kind = NODE_CASE_NUMBER;
       (yyval.node)->r.number = (LPC_INT)(yyvsp[0].number);
     }
-#line 3493 "/projects/git/fluffos/build/src/grammar.autogen.cc"
+#line 3522 "/projects/git/fluffos/build/src/grammar.autogen.cc"
     break;
 
   case 123: /* case_label: string_con1  */
-#line 1132 "/projects/git/fluffos/src/compiler/internal/grammar.y"
+#line 1136 "/projects/git/fluffos/src/compiler/internal/grammar.y"
     {
       POINTER_INT str;
       str = store_prog_string((yyvsp[0].string));
@@ -3505,51 +3534,51 @@ yyreduce:
       (yyval.node)->kind = NODE_CASE_STRING;
       (yyval.node)->r.number = (LPC_INT)str;
     }
-#line 3509 "/projects/git/fluffos/build/src/grammar.autogen.cc"
+#line 3538 "/projects/git/fluffos/build/src/grammar.autogen.cc"
     break;
 
   case 124: /* constant: constant '|' constant  */
-#line 1147 "/projects/git/fluffos/src/compiler/internal/grammar.y"
+#line 1151 "/projects/git/fluffos/src/compiler/internal/grammar.y"
     {
       (yyval.number) = (yyvsp[-2].number) | (yyvsp[0].number);
     }
-#line 3517 "/projects/git/fluffos/build/src/grammar.autogen.cc"
+#line 3546 "/projects/git/fluffos/build/src/grammar.autogen.cc"
     break;
 
   case 125: /* constant: constant '^' constant  */
-#line 1151 "/projects/git/fluffos/src/compiler/internal/grammar.y"
+#line 1155 "/projects/git/fluffos/src/compiler/internal/grammar.y"
     {
       (yyval.number) = (yyvsp[-2].number) ^ (yyvsp[0].number);
     }
-#line 3525 "/projects/git/fluffos/build/src/grammar.autogen.cc"
+#line 3554 "/projects/git/fluffos/build/src/grammar.autogen.cc"
     break;
 
   case 126: /* constant: constant '&' constant  */
-#line 1155 "/projects/git/fluffos/src/compiler/internal/grammar.y"
+#line 1159 "/projects/git/fluffos/src/compiler/internal/grammar.y"
     {
       (yyval.number) = (yyvsp[-2].number) & (yyvsp[0].number);
     }
-#line 3533 "/projects/git/fluffos/build/src/grammar.autogen.cc"
+#line 3562 "/projects/git/fluffos/build/src/grammar.autogen.cc"
     break;
 
   case 127: /* constant: constant L_EQ constant  */
-#line 1159 "/projects/git/fluffos/src/compiler/internal/grammar.y"
+#line 1163 "/projects/git/fluffos/src/compiler/internal/grammar.y"
     {
       (yyval.number) = (yyvsp[-2].number) == (yyvsp[0].number);
     }
-#line 3541 "/projects/git/fluffos/build/src/grammar.autogen.cc"
+#line 3570 "/projects/git/fluffos/build/src/grammar.autogen.cc"
     break;
 
   case 128: /* constant: constant L_NE constant  */
-#line 1163 "/projects/git/fluffos/src/compiler/internal/grammar.y"
+#line 1167 "/projects/git/fluffos/src/compiler/internal/grammar.y"
     {
       (yyval.number) = (yyvsp[-2].number) != (yyvsp[0].number);
     }
-#line 3549 "/projects/git/fluffos/build/src/grammar.autogen.cc"
+#line 3578 "/projects/git/fluffos/build/src/grammar.autogen.cc"
     break;
 
   case 129: /* constant: constant L_ORDER constant  */
-#line 1167 "/projects/git/fluffos/src/compiler/internal/grammar.y"
+#line 1171 "/projects/git/fluffos/src/compiler/internal/grammar.y"
     {
       switch((yyvsp[-1].number)){
         case F_GE: (yyval.number) = (yyvsp[-2].number) >= (yyvsp[0].number); break;
@@ -3557,131 +3586,131 @@ yyreduce:
         case F_GT: (yyval.number) = (yyvsp[-2].number) >  (yyvsp[0].number); break;
       }
     }
-#line 3561 "/projects/git/fluffos/build/src/grammar.autogen.cc"
+#line 3590 "/projects/git/fluffos/build/src/grammar.autogen.cc"
     break;
 
   case 130: /* constant: constant '<' constant  */
-#line 1175 "/projects/git/fluffos/src/compiler/internal/grammar.y"
+#line 1179 "/projects/git/fluffos/src/compiler/internal/grammar.y"
     {
       (yyval.number) = (yyvsp[-2].number) < (yyvsp[0].number);
     }
-#line 3569 "/projects/git/fluffos/build/src/grammar.autogen.cc"
+#line 3598 "/projects/git/fluffos/build/src/grammar.autogen.cc"
     break;
 
   case 131: /* constant: constant L_LSH constant  */
-#line 1179 "/projects/git/fluffos/src/compiler/internal/grammar.y"
+#line 1183 "/projects/git/fluffos/src/compiler/internal/grammar.y"
     {
       (yyval.number) = (yyvsp[-2].number) << (yyvsp[0].number);
     }
-#line 3577 "/projects/git/fluffos/build/src/grammar.autogen.cc"
+#line 3606 "/projects/git/fluffos/build/src/grammar.autogen.cc"
     break;
 
   case 132: /* constant: constant L_RSH constant  */
-#line 1183 "/projects/git/fluffos/src/compiler/internal/grammar.y"
+#line 1187 "/projects/git/fluffos/src/compiler/internal/grammar.y"
     {
       (yyval.number) = (yyvsp[-2].number) >> (yyvsp[0].number);
     }
-#line 3585 "/projects/git/fluffos/build/src/grammar.autogen.cc"
+#line 3614 "/projects/git/fluffos/build/src/grammar.autogen.cc"
     break;
 
   case 133: /* constant: constant '+' constant  */
-#line 1187 "/projects/git/fluffos/src/compiler/internal/grammar.y"
+#line 1191 "/projects/git/fluffos/src/compiler/internal/grammar.y"
     {
       (yyval.number) = (yyvsp[-2].number) + (yyvsp[0].number);
     }
-#line 3593 "/projects/git/fluffos/build/src/grammar.autogen.cc"
+#line 3622 "/projects/git/fluffos/build/src/grammar.autogen.cc"
     break;
 
   case 134: /* constant: constant '-' constant  */
-#line 1191 "/projects/git/fluffos/src/compiler/internal/grammar.y"
+#line 1195 "/projects/git/fluffos/src/compiler/internal/grammar.y"
     {
       (yyval.number) = (yyvsp[-2].number) - (yyvsp[0].number);
     }
-#line 3601 "/projects/git/fluffos/build/src/grammar.autogen.cc"
+#line 3630 "/projects/git/fluffos/build/src/grammar.autogen.cc"
     break;
 
   case 135: /* constant: constant '*' constant  */
-#line 1195 "/projects/git/fluffos/src/compiler/internal/grammar.y"
+#line 1199 "/projects/git/fluffos/src/compiler/internal/grammar.y"
     {
       (yyval.number) = (yyvsp[-2].number) * (yyvsp[0].number);
     }
-#line 3609 "/projects/git/fluffos/build/src/grammar.autogen.cc"
+#line 3638 "/projects/git/fluffos/build/src/grammar.autogen.cc"
     break;
 
   case 136: /* constant: constant '%' constant  */
-#line 1199 "/projects/git/fluffos/src/compiler/internal/grammar.y"
+#line 1203 "/projects/git/fluffos/src/compiler/internal/grammar.y"
     {
       if ((yyvsp[0].number)) (yyval.number) = (yyvsp[-2].number) % (yyvsp[0].number); else yyerror("Modulo by zero");
     }
-#line 3617 "/projects/git/fluffos/build/src/grammar.autogen.cc"
+#line 3646 "/projects/git/fluffos/build/src/grammar.autogen.cc"
     break;
 
   case 137: /* constant: constant '/' constant  */
-#line 1203 "/projects/git/fluffos/src/compiler/internal/grammar.y"
+#line 1207 "/projects/git/fluffos/src/compiler/internal/grammar.y"
     {
       if ((yyvsp[0].number)) (yyval.number) = (yyvsp[-2].number) / (yyvsp[0].number); else yyerror("Division by zero");
     }
-#line 3625 "/projects/git/fluffos/build/src/grammar.autogen.cc"
+#line 3654 "/projects/git/fluffos/build/src/grammar.autogen.cc"
     break;
 
   case 138: /* constant: '(' constant ')'  */
-#line 1207 "/projects/git/fluffos/src/compiler/internal/grammar.y"
+#line 1211 "/projects/git/fluffos/src/compiler/internal/grammar.y"
     {
       (yyval.number) = (yyvsp[-1].number);
     }
-#line 3633 "/projects/git/fluffos/build/src/grammar.autogen.cc"
+#line 3662 "/projects/git/fluffos/build/src/grammar.autogen.cc"
     break;
 
   case 139: /* constant: L_NUMBER  */
-#line 1211 "/projects/git/fluffos/src/compiler/internal/grammar.y"
+#line 1215 "/projects/git/fluffos/src/compiler/internal/grammar.y"
     {
       (yyval.number) = (yyvsp[0].number);
     }
-#line 3641 "/projects/git/fluffos/build/src/grammar.autogen.cc"
+#line 3670 "/projects/git/fluffos/build/src/grammar.autogen.cc"
     break;
 
   case 140: /* constant: '-' L_NUMBER  */
-#line 1215 "/projects/git/fluffos/src/compiler/internal/grammar.y"
+#line 1219 "/projects/git/fluffos/src/compiler/internal/grammar.y"
     {
       (yyval.number) = -(yyvsp[0].number);
     }
-#line 3649 "/projects/git/fluffos/build/src/grammar.autogen.cc"
+#line 3678 "/projects/git/fluffos/build/src/grammar.autogen.cc"
     break;
 
   case 141: /* constant: L_NOT L_NUMBER  */
-#line 1219 "/projects/git/fluffos/src/compiler/internal/grammar.y"
+#line 1223 "/projects/git/fluffos/src/compiler/internal/grammar.y"
     {
       (yyval.number) = !(yyvsp[0].number);
     }
-#line 3657 "/projects/git/fluffos/build/src/grammar.autogen.cc"
+#line 3686 "/projects/git/fluffos/build/src/grammar.autogen.cc"
     break;
 
   case 142: /* constant: '~' L_NUMBER  */
-#line 1223 "/projects/git/fluffos/src/compiler/internal/grammar.y"
+#line 1227 "/projects/git/fluffos/src/compiler/internal/grammar.y"
     {
       (yyval.number) = ~(yyvsp[0].number);
     }
-#line 3665 "/projects/git/fluffos/build/src/grammar.autogen.cc"
+#line 3694 "/projects/git/fluffos/build/src/grammar.autogen.cc"
     break;
 
   case 143: /* comma_expr: expr0  */
-#line 1230 "/projects/git/fluffos/src/compiler/internal/grammar.y"
+#line 1234 "/projects/git/fluffos/src/compiler/internal/grammar.y"
     {
       (yyval.node) = (yyvsp[0].node);
     }
-#line 3673 "/projects/git/fluffos/build/src/grammar.autogen.cc"
+#line 3702 "/projects/git/fluffos/build/src/grammar.autogen.cc"
     break;
 
   case 144: /* comma_expr: comma_expr ',' expr0  */
-#line 1234 "/projects/git/fluffos/src/compiler/internal/grammar.y"
+#line 1238 "/projects/git/fluffos/src/compiler/internal/grammar.y"
     {
       CREATE_TWO_VALUES((yyval.node), (yyvsp[0].node)->type, pop_value((yyvsp[-2].node)), (yyvsp[0].node));
     }
-#line 3681 "/projects/git/fluffos/build/src/grammar.autogen.cc"
+#line 3710 "/projects/git/fluffos/build/src/grammar.autogen.cc"
     break;
 
   case 146: /* expr0: ref lvalue  */
-#line 1245 "/projects/git/fluffos/src/compiler/internal/grammar.y"
+#line 1249 "/projects/git/fluffos/src/compiler/internal/grammar.y"
     {
       int op;
 
@@ -3708,11 +3737,11 @@ yyreduce:
       }
       CREATE_UNARY_OP_1((yyval.node), F_MAKE_REF, TYPE_ANY, (yyvsp[0].node), op);
     }
-#line 3712 "/projects/git/fluffos/build/src/grammar.autogen.cc"
+#line 3741 "/projects/git/fluffos/build/src/grammar.autogen.cc"
     break;
 
   case 147: /* expr0: lvalue L_ASSIGN expr0  */
-#line 1272 "/projects/git/fluffos/src/compiler/internal/grammar.y"
+#line 1276 "/projects/git/fluffos/src/compiler/internal/grammar.y"
     {
       parse_node_t *l = (yyvsp[-2].node), *r = (yyvsp[0].node);
       int opcode = (yyvsp[-1].number);
@@ -3752,20 +3781,20 @@ yyreduce:
           (yyval.node)->l.expr = do_promotions(r, l->type);
       }
     }
-#line 3756 "/projects/git/fluffos/build/src/grammar.autogen.cc"
+#line 3785 "/projects/git/fluffos/build/src/grammar.autogen.cc"
     break;
 
   case 148: /* expr0: error L_ASSIGN expr0  */
-#line 1312 "/projects/git/fluffos/src/compiler/internal/grammar.y"
+#line 1316 "/projects/git/fluffos/src/compiler/internal/grammar.y"
     {
       yyerror("Illegal LHS");
       CREATE_ERROR((yyval.node));
     }
-#line 3765 "/projects/git/fluffos/build/src/grammar.autogen.cc"
+#line 3794 "/projects/git/fluffos/build/src/grammar.autogen.cc"
     break;
 
   case 149: /* expr0: expr0 '?' expr0 ':' expr0  */
-#line 1317 "/projects/git/fluffos/src/compiler/internal/grammar.y"
+#line 1321 "/projects/git/fluffos/src/compiler/internal/grammar.y"
     {
       parse_node_t *p1 = (yyvsp[-2].node), *p2 = (yyvsp[0].node);
 
@@ -3789,41 +3818,41 @@ yyreduce:
       }
       (yyval.node)->type = ((p1->type == p2->type) ? p1->type : TYPE_ANY);
     }
-#line 3793 "/projects/git/fluffos/build/src/grammar.autogen.cc"
+#line 3822 "/projects/git/fluffos/build/src/grammar.autogen.cc"
     break;
 
   case 150: /* expr0: expr0 L_QUESTION_QUESTION expr0  */
-#line 1341 "/projects/git/fluffos/src/compiler/internal/grammar.y"
+#line 1345 "/projects/git/fluffos/src/compiler/internal/grammar.y"
     {
       /* Nullish coalescing: left ?? right
        * Return left if defined, otherwise return right */
       CREATE_NULLISH((yyval.node), (yyvsp[-2].node), (yyvsp[0].node));
     }
-#line 3803 "/projects/git/fluffos/build/src/grammar.autogen.cc"
+#line 3832 "/projects/git/fluffos/build/src/grammar.autogen.cc"
     break;
 
   case 151: /* expr0: expr0 L_LOR expr0  */
-#line 1347 "/projects/git/fluffos/src/compiler/internal/grammar.y"
+#line 1351 "/projects/git/fluffos/src/compiler/internal/grammar.y"
     {
       CREATE_LAND_LOR((yyval.node), F_LOR, (yyvsp[-2].node), (yyvsp[0].node));
       if (IS_NODE((yyvsp[-2].node), NODE_LAND_LOR, F_LOR))
         (yyvsp[-2].node)->kind = NODE_BRANCH_LINK;
     }
-#line 3813 "/projects/git/fluffos/build/src/grammar.autogen.cc"
+#line 3842 "/projects/git/fluffos/build/src/grammar.autogen.cc"
     break;
 
   case 152: /* expr0: expr0 L_LAND expr0  */
-#line 1353 "/projects/git/fluffos/src/compiler/internal/grammar.y"
+#line 1357 "/projects/git/fluffos/src/compiler/internal/grammar.y"
     {
       CREATE_LAND_LOR((yyval.node), F_LAND, (yyvsp[-2].node), (yyvsp[0].node));
       if (IS_NODE((yyvsp[-2].node), NODE_LAND_LOR, F_LAND))
         (yyvsp[-2].node)->kind = NODE_BRANCH_LINK;
     }
-#line 3823 "/projects/git/fluffos/build/src/grammar.autogen.cc"
+#line 3852 "/projects/git/fluffos/build/src/grammar.autogen.cc"
     break;
 
   case 153: /* expr0: expr0 '|' expr0  */
-#line 1359 "/projects/git/fluffos/src/compiler/internal/grammar.y"
+#line 1363 "/projects/git/fluffos/src/compiler/internal/grammar.y"
     {
       int t1 = (yyvsp[-2].node)->type, t3 = (yyvsp[0].node)->type;
 
@@ -3848,19 +3877,19 @@ yyreduce:
       }
       else (yyval.node) = binary_int_op((yyvsp[-2].node), (yyvsp[0].node), F_OR, "|");
     }
-#line 3852 "/projects/git/fluffos/build/src/grammar.autogen.cc"
+#line 3881 "/projects/git/fluffos/build/src/grammar.autogen.cc"
     break;
 
   case 154: /* expr0: expr0 '^' expr0  */
-#line 1384 "/projects/git/fluffos/src/compiler/internal/grammar.y"
+#line 1388 "/projects/git/fluffos/src/compiler/internal/grammar.y"
     {
       (yyval.node) = binary_int_op((yyvsp[-2].node), (yyvsp[0].node), F_XOR, "^");
     }
-#line 3860 "/projects/git/fluffos/build/src/grammar.autogen.cc"
+#line 3889 "/projects/git/fluffos/build/src/grammar.autogen.cc"
     break;
 
   case 155: /* expr0: expr0 '&' expr0  */
-#line 1388 "/projects/git/fluffos/src/compiler/internal/grammar.y"
+#line 1392 "/projects/git/fluffos/src/compiler/internal/grammar.y"
     {
       int t1 = (yyvsp[-2].node)->type, t3 = (yyvsp[0].node)->type;
       if (is_boolean((yyvsp[-2].node)) && is_boolean((yyvsp[0].node)))
@@ -3883,11 +3912,11 @@ yyreduce:
         CREATE_BINARY_OP((yyval.node), F_AND, t1, (yyvsp[-2].node), (yyvsp[0].node));
       } else (yyval.node) = binary_int_op((yyvsp[-2].node), (yyvsp[0].node), F_AND, "&");
     }
-#line 3887 "/projects/git/fluffos/build/src/grammar.autogen.cc"
+#line 3916 "/projects/git/fluffos/build/src/grammar.autogen.cc"
     break;
 
   case 156: /* expr0: expr0 L_EQ expr0  */
-#line 1411 "/projects/git/fluffos/src/compiler/internal/grammar.y"
+#line 1415 "/projects/git/fluffos/src/compiler/internal/grammar.y"
     {
       if (exact_types && !compatible_types2((yyvsp[-2].node)->type, (yyvsp[0].node)->type)){
         char buf[256];
@@ -3909,11 +3938,11 @@ yyreduce:
           CREATE_BINARY_OP((yyval.node), F_EQ, TYPE_NUMBER, (yyvsp[-2].node), (yyvsp[0].node));
         }
     }
-#line 3913 "/projects/git/fluffos/build/src/grammar.autogen.cc"
+#line 3942 "/projects/git/fluffos/build/src/grammar.autogen.cc"
     break;
 
   case 157: /* expr0: expr0 L_NE expr0  */
-#line 1433 "/projects/git/fluffos/src/compiler/internal/grammar.y"
+#line 1437 "/projects/git/fluffos/src/compiler/internal/grammar.y"
     {
       if (exact_types && !compatible_types2((yyvsp[-2].node)->type, (yyvsp[0].node)->type)){
         char buf[256];
@@ -3927,11 +3956,11 @@ yyreduce:
       }
       CREATE_BINARY_OP((yyval.node), F_NE, TYPE_NUMBER, (yyvsp[-2].node), (yyvsp[0].node));
     }
-#line 3931 "/projects/git/fluffos/build/src/grammar.autogen.cc"
+#line 3960 "/projects/git/fluffos/build/src/grammar.autogen.cc"
     break;
 
   case 158: /* expr0: expr0 L_ORDER expr0  */
-#line 1447 "/projects/git/fluffos/src/compiler/internal/grammar.y"
+#line 1451 "/projects/git/fluffos/src/compiler/internal/grammar.y"
     {
       if (exact_types) {
         int t1 = (yyvsp[-2].node)->type;
@@ -3975,11 +4004,11 @@ yyreduce:
       }
       CREATE_BINARY_OP((yyval.node), (yyvsp[-1].number), TYPE_NUMBER, (yyvsp[-2].node), (yyvsp[0].node));
     }
-#line 3979 "/projects/git/fluffos/build/src/grammar.autogen.cc"
+#line 4008 "/projects/git/fluffos/build/src/grammar.autogen.cc"
     break;
 
   case 159: /* expr0: expr0 '<' expr0  */
-#line 1491 "/projects/git/fluffos/src/compiler/internal/grammar.y"
+#line 1495 "/projects/git/fluffos/src/compiler/internal/grammar.y"
     {
       if (exact_types) {
         int t1 = (yyvsp[-2].node)->type, t3 = (yyvsp[0].node)->type;
@@ -4016,27 +4045,27 @@ yyreduce:
       }
       CREATE_BINARY_OP((yyval.node), F_LT, TYPE_NUMBER, (yyvsp[-2].node), (yyvsp[0].node));
     }
-#line 4020 "/projects/git/fluffos/build/src/grammar.autogen.cc"
+#line 4049 "/projects/git/fluffos/build/src/grammar.autogen.cc"
     break;
 
   case 160: /* expr0: expr0 L_LSH expr0  */
-#line 1528 "/projects/git/fluffos/src/compiler/internal/grammar.y"
+#line 1532 "/projects/git/fluffos/src/compiler/internal/grammar.y"
     {
       (yyval.node) = binary_int_op((yyvsp[-2].node), (yyvsp[0].node), F_LSH, "<<");
     }
-#line 4028 "/projects/git/fluffos/build/src/grammar.autogen.cc"
+#line 4057 "/projects/git/fluffos/build/src/grammar.autogen.cc"
     break;
 
   case 161: /* expr0: expr0 L_RSH expr0  */
-#line 1532 "/projects/git/fluffos/src/compiler/internal/grammar.y"
+#line 1536 "/projects/git/fluffos/src/compiler/internal/grammar.y"
     {
       (yyval.node) = binary_int_op((yyvsp[-2].node), (yyvsp[0].node), F_RSH, ">>");
     }
-#line 4036 "/projects/git/fluffos/build/src/grammar.autogen.cc"
+#line 4065 "/projects/git/fluffos/build/src/grammar.autogen.cc"
     break;
 
   case 162: /* expr0: expr0 '+' expr0  */
-#line 1536 "/projects/git/fluffos/src/compiler/internal/grammar.y"
+#line 1540 "/projects/git/fluffos/src/compiler/internal/grammar.y"
     {
       int result_type;
 
@@ -4206,11 +4235,11 @@ yyreduce:
           break;
       }
     }
-#line 4210 "/projects/git/fluffos/build/src/grammar.autogen.cc"
+#line 4239 "/projects/git/fluffos/build/src/grammar.autogen.cc"
     break;
 
   case 163: /* expr0: expr0 '-' expr0  */
-#line 1706 "/projects/git/fluffos/src/compiler/internal/grammar.y"
+#line 1710 "/projects/git/fluffos/src/compiler/internal/grammar.y"
     {
       int result_type;
 
@@ -4304,11 +4333,11 @@ yyreduce:
           CREATE_BINARY_OP((yyval.node), F_SUBTRACT, result_type, (yyvsp[-2].node), (yyvsp[0].node));
       }
     }
-#line 4308 "/projects/git/fluffos/build/src/grammar.autogen.cc"
+#line 4337 "/projects/git/fluffos/build/src/grammar.autogen.cc"
     break;
 
   case 164: /* expr0: expr0 '*' expr0  */
-#line 1800 "/projects/git/fluffos/src/compiler/internal/grammar.y"
+#line 1804 "/projects/git/fluffos/src/compiler/internal/grammar.y"
     {
       int result_type;
 
@@ -4388,19 +4417,19 @@ yyreduce:
           CREATE_BINARY_OP((yyval.node), F_MULTIPLY, result_type, (yyvsp[-2].node), (yyvsp[0].node));
       }
     }
-#line 4392 "/projects/git/fluffos/build/src/grammar.autogen.cc"
+#line 4421 "/projects/git/fluffos/build/src/grammar.autogen.cc"
     break;
 
   case 165: /* expr0: expr0 '%' expr0  */
-#line 1880 "/projects/git/fluffos/src/compiler/internal/grammar.y"
+#line 1884 "/projects/git/fluffos/src/compiler/internal/grammar.y"
     {
       (yyval.node) = binary_int_op((yyvsp[-2].node), (yyvsp[0].node), F_MOD, "%");
     }
-#line 4400 "/projects/git/fluffos/build/src/grammar.autogen.cc"
+#line 4429 "/projects/git/fluffos/build/src/grammar.autogen.cc"
     break;
 
   case 166: /* expr0: expr0 '/' expr0  */
-#line 1884 "/projects/git/fluffos/src/compiler/internal/grammar.y"
+#line 1888 "/projects/git/fluffos/src/compiler/internal/grammar.y"
     {
       int result_type;
 
@@ -4495,11 +4524,11 @@ yyreduce:
           CREATE_BINARY_OP((yyval.node), F_DIVIDE, result_type, (yyvsp[-2].node), (yyvsp[0].node));
       }
     }
-#line 4499 "/projects/git/fluffos/build/src/grammar.autogen.cc"
+#line 4528 "/projects/git/fluffos/build/src/grammar.autogen.cc"
     break;
 
   case 167: /* expr0: cast expr0  */
-#line 1979 "/projects/git/fluffos/src/compiler/internal/grammar.y"
+#line 1983 "/projects/git/fluffos/src/compiler/internal/grammar.y"
     {
       (yyval.node) = (yyvsp[0].node);
       (yyval.node)->type = (yyvsp[-1].number);
@@ -4520,11 +4549,11 @@ yyreduce:
         yyerror(buf);
       }
     }
-#line 4524 "/projects/git/fluffos/build/src/grammar.autogen.cc"
+#line 4553 "/projects/git/fluffos/build/src/grammar.autogen.cc"
     break;
 
   case 168: /* expr0: L_INC lvalue  */
-#line 2000 "/projects/git/fluffos/src/compiler/internal/grammar.y"
+#line 2004 "/projects/git/fluffos/src/compiler/internal/grammar.y"
     {
       CREATE_UNARY_OP((yyval.node), F_PRE_INC, 0, (yyvsp[0].node));
       if (exact_types){
@@ -4545,11 +4574,11 @@ yyreduce:
         }
       } else (yyval.node)->type = TYPE_ANY;
     }
-#line 4549 "/projects/git/fluffos/build/src/grammar.autogen.cc"
+#line 4578 "/projects/git/fluffos/build/src/grammar.autogen.cc"
     break;
 
   case 169: /* expr0: L_DEC lvalue  */
-#line 2021 "/projects/git/fluffos/src/compiler/internal/grammar.y"
+#line 2025 "/projects/git/fluffos/src/compiler/internal/grammar.y"
     {
       CREATE_UNARY_OP((yyval.node), F_PRE_DEC, 0, (yyvsp[0].node));
       if (exact_types){
@@ -4571,11 +4600,11 @@ yyreduce:
       } else (yyval.node)->type = TYPE_ANY;
 
     }
-#line 4575 "/projects/git/fluffos/build/src/grammar.autogen.cc"
+#line 4604 "/projects/git/fluffos/build/src/grammar.autogen.cc"
     break;
 
   case 170: /* expr0: L_NOT expr0  */
-#line 2043 "/projects/git/fluffos/src/compiler/internal/grammar.y"
+#line 2047 "/projects/git/fluffos/src/compiler/internal/grammar.y"
     {
       if ((yyvsp[0].node)->kind == NODE_NUMBER) {
         (yyval.node) = (yyvsp[0].node);
@@ -4584,11 +4613,11 @@ yyreduce:
         CREATE_UNARY_OP((yyval.node), F_NOT, TYPE_NUMBER, (yyvsp[0].node));
       }
     }
-#line 4588 "/projects/git/fluffos/build/src/grammar.autogen.cc"
+#line 4617 "/projects/git/fluffos/build/src/grammar.autogen.cc"
     break;
 
   case 171: /* expr0: '~' expr0  */
-#line 2052 "/projects/git/fluffos/src/compiler/internal/grammar.y"
+#line 2056 "/projects/git/fluffos/src/compiler/internal/grammar.y"
     {
       if (exact_types && !IS_TYPE((yyvsp[0].node)->type, TYPE_NUMBER))
         type_error("Bad argument to ~", (yyvsp[0].node)->type);
@@ -4599,11 +4628,11 @@ yyreduce:
         CREATE_UNARY_OP((yyval.node), F_COMPL, TYPE_NUMBER, (yyvsp[0].node));
       }
     }
-#line 4603 "/projects/git/fluffos/build/src/grammar.autogen.cc"
+#line 4632 "/projects/git/fluffos/build/src/grammar.autogen.cc"
     break;
 
   case 172: /* expr0: '-' expr0  */
-#line 2063 "/projects/git/fluffos/src/compiler/internal/grammar.y"
+#line 2067 "/projects/git/fluffos/src/compiler/internal/grammar.y"
     {
       int result_type;
       if (exact_types){
@@ -4627,11 +4656,11 @@ yyreduce:
           CREATE_UNARY_OP((yyval.node), F_NEGATE, result_type, (yyvsp[0].node));
       }
     }
-#line 4631 "/projects/git/fluffos/build/src/grammar.autogen.cc"
+#line 4660 "/projects/git/fluffos/build/src/grammar.autogen.cc"
     break;
 
   case 173: /* expr0: lvalue L_INC  */
-#line 2087 "/projects/git/fluffos/src/compiler/internal/grammar.y"
+#line 2091 "/projects/git/fluffos/src/compiler/internal/grammar.y"
     {
       CREATE_UNARY_OP((yyval.node), F_POST_INC, 0, (yyvsp[-1].node));
       (yyval.node)->v.number = F_POST_INC;
@@ -4653,11 +4682,11 @@ yyreduce:
         }
       } else (yyval.node)->type = TYPE_ANY;
     }
-#line 4657 "/projects/git/fluffos/build/src/grammar.autogen.cc"
+#line 4686 "/projects/git/fluffos/build/src/grammar.autogen.cc"
     break;
 
   case 174: /* expr0: lvalue L_DEC  */
-#line 2109 "/projects/git/fluffos/src/compiler/internal/grammar.y"
+#line 2113 "/projects/git/fluffos/src/compiler/internal/grammar.y"
     {
       CREATE_UNARY_OP((yyval.node), F_POST_DEC, 0, (yyvsp[-1].node));
       if (exact_types){
@@ -4678,21 +4707,21 @@ yyreduce:
         }
       } else (yyval.node)->type = TYPE_ANY;
     }
-#line 4682 "/projects/git/fluffos/build/src/grammar.autogen.cc"
+#line 4711 "/projects/git/fluffos/build/src/grammar.autogen.cc"
     break;
 
   case 181: /* return: L_RETURN ';'  */
-#line 2139 "/projects/git/fluffos/src/compiler/internal/grammar.y"
+#line 2143 "/projects/git/fluffos/src/compiler/internal/grammar.y"
     {
       if (exact_types && !IS_TYPE(exact_types, TYPE_VOID))
         yywarn("Non-void functions must return a value.");
       CREATE_RETURN((yyval.node), 0);
     }
-#line 4692 "/projects/git/fluffos/build/src/grammar.autogen.cc"
+#line 4721 "/projects/git/fluffos/build/src/grammar.autogen.cc"
     break;
 
   case 182: /* return: L_RETURN comma_expr ';'  */
-#line 2145 "/projects/git/fluffos/src/compiler/internal/grammar.y"
+#line 2149 "/projects/git/fluffos/src/compiler/internal/grammar.y"
     {
       if (exact_types && !compatible_types((yyvsp[-1].node)->type, exact_types)) {
         char buf[256];
@@ -4709,60 +4738,60 @@ yyreduce:
         CREATE_RETURN((yyval.node), (yyvsp[-1].node));
       }
     }
-#line 4713 "/projects/git/fluffos/build/src/grammar.autogen.cc"
+#line 4742 "/projects/git/fluffos/build/src/grammar.autogen.cc"
     break;
 
   case 183: /* expr_list: %empty  */
-#line 2165 "/projects/git/fluffos/src/compiler/internal/grammar.y"
+#line 2169 "/projects/git/fluffos/src/compiler/internal/grammar.y"
             {
       CREATE_EXPR_LIST((yyval.node), 0);
     }
-#line 4721 "/projects/git/fluffos/build/src/grammar.autogen.cc"
+#line 4750 "/projects/git/fluffos/build/src/grammar.autogen.cc"
     break;
 
   case 184: /* expr_list: expr_list2  */
-#line 2169 "/projects/git/fluffos/src/compiler/internal/grammar.y"
+#line 2173 "/projects/git/fluffos/src/compiler/internal/grammar.y"
     {
       CREATE_EXPR_LIST((yyval.node), (yyvsp[0].node));
     }
-#line 4729 "/projects/git/fluffos/build/src/grammar.autogen.cc"
+#line 4758 "/projects/git/fluffos/build/src/grammar.autogen.cc"
     break;
 
   case 185: /* expr_list: expr_list2 ','  */
-#line 2173 "/projects/git/fluffos/src/compiler/internal/grammar.y"
+#line 2177 "/projects/git/fluffos/src/compiler/internal/grammar.y"
     {
       CREATE_EXPR_LIST((yyval.node), (yyvsp[-1].node));
     }
-#line 4737 "/projects/git/fluffos/build/src/grammar.autogen.cc"
+#line 4766 "/projects/git/fluffos/build/src/grammar.autogen.cc"
     break;
 
   case 186: /* expr_list_node: expr0  */
-#line 2180 "/projects/git/fluffos/src/compiler/internal/grammar.y"
+#line 2184 "/projects/git/fluffos/src/compiler/internal/grammar.y"
     {
       CREATE_EXPR_NODE((yyval.node), (yyvsp[0].node), 0);
     }
-#line 4745 "/projects/git/fluffos/build/src/grammar.autogen.cc"
+#line 4774 "/projects/git/fluffos/build/src/grammar.autogen.cc"
     break;
 
   case 187: /* expr_list_node: expr0 L_DOT_DOT_DOT  */
-#line 2184 "/projects/git/fluffos/src/compiler/internal/grammar.y"
+#line 2188 "/projects/git/fluffos/src/compiler/internal/grammar.y"
     {
       CREATE_EXPR_NODE((yyval.node), (yyvsp[-1].node), 1);
     }
-#line 4753 "/projects/git/fluffos/build/src/grammar.autogen.cc"
+#line 4782 "/projects/git/fluffos/build/src/grammar.autogen.cc"
     break;
 
   case 188: /* expr_list2: expr_list_node  */
-#line 2191 "/projects/git/fluffos/src/compiler/internal/grammar.y"
+#line 2195 "/projects/git/fluffos/src/compiler/internal/grammar.y"
     {
       (yyvsp[0].node)->kind = 1;
       (yyval.node) = (yyvsp[0].node);
     }
-#line 4762 "/projects/git/fluffos/build/src/grammar.autogen.cc"
+#line 4791 "/projects/git/fluffos/build/src/grammar.autogen.cc"
     break;
 
   case 189: /* expr_list2: expr_list2 ',' expr_list_node  */
-#line 2196 "/projects/git/fluffos/src/compiler/internal/grammar.y"
+#line 2200 "/projects/git/fluffos/src/compiler/internal/grammar.y"
     {
       (yyvsp[0].node)->kind = 0;
 
@@ -4771,36 +4800,36 @@ yyreduce:
       (yyval.node)->l.expr->r.expr = (yyvsp[0].node);
       (yyval.node)->l.expr = (yyvsp[0].node);
     }
-#line 4775 "/projects/git/fluffos/build/src/grammar.autogen.cc"
+#line 4804 "/projects/git/fluffos/build/src/grammar.autogen.cc"
     break;
 
   case 190: /* expr_list3: %empty  */
-#line 2208 "/projects/git/fluffos/src/compiler/internal/grammar.y"
+#line 2212 "/projects/git/fluffos/src/compiler/internal/grammar.y"
             {
       /* this is a dummy node */
       CREATE_EXPR_LIST((yyval.node), 0);
     }
-#line 4784 "/projects/git/fluffos/build/src/grammar.autogen.cc"
+#line 4813 "/projects/git/fluffos/build/src/grammar.autogen.cc"
     break;
 
   case 191: /* expr_list3: expr_list4  */
-#line 2213 "/projects/git/fluffos/src/compiler/internal/grammar.y"
+#line 2217 "/projects/git/fluffos/src/compiler/internal/grammar.y"
     {
       CREATE_EXPR_LIST((yyval.node), (yyvsp[0].node));
     }
-#line 4792 "/projects/git/fluffos/build/src/grammar.autogen.cc"
+#line 4821 "/projects/git/fluffos/build/src/grammar.autogen.cc"
     break;
 
   case 192: /* expr_list3: expr_list4 ','  */
-#line 2217 "/projects/git/fluffos/src/compiler/internal/grammar.y"
+#line 2221 "/projects/git/fluffos/src/compiler/internal/grammar.y"
     {
       CREATE_EXPR_LIST((yyval.node), (yyvsp[-1].node));
     }
-#line 4800 "/projects/git/fluffos/build/src/grammar.autogen.cc"
+#line 4829 "/projects/git/fluffos/build/src/grammar.autogen.cc"
     break;
 
   case 193: /* expr_list4: assoc_pair  */
-#line 2224 "/projects/git/fluffos/src/compiler/internal/grammar.y"
+#line 2228 "/projects/git/fluffos/src/compiler/internal/grammar.y"
     {
       (yyval.node) = new_node_no_line();
       (yyval.node)->kind = 2;
@@ -4810,11 +4839,11 @@ yyreduce:
       /* we keep track of the end of the chain in the left nodes */
       (yyval.node)->l.expr = (yyval.node);
     }
-#line 4814 "/projects/git/fluffos/build/src/grammar.autogen.cc"
+#line 4843 "/projects/git/fluffos/build/src/grammar.autogen.cc"
     break;
 
   case 194: /* expr_list4: expr_list4 ',' assoc_pair  */
-#line 2234 "/projects/git/fluffos/src/compiler/internal/grammar.y"
+#line 2238 "/projects/git/fluffos/src/compiler/internal/grammar.y"
     {
       parse_node_t *expr;
 
@@ -4829,19 +4858,19 @@ yyreduce:
       (yyvsp[-2].node)->kind += 2;
       (yyval.node) = (yyvsp[-2].node);
     }
-#line 4833 "/projects/git/fluffos/build/src/grammar.autogen.cc"
+#line 4862 "/projects/git/fluffos/build/src/grammar.autogen.cc"
     break;
 
   case 195: /* assoc_pair: expr0 ':' expr0  */
-#line 2252 "/projects/git/fluffos/src/compiler/internal/grammar.y"
+#line 2256 "/projects/git/fluffos/src/compiler/internal/grammar.y"
     {
       CREATE_TWO_VALUES((yyval.node), 0, (yyvsp[-2].node), (yyvsp[0].node));
     }
-#line 4841 "/projects/git/fluffos/build/src/grammar.autogen.cc"
+#line 4870 "/projects/git/fluffos/build/src/grammar.autogen.cc"
     break;
 
   case 196: /* lvalue: expr4  */
-#line 2259 "/projects/git/fluffos/src/compiler/internal/grammar.y"
+#line 2263 "/projects/git/fluffos/src/compiler/internal/grammar.y"
     {
 #define LV_ILLEGAL 1
 #define LV_RANGE 2
@@ -4954,19 +4983,19 @@ yyreduce:
           break;
       }
     }
-#line 4958 "/projects/git/fluffos/build/src/grammar.autogen.cc"
+#line 4987 "/projects/git/fluffos/build/src/grammar.autogen.cc"
     break;
 
   case 198: /* l_new_function_open: L_FUNCTION_OPEN efun_override  */
-#line 2376 "/projects/git/fluffos/src/compiler/internal/grammar.y"
+#line 2380 "/projects/git/fluffos/src/compiler/internal/grammar.y"
     {
       (yyval.number) = ((yyvsp[0].number) << 8) | FP_EFUN;
     }
-#line 4966 "/projects/git/fluffos/build/src/grammar.autogen.cc"
+#line 4995 "/projects/git/fluffos/build/src/grammar.autogen.cc"
     break;
 
   case 200: /* expr4: L_DEFINED_NAME  */
-#line 2384 "/projects/git/fluffos/src/compiler/internal/grammar.y"
+#line 2388 "/projects/git/fluffos/src/compiler/internal/grammar.y"
     {
       int i;
       if ((i = (yyvsp[0].ihe)->dn.local_num) != -1) {
@@ -5039,11 +5068,11 @@ yyreduce:
           yyerror(buf);
         }
     }
-#line 5043 "/projects/git/fluffos/build/src/grammar.autogen.cc"
+#line 5072 "/projects/git/fluffos/build/src/grammar.autogen.cc"
     break;
 
   case 201: /* expr4: L_IDENTIFIER  */
-#line 2457 "/projects/git/fluffos/src/compiler/internal/grammar.y"
+#line 2461 "/projects/git/fluffos/src/compiler/internal/grammar.y"
     {
       char buf[256];
       char *end = EndOf(buf);
@@ -5061,30 +5090,30 @@ yyreduce:
       if (current_function_context)
         current_function_context->bindable = FP_NOT_BINDABLE;
     }
-#line 5065 "/projects/git/fluffos/build/src/grammar.autogen.cc"
+#line 5094 "/projects/git/fluffos/build/src/grammar.autogen.cc"
     break;
 
   case 202: /* expr4: L_PARAMETER  */
-#line 2475 "/projects/git/fluffos/src/compiler/internal/grammar.y"
+#line 2479 "/projects/git/fluffos/src/compiler/internal/grammar.y"
     {
       CREATE_PARAMETER((yyval.node), TYPE_ANY, (yyvsp[0].number));
     }
-#line 5073 "/projects/git/fluffos/build/src/grammar.autogen.cc"
+#line 5102 "/projects/git/fluffos/build/src/grammar.autogen.cc"
     break;
 
   case 203: /* @13: %empty  */
-#line 2479 "/projects/git/fluffos/src/compiler/internal/grammar.y"
+#line 2483 "/projects/git/fluffos/src/compiler/internal/grammar.y"
     {
       (yyval.contextp) = current_function_context;
       /* already flagged as an error */
       if (current_function_context)
         current_function_context = current_function_context->parent;
     }
-#line 5084 "/projects/git/fluffos/build/src/grammar.autogen.cc"
+#line 5113 "/projects/git/fluffos/build/src/grammar.autogen.cc"
     break;
 
   case 204: /* expr4: '$' '(' @13 comma_expr ')'  */
-#line 2486 "/projects/git/fluffos/src/compiler/internal/grammar.y"
+#line 2490 "/projects/git/fluffos/src/compiler/internal/grammar.y"
     {
       parse_node_t *node;
 
@@ -5107,11 +5136,11 @@ yyreduce:
         node->v.expr = (yyvsp[-1].node);
       }
     }
-#line 5111 "/projects/git/fluffos/build/src/grammar.autogen.cc"
+#line 5140 "/projects/git/fluffos/build/src/grammar.autogen.cc"
     break;
 
   case 205: /* expr4: expr4 L_ARROW identifier  */
-#line 2509 "/projects/git/fluffos/src/compiler/internal/grammar.y"
+#line 2513 "/projects/git/fluffos/src/compiler/internal/grammar.y"
     {
       if ((yyvsp[-2].node)->type == TYPE_ANY) {
         int cmi;
@@ -5135,11 +5164,11 @@ yyreduce:
 
       scratch_free((yyvsp[0].string));
     }
-#line 5139 "/projects/git/fluffos/build/src/grammar.autogen.cc"
+#line 5168 "/projects/git/fluffos/build/src/grammar.autogen.cc"
     break;
 
   case 206: /* expr4: expr4 L_DOT identifier  */
-#line 2533 "/projects/git/fluffos/src/compiler/internal/grammar.y"
+#line 2537 "/projects/git/fluffos/src/compiler/internal/grammar.y"
     {
       if ((yyvsp[-2].node)->type == TYPE_ANY) {
         int cmi;
@@ -5163,11 +5192,11 @@ yyreduce:
 
       scratch_free((yyvsp[0].string));
     }
-#line 5167 "/projects/git/fluffos/build/src/grammar.autogen.cc"
+#line 5196 "/projects/git/fluffos/build/src/grammar.autogen.cc"
     break;
 
   case 207: /* expr4: expr4 '[' comma_expr L_RANGE comma_expr ']'  */
-#line 2557 "/projects/git/fluffos/src/compiler/internal/grammar.y"
+#line 2561 "/projects/git/fluffos/src/compiler/internal/grammar.y"
     {
     if (!CONFIG_INT(__RC_OLD_RANGE_BEHAVIOR__)) {
       if (CONFIG_INT(__RC_WARN_OLD_RANGE_BEHAVIOR__)) {
@@ -5178,57 +5207,57 @@ yyreduce:
     }
       (yyval.node) = make_range_node(F_NN_RANGE, (yyvsp[-5].node), (yyvsp[-3].node), (yyvsp[-1].node));
     }
-#line 5182 "/projects/git/fluffos/build/src/grammar.autogen.cc"
+#line 5211 "/projects/git/fluffos/build/src/grammar.autogen.cc"
     break;
 
   case 208: /* expr4: expr4 '[' '<' comma_expr L_RANGE comma_expr ']'  */
-#line 2568 "/projects/git/fluffos/src/compiler/internal/grammar.y"
+#line 2572 "/projects/git/fluffos/src/compiler/internal/grammar.y"
     {
       (yyval.node) = make_range_node(F_RN_RANGE, (yyvsp[-6].node), (yyvsp[-3].node), (yyvsp[-1].node));
     }
-#line 5190 "/projects/git/fluffos/build/src/grammar.autogen.cc"
+#line 5219 "/projects/git/fluffos/build/src/grammar.autogen.cc"
     break;
 
   case 209: /* expr4: expr4 '[' '<' comma_expr L_RANGE '<' comma_expr ']'  */
-#line 2572 "/projects/git/fluffos/src/compiler/internal/grammar.y"
+#line 2576 "/projects/git/fluffos/src/compiler/internal/grammar.y"
     {
       if ((yyvsp[-1].node)->kind == NODE_NUMBER && (yyvsp[-1].node)->v.number <= 1)
         (yyval.node) = make_range_node(F_RE_RANGE, (yyvsp[-7].node), (yyvsp[-4].node), 0);
       else
         (yyval.node) = make_range_node(F_RR_RANGE, (yyvsp[-7].node), (yyvsp[-4].node), (yyvsp[-1].node));
     }
-#line 5201 "/projects/git/fluffos/build/src/grammar.autogen.cc"
+#line 5230 "/projects/git/fluffos/build/src/grammar.autogen.cc"
     break;
 
   case 210: /* expr4: expr4 '[' comma_expr L_RANGE '<' comma_expr ']'  */
-#line 2579 "/projects/git/fluffos/src/compiler/internal/grammar.y"
+#line 2583 "/projects/git/fluffos/src/compiler/internal/grammar.y"
     {
       if ((yyvsp[-1].node)->kind == NODE_NUMBER && (yyvsp[-1].node)->v.number <= 1)
         (yyval.node) = make_range_node(F_NE_RANGE, (yyvsp[-6].node), (yyvsp[-4].node), 0);
       else
         (yyval.node) = make_range_node(F_NR_RANGE, (yyvsp[-6].node), (yyvsp[-4].node), (yyvsp[-1].node));
     }
-#line 5212 "/projects/git/fluffos/build/src/grammar.autogen.cc"
+#line 5241 "/projects/git/fluffos/build/src/grammar.autogen.cc"
     break;
 
   case 211: /* expr4: expr4 '[' comma_expr L_RANGE ']'  */
-#line 2586 "/projects/git/fluffos/src/compiler/internal/grammar.y"
+#line 2590 "/projects/git/fluffos/src/compiler/internal/grammar.y"
     {
       (yyval.node) = make_range_node(F_NE_RANGE, (yyvsp[-4].node), (yyvsp[-2].node), 0);
     }
-#line 5220 "/projects/git/fluffos/build/src/grammar.autogen.cc"
+#line 5249 "/projects/git/fluffos/build/src/grammar.autogen.cc"
     break;
 
   case 212: /* expr4: expr4 '[' '<' comma_expr L_RANGE ']'  */
-#line 2590 "/projects/git/fluffos/src/compiler/internal/grammar.y"
+#line 2594 "/projects/git/fluffos/src/compiler/internal/grammar.y"
     {
       (yyval.node) = make_range_node(F_RE_RANGE, (yyvsp[-5].node), (yyvsp[-2].node), 0);
     }
-#line 5228 "/projects/git/fluffos/build/src/grammar.autogen.cc"
+#line 5257 "/projects/git/fluffos/build/src/grammar.autogen.cc"
     break;
 
   case 213: /* expr4: expr4 '[' '<' comma_expr ']'  */
-#line 2594 "/projects/git/fluffos/src/compiler/internal/grammar.y"
+#line 2598 "/projects/git/fluffos/src/compiler/internal/grammar.y"
     {
       if (IS_NODE((yyvsp[-4].node), NODE_CALL, F_AGGREGATE)
           && (yyvsp[-1].node)->kind == NODE_NUMBER) {
@@ -5273,11 +5302,11 @@ yyreduce:
         }
       } else (yyval.node)->type = TYPE_ANY;
     }
-#line 5277 "/projects/git/fluffos/build/src/grammar.autogen.cc"
+#line 5306 "/projects/git/fluffos/build/src/grammar.autogen.cc"
     break;
 
   case 214: /* expr4: expr4 '[' comma_expr ']'  */
-#line 2639 "/projects/git/fluffos/src/compiler/internal/grammar.y"
+#line 2643 "/projects/git/fluffos/src/compiler/internal/grammar.y"
     {
       /* Something stupid like ({ 1, 2, 3 })[1]; we take the
        * time to optimize this because people who don't understand
@@ -5333,19 +5362,19 @@ yyreduce:
         }
       } else (yyval.node)->type = TYPE_ANY;
     }
-#line 5337 "/projects/git/fluffos/build/src/grammar.autogen.cc"
+#line 5366 "/projects/git/fluffos/build/src/grammar.autogen.cc"
     break;
 
   case 216: /* expr4: '(' comma_expr ')'  */
-#line 2696 "/projects/git/fluffos/src/compiler/internal/grammar.y"
+#line 2700 "/projects/git/fluffos/src/compiler/internal/grammar.y"
     {
       (yyval.node) = (yyvsp[-1].node);
     }
-#line 5345 "/projects/git/fluffos/build/src/grammar.autogen.cc"
+#line 5374 "/projects/git/fluffos/build/src/grammar.autogen.cc"
     break;
 
   case 219: /* @14: %empty  */
-#line 2702 "/projects/git/fluffos/src/compiler/internal/grammar.y"
+#line 2706 "/projects/git/fluffos/src/compiler/internal/grammar.y"
     {
       auto max_local_variables = CFG_INT(__MAX_LOCAL_VARIABLES__);
 
@@ -5366,11 +5395,11 @@ yyreduce:
       exact_types = TYPE_ANY;
       context = 0;
     }
-#line 5370 "/projects/git/fluffos/build/src/grammar.autogen.cc"
+#line 5399 "/projects/git/fluffos/build/src/grammar.autogen.cc"
     break;
 
   case 220: /* expr4: L_BASIC_TYPE @14 '(' argument ')' block  */
-#line 2723 "/projects/git/fluffos/src/compiler/internal/grammar.y"
+#line 2727 "/projects/git/fluffos/src/compiler/internal/grammar.y"
     {
       if ((yyvsp[-2].argument).flags & ARG_IS_VARARGS) {
         yyerror("Anonymous varargs functions aren't implemented");
@@ -5406,11 +5435,11 @@ yyreduce:
       type_of_locals_ptr -= max_num_locals;
       reactivate_current_locals();
     }
-#line 5410 "/projects/git/fluffos/build/src/grammar.autogen.cc"
+#line 5439 "/projects/git/fluffos/build/src/grammar.autogen.cc"
     break;
 
   case 221: /* expr4: l_new_function_open ':' ')'  */
-#line 2759 "/projects/git/fluffos/src/compiler/internal/grammar.y"
+#line 2763 "/projects/git/fluffos/src/compiler/internal/grammar.y"
     {
       if (CONFIG_INT(__RC_WOMBLES__)) {
         if(*(outp-2) != ':') {
@@ -5448,11 +5477,11 @@ yyreduce:
           break;
       }
     }
-#line 5452 "/projects/git/fluffos/build/src/grammar.autogen.cc"
+#line 5481 "/projects/git/fluffos/build/src/grammar.autogen.cc"
     break;
 
   case 222: /* expr4: l_new_function_open ',' expr_list2 ':' ')'  */
-#line 2797 "/projects/git/fluffos/src/compiler/internal/grammar.y"
+#line 2801 "/projects/git/fluffos/src/compiler/internal/grammar.y"
     {
       if (CONFIG_INT(__RC_WOMBLES__)) {
         if(*(outp-2) != ':') {
@@ -5547,11 +5576,11 @@ yyreduce:
                       break;
       }
     }
-#line 5551 "/projects/git/fluffos/build/src/grammar.autogen.cc"
+#line 5580 "/projects/git/fluffos/build/src/grammar.autogen.cc"
     break;
 
   case 223: /* expr4: L_FUNCTION_OPEN comma_expr ':' ')'  */
-#line 2892 "/projects/git/fluffos/src/compiler/internal/grammar.y"
+#line 2896 "/projects/git/fluffos/src/compiler/internal/grammar.y"
     {
       if (CONFIG_INT(__RC_WOMBLES__)) {
         if(*(outp-2) != ':') {
@@ -5574,11 +5603,11 @@ yyreduce:
         + (current_function_context->num_parameters << 8);
       pop_function_context();
     }
-#line 5578 "/projects/git/fluffos/build/src/grammar.autogen.cc"
+#line 5607 "/projects/git/fluffos/build/src/grammar.autogen.cc"
     break;
 
   case 224: /* expr4: L_MAPPING_OPEN expr_list3 ']' ')'  */
-#line 2915 "/projects/git/fluffos/src/compiler/internal/grammar.y"
+#line 2919 "/projects/git/fluffos/src/compiler/internal/grammar.y"
     {
       if (CONFIG_INT(__RC_WOMBLES__)) {
         if(*(outp-2) != ']') {
@@ -5587,11 +5616,11 @@ yyreduce:
       }
       CREATE_CALL((yyval.node), F_AGGREGATE_ASSOC, TYPE_MAPPING, (yyvsp[-2].node));
     }
-#line 5591 "/projects/git/fluffos/build/src/grammar.autogen.cc"
+#line 5620 "/projects/git/fluffos/build/src/grammar.autogen.cc"
     break;
 
   case 225: /* expr4: L_ARRAY_OPEN expr_list '}' ')'  */
-#line 2924 "/projects/git/fluffos/src/compiler/internal/grammar.y"
+#line 2928 "/projects/git/fluffos/src/compiler/internal/grammar.y"
     {
       if (CONFIG_INT(__RC_WOMBLES__)) {
         if(*(outp-2) != '}') {
@@ -5600,116 +5629,116 @@ yyreduce:
       }
       CREATE_CALL((yyval.node), F_AGGREGATE, TYPE_ANY | TYPE_MOD_ARRAY, (yyvsp[-2].node));
     }
-#line 5604 "/projects/git/fluffos/build/src/grammar.autogen.cc"
+#line 5633 "/projects/git/fluffos/build/src/grammar.autogen.cc"
     break;
 
   case 226: /* expr_or_block: block  */
-#line 2936 "/projects/git/fluffos/src/compiler/internal/grammar.y"
+#line 2940 "/projects/git/fluffos/src/compiler/internal/grammar.y"
     {
       (yyval.node) = (yyvsp[0].decl).node;
     }
-#line 5612 "/projects/git/fluffos/build/src/grammar.autogen.cc"
+#line 5641 "/projects/git/fluffos/build/src/grammar.autogen.cc"
     break;
 
   case 227: /* expr_or_block: '(' comma_expr ')'  */
-#line 2940 "/projects/git/fluffos/src/compiler/internal/grammar.y"
+#line 2944 "/projects/git/fluffos/src/compiler/internal/grammar.y"
     {
       (yyval.node) = insert_pop_value((yyvsp[-1].node));
     }
-#line 5620 "/projects/git/fluffos/build/src/grammar.autogen.cc"
+#line 5649 "/projects/git/fluffos/build/src/grammar.autogen.cc"
     break;
 
   case 228: /* @15: %empty  */
-#line 2947 "/projects/git/fluffos/src/compiler/internal/grammar.y"
+#line 2951 "/projects/git/fluffos/src/compiler/internal/grammar.y"
     {
       (yyval.number) = context;
       context = SPECIAL_CONTEXT;
     }
-#line 5629 "/projects/git/fluffos/build/src/grammar.autogen.cc"
+#line 5658 "/projects/git/fluffos/build/src/grammar.autogen.cc"
     break;
 
   case 229: /* catch: L_CATCH @15 expr_or_block  */
-#line 2952 "/projects/git/fluffos/src/compiler/internal/grammar.y"
+#line 2956 "/projects/git/fluffos/src/compiler/internal/grammar.y"
     {
       CREATE_CATCH((yyval.node), (yyvsp[0].node));
       context = (yyvsp[-1].number);
     }
-#line 5638 "/projects/git/fluffos/build/src/grammar.autogen.cc"
+#line 5667 "/projects/git/fluffos/build/src/grammar.autogen.cc"
     break;
 
   case 230: /* tree: L_TREE block  */
-#line 2960 "/projects/git/fluffos/src/compiler/internal/grammar.y"
+#line 2964 "/projects/git/fluffos/src/compiler/internal/grammar.y"
     {
 #ifdef DEBUG
       (yyval.node) = new_node_no_line();
       lpc_tree_form((yyvsp[0].decl).node, (yyval.node));
 #endif
     }
-#line 5649 "/projects/git/fluffos/build/src/grammar.autogen.cc"
+#line 5678 "/projects/git/fluffos/build/src/grammar.autogen.cc"
     break;
 
   case 231: /* tree: L_TREE '(' comma_expr ')'  */
-#line 2967 "/projects/git/fluffos/src/compiler/internal/grammar.y"
+#line 2971 "/projects/git/fluffos/src/compiler/internal/grammar.y"
     {
 #ifdef DEBUG
       (yyval.node) = new_node_no_line();
       lpc_tree_form((yyvsp[-1].node), (yyval.node));
 #endif
     }
-#line 5660 "/projects/git/fluffos/build/src/grammar.autogen.cc"
+#line 5689 "/projects/git/fluffos/build/src/grammar.autogen.cc"
     break;
 
   case 232: /* sscanf: L_SSCANF '(' expr0 ',' expr0 lvalue_list ')'  */
-#line 2977 "/projects/git/fluffos/src/compiler/internal/grammar.y"
+#line 2981 "/projects/git/fluffos/src/compiler/internal/grammar.y"
     {
       int p = (yyvsp[-1].node)->v.number;
       CREATE_LVALUE_EFUN((yyval.node), TYPE_NUMBER, (yyvsp[-1].node));
       CREATE_BINARY_OP_1((yyval.node)->l.expr, F_SSCANF, 0, (yyvsp[-4].node), (yyvsp[-2].node), p);
     }
-#line 5670 "/projects/git/fluffos/build/src/grammar.autogen.cc"
+#line 5699 "/projects/git/fluffos/build/src/grammar.autogen.cc"
     break;
 
   case 233: /* parse_command: L_PARSE_COMMAND '(' expr0 ',' expr0 ',' expr0 lvalue_list ')'  */
-#line 2986 "/projects/git/fluffos/src/compiler/internal/grammar.y"
+#line 2990 "/projects/git/fluffos/src/compiler/internal/grammar.y"
     {
       int p = (yyvsp[-1].node)->v.number;
       CREATE_LVALUE_EFUN((yyval.node), TYPE_NUMBER, (yyvsp[-1].node));
       CREATE_TERNARY_OP_1((yyval.node)->l.expr, F_PARSE_COMMAND, 0,
           (yyvsp[-6].node), (yyvsp[-4].node), (yyvsp[-2].node), p);
     }
-#line 5681 "/projects/git/fluffos/build/src/grammar.autogen.cc"
+#line 5710 "/projects/git/fluffos/build/src/grammar.autogen.cc"
     break;
 
   case 234: /* @16: %empty  */
-#line 2996 "/projects/git/fluffos/src/compiler/internal/grammar.y"
+#line 3000 "/projects/git/fluffos/src/compiler/internal/grammar.y"
     {
       (yyval.number) = context;
       context = SPECIAL_CONTEXT;
     }
-#line 5690 "/projects/git/fluffos/build/src/grammar.autogen.cc"
+#line 5719 "/projects/git/fluffos/build/src/grammar.autogen.cc"
     break;
 
   case 235: /* time_expression: L_TIME_EXPRESSION @16 expr_or_block  */
-#line 3001 "/projects/git/fluffos/src/compiler/internal/grammar.y"
+#line 3005 "/projects/git/fluffos/src/compiler/internal/grammar.y"
     {
       CREATE_TIME_EXPRESSION((yyval.node), (yyvsp[0].node));
       context = (yyvsp[-1].number);
     }
-#line 5699 "/projects/git/fluffos/build/src/grammar.autogen.cc"
+#line 5728 "/projects/git/fluffos/build/src/grammar.autogen.cc"
     break;
 
   case 236: /* lvalue_list: %empty  */
-#line 3009 "/projects/git/fluffos/src/compiler/internal/grammar.y"
+#line 3013 "/projects/git/fluffos/src/compiler/internal/grammar.y"
             {
       (yyval.node) = new_node_no_line();
       (yyval.node)->r.expr = 0;
       (yyval.node)->v.number = 0;
     }
-#line 5709 "/projects/git/fluffos/build/src/grammar.autogen.cc"
+#line 5738 "/projects/git/fluffos/build/src/grammar.autogen.cc"
     break;
 
   case 237: /* lvalue_list: ',' lvalue lvalue_list  */
-#line 3015 "/projects/git/fluffos/src/compiler/internal/grammar.y"
+#line 3019 "/projects/git/fluffos/src/compiler/internal/grammar.y"
     {
       parse_node_t *insert;
 
@@ -5720,103 +5749,154 @@ yyreduce:
       (yyvsp[0].node)->r.expr = insert;
       (yyval.node)->v.number++;
     }
-#line 5724 "/projects/git/fluffos/build/src/grammar.autogen.cc"
+#line 5753 "/projects/git/fluffos/build/src/grammar.autogen.cc"
     break;
 
   case 238: /* string: string_con2  */
-#line 3029 "/projects/git/fluffos/src/compiler/internal/grammar.y"
+#line 3033 "/projects/git/fluffos/src/compiler/internal/grammar.y"
     {
       CREATE_STRING((yyval.node), (yyvsp[0].string));
       scratch_free((yyvsp[0].string));
     }
-#line 5733 "/projects/git/fluffos/build/src/grammar.autogen.cc"
+#line 5762 "/projects/git/fluffos/build/src/grammar.autogen.cc"
     break;
 
   case 240: /* string_con1: '(' string_con1 ')'  */
-#line 3038 "/projects/git/fluffos/src/compiler/internal/grammar.y"
+#line 3042 "/projects/git/fluffos/src/compiler/internal/grammar.y"
     {
       (yyval.string) = (yyvsp[-1].string);
     }
-#line 5741 "/projects/git/fluffos/build/src/grammar.autogen.cc"
+#line 5770 "/projects/git/fluffos/build/src/grammar.autogen.cc"
     break;
 
   case 241: /* string_con1: string_con1 '+' string_con1  */
-#line 3042 "/projects/git/fluffos/src/compiler/internal/grammar.y"
+#line 3046 "/projects/git/fluffos/src/compiler/internal/grammar.y"
     {
       (yyval.string) = scratch_join((yyvsp[-2].string), (yyvsp[0].string));
     }
-#line 5749 "/projects/git/fluffos/build/src/grammar.autogen.cc"
+#line 5778 "/projects/git/fluffos/build/src/grammar.autogen.cc"
     break;
 
   case 243: /* string_con2: string_con2 L_STRING  */
-#line 3050 "/projects/git/fluffos/src/compiler/internal/grammar.y"
+#line 3054 "/projects/git/fluffos/src/compiler/internal/grammar.y"
     {
       (yyval.string) = scratch_join((yyvsp[-1].string), (yyvsp[0].string));
     }
-#line 5757 "/projects/git/fluffos/build/src/grammar.autogen.cc"
+#line 5786 "/projects/git/fluffos/build/src/grammar.autogen.cc"
     break;
 
-  case 244: /* class_init: identifier ':' expr0  */
-#line 3057 "/projects/git/fluffos/src/compiler/internal/grammar.y"
+  case 244: /* template_literal: L_TEMPLATE_HEAD expr0 template_parts  */
+#line 3061 "/projects/git/fluffos/src/compiler/internal/grammar.y"
+    {
+      parse_node_t *head, *tmp, *coerced;
+      CREATE_STRING(head, (yyvsp[-2].string));
+      scratch_free((yyvsp[-2].string));
+      CREATE_UNARY_OP(coerced, F_TEMPLATE_COERCE, TYPE_STRING, (yyvsp[-1].node));
+      CREATE_BINARY_OP(tmp, F_ADD, TYPE_STRING, head, coerced);
+      CREATE_BINARY_OP((yyval.node), F_ADD, TYPE_STRING, tmp, (yyvsp[0].node));
+    }
+#line 5799 "/projects/git/fluffos/build/src/grammar.autogen.cc"
+    break;
+
+  case 245: /* template_parts: L_TEMPLATE_TAIL  */
+#line 3073 "/projects/git/fluffos/src/compiler/internal/grammar.y"
+    {
+      CREATE_STRING((yyval.node), (yyvsp[0].string));
+      scratch_free((yyvsp[0].string));
+    }
+#line 5808 "/projects/git/fluffos/build/src/grammar.autogen.cc"
+    break;
+
+  case 246: /* template_parts: L_TEMPLATE_MIDDLE expr0 template_parts  */
+#line 3078 "/projects/git/fluffos/src/compiler/internal/grammar.y"
+    {
+      parse_node_t *mid, *tmp, *coerced;
+      CREATE_STRING(mid, (yyvsp[-2].string));
+      scratch_free((yyvsp[-2].string));
+      CREATE_UNARY_OP(coerced, F_TEMPLATE_COERCE, TYPE_STRING, (yyvsp[-1].node));
+      CREATE_BINARY_OP(tmp, F_ADD, TYPE_STRING, mid, coerced);
+      CREATE_BINARY_OP((yyval.node), F_ADD, TYPE_STRING, tmp, (yyvsp[0].node));
+    }
+#line 5821 "/projects/git/fluffos/build/src/grammar.autogen.cc"
+    break;
+
+  case 249: /* string_like: string_like string  */
+#line 3092 "/projects/git/fluffos/src/compiler/internal/grammar.y"
+    {
+      CREATE_BINARY_OP((yyval.node), F_ADD, TYPE_STRING, (yyvsp[-1].node), (yyvsp[0].node));
+    }
+#line 5829 "/projects/git/fluffos/build/src/grammar.autogen.cc"
+    break;
+
+  case 250: /* string_like: string_like template_literal  */
+#line 3096 "/projects/git/fluffos/src/compiler/internal/grammar.y"
+    {
+      CREATE_BINARY_OP((yyval.node), F_ADD, TYPE_STRING, (yyvsp[-1].node), (yyvsp[0].node));
+    }
+#line 5837 "/projects/git/fluffos/build/src/grammar.autogen.cc"
+    break;
+
+  case 251: /* class_init: identifier ':' expr0  */
+#line 3103 "/projects/git/fluffos/src/compiler/internal/grammar.y"
     {
       (yyval.node) = new_node();
       (yyval.node)->l.expr = (parse_node_t *)(yyvsp[-2].string);
       (yyval.node)->v.expr = (yyvsp[0].node);
       (yyval.node)->r.expr = 0;
     }
-#line 5768 "/projects/git/fluffos/build/src/grammar.autogen.cc"
+#line 5848 "/projects/git/fluffos/build/src/grammar.autogen.cc"
     break;
 
-  case 245: /* opt_class_init: %empty  */
-#line 3067 "/projects/git/fluffos/src/compiler/internal/grammar.y"
+  case 252: /* opt_class_init: %empty  */
+#line 3113 "/projects/git/fluffos/src/compiler/internal/grammar.y"
             {
       (yyval.node) = 0;
     }
-#line 5776 "/projects/git/fluffos/build/src/grammar.autogen.cc"
+#line 5856 "/projects/git/fluffos/build/src/grammar.autogen.cc"
     break;
 
-  case 246: /* opt_class_init: opt_class_init ',' class_init  */
-#line 3071 "/projects/git/fluffos/src/compiler/internal/grammar.y"
+  case 253: /* opt_class_init: opt_class_init ',' class_init  */
+#line 3117 "/projects/git/fluffos/src/compiler/internal/grammar.y"
     {
       (yyval.node) = (yyvsp[0].node);
       (yyval.node)->r.expr = (yyvsp[-2].node);
     }
-#line 5785 "/projects/git/fluffos/build/src/grammar.autogen.cc"
+#line 5865 "/projects/git/fluffos/build/src/grammar.autogen.cc"
     break;
 
-  case 247: /* @17: %empty  */
-#line 3079 "/projects/git/fluffos/src/compiler/internal/grammar.y"
+  case 254: /* @17: %empty  */
+#line 3125 "/projects/git/fluffos/src/compiler/internal/grammar.y"
     {
       (yyval.number) = context;
       (yyvsp[0].number) = num_refs;
       context |= ARG_LIST;
     }
-#line 5795 "/projects/git/fluffos/build/src/grammar.autogen.cc"
+#line 5875 "/projects/git/fluffos/build/src/grammar.autogen.cc"
     break;
 
-  case 248: /* function_call: efun_override '(' @17 expr_list ')'  */
-#line 3085 "/projects/git/fluffos/src/compiler/internal/grammar.y"
+  case 255: /* function_call: efun_override '(' @17 expr_list ')'  */
+#line 3131 "/projects/git/fluffos/src/compiler/internal/grammar.y"
     {
       context = (yyvsp[-2].number);
       (yyval.node) = validate_efun_call((yyvsp[-4].number),(yyvsp[-1].node));
       (yyval.node) = check_refs(num_refs - (yyvsp[-3].number), (yyvsp[-1].node), (yyval.node));
       num_refs = (yyvsp[-3].number);
     }
-#line 5806 "/projects/git/fluffos/build/src/grammar.autogen.cc"
+#line 5886 "/projects/git/fluffos/build/src/grammar.autogen.cc"
     break;
 
-  case 249: /* @18: %empty  */
-#line 3092 "/projects/git/fluffos/src/compiler/internal/grammar.y"
+  case 256: /* @18: %empty  */
+#line 3138 "/projects/git/fluffos/src/compiler/internal/grammar.y"
     {
       (yyval.number) = context;
       (yyvsp[0].number) = num_refs;
       context |= ARG_LIST;
     }
-#line 5816 "/projects/git/fluffos/build/src/grammar.autogen.cc"
+#line 5896 "/projects/git/fluffos/build/src/grammar.autogen.cc"
     break;
 
-  case 250: /* function_call: L_NEW '(' @18 expr_list ')'  */
-#line 3098 "/projects/git/fluffos/src/compiler/internal/grammar.y"
+  case 257: /* function_call: L_NEW '(' @18 expr_list ')'  */
+#line 3144 "/projects/git/fluffos/src/compiler/internal/grammar.y"
     {
       ident_hash_elem_t *ihe;
       int f;
@@ -5841,11 +5921,11 @@ yyreduce:
       (yyval.node) = check_refs(num_refs - (yyvsp[-3].number), (yyvsp[-1].node), (yyval.node));
       num_refs = (yyvsp[-3].number);
     }
-#line 5845 "/projects/git/fluffos/build/src/grammar.autogen.cc"
+#line 5925 "/projects/git/fluffos/build/src/grammar.autogen.cc"
     break;
 
-  case 251: /* function_call: L_NEW '(' L_CLASS L_DEFINED_NAME opt_class_init ')'  */
-#line 3123 "/projects/git/fluffos/src/compiler/internal/grammar.y"
+  case 258: /* function_call: L_NEW '(' L_CLASS L_DEFINED_NAME opt_class_init ')'  */
+#line 3169 "/projects/git/fluffos/src/compiler/internal/grammar.y"
     {
       parse_node_t *node;
 
@@ -5880,11 +5960,11 @@ yyreduce:
         }
       }
     }
-#line 5884 "/projects/git/fluffos/build/src/grammar.autogen.cc"
+#line 5964 "/projects/git/fluffos/build/src/grammar.autogen.cc"
     break;
 
-  case 252: /* function_call: L_NEW '(' L_CLASS L_IDENTIFIER opt_class_init ')'  */
-#line 3158 "/projects/git/fluffos/src/compiler/internal/grammar.y"
+  case 259: /* function_call: L_NEW '(' L_CLASS L_IDENTIFIER opt_class_init ')'  */
+#line 3204 "/projects/git/fluffos/src/compiler/internal/grammar.y"
     {
       parse_node_t *node;
       char buf[256];
@@ -5902,21 +5982,21 @@ yyreduce:
         node = node->r.expr;
       }
     }
-#line 5906 "/projects/git/fluffos/build/src/grammar.autogen.cc"
+#line 5986 "/projects/git/fluffos/build/src/grammar.autogen.cc"
     break;
 
-  case 253: /* @19: %empty  */
-#line 3176 "/projects/git/fluffos/src/compiler/internal/grammar.y"
+  case 260: /* @19: %empty  */
+#line 3222 "/projects/git/fluffos/src/compiler/internal/grammar.y"
     {
       (yyval.number) = context;
       (yyvsp[0].number) = num_refs;
       context |= ARG_LIST;
     }
-#line 5916 "/projects/git/fluffos/build/src/grammar.autogen.cc"
+#line 5996 "/projects/git/fluffos/build/src/grammar.autogen.cc"
     break;
 
-  case 254: /* function_call: L_DEFINED_NAME '(' @19 expr_list ')'  */
-#line 3182 "/projects/git/fluffos/src/compiler/internal/grammar.y"
+  case 261: /* function_call: L_DEFINED_NAME '(' @19 expr_list ')'  */
+#line 3228 "/projects/git/fluffos/src/compiler/internal/grammar.y"
     {
       int f;
       int i;
@@ -6045,21 +6125,21 @@ yyreduce:
       (yyval.node) = check_refs(num_refs - (yyvsp[-3].number), (yyvsp[-1].node), (yyval.node));
       num_refs = (yyvsp[-3].number);
     }
-#line 6049 "/projects/git/fluffos/build/src/grammar.autogen.cc"
+#line 6129 "/projects/git/fluffos/build/src/grammar.autogen.cc"
     break;
 
-  case 255: /* @20: %empty  */
-#line 3311 "/projects/git/fluffos/src/compiler/internal/grammar.y"
+  case 262: /* @20: %empty  */
+#line 3357 "/projects/git/fluffos/src/compiler/internal/grammar.y"
     {
       (yyval.number) = context;
       (yyvsp[0].number) = num_refs;
       context |= ARG_LIST;
     }
-#line 6059 "/projects/git/fluffos/build/src/grammar.autogen.cc"
+#line 6139 "/projects/git/fluffos/build/src/grammar.autogen.cc"
     break;
 
-  case 256: /* function_call: function_name '(' @20 expr_list ')'  */
-#line 3317 "/projects/git/fluffos/src/compiler/internal/grammar.y"
+  case 263: /* function_call: function_name '(' @20 expr_list ')'  */
+#line 3363 "/projects/git/fluffos/src/compiler/internal/grammar.y"
     {
       char *name = (yyvsp[-4].string);
 
@@ -6121,21 +6201,21 @@ yyreduce:
       num_refs = (yyvsp[-3].number);
       scratch_free(name);
     }
-#line 6125 "/projects/git/fluffos/build/src/grammar.autogen.cc"
+#line 6205 "/projects/git/fluffos/build/src/grammar.autogen.cc"
     break;
 
-  case 257: /* @21: %empty  */
-#line 3379 "/projects/git/fluffos/src/compiler/internal/grammar.y"
+  case 264: /* @21: %empty  */
+#line 3425 "/projects/git/fluffos/src/compiler/internal/grammar.y"
     {
       (yyval.number) = context;
       (yyvsp[0].number) = num_refs;
       context |= ARG_LIST;
     }
-#line 6135 "/projects/git/fluffos/build/src/grammar.autogen.cc"
+#line 6215 "/projects/git/fluffos/build/src/grammar.autogen.cc"
     break;
 
-  case 258: /* function_call: expr4 '[' comma_expr ']' '(' @21 expr_list ')'  */
-#line 3385 "/projects/git/fluffos/src/compiler/internal/grammar.y"
+  case 265: /* function_call: expr4 '[' comma_expr ']' '(' @21 expr_list ')'  */
+#line 3431 "/projects/git/fluffos/src/compiler/internal/grammar.y"
     {
       parse_node_t *expr;
       parse_node_t *index_expr;
@@ -6180,21 +6260,21 @@ yyreduce:
       (yyval.node) = check_refs(num_refs - (yyvsp[-3].number), (yyvsp[-1].node), (yyval.node));
       num_refs = (yyvsp[-3].number);
     }
-#line 6184 "/projects/git/fluffos/build/src/grammar.autogen.cc"
+#line 6264 "/projects/git/fluffos/build/src/grammar.autogen.cc"
     break;
 
-  case 259: /* @22: %empty  */
-#line 3430 "/projects/git/fluffos/src/compiler/internal/grammar.y"
+  case 266: /* @22: %empty  */
+#line 3476 "/projects/git/fluffos/src/compiler/internal/grammar.y"
     {
       (yyval.number) = context;
       (yyvsp[0].number) = num_refs;
       context |= ARG_LIST;
     }
-#line 6194 "/projects/git/fluffos/build/src/grammar.autogen.cc"
+#line 6274 "/projects/git/fluffos/build/src/grammar.autogen.cc"
     break;
 
-  case 260: /* function_call: expr4 L_ARROW identifier '(' @22 expr_list ')'  */
-#line 3436 "/projects/git/fluffos/src/compiler/internal/grammar.y"
+  case 267: /* function_call: expr4 L_ARROW identifier '(' @22 expr_list ')'  */
+#line 3482 "/projects/git/fluffos/src/compiler/internal/grammar.y"
     {
       ident_hash_elem_t *ihe;
       int f;
@@ -6239,21 +6319,21 @@ yyreduce:
       (yyval.node) = check_refs(num_refs - (yyvsp[-3].number), (yyvsp[-1].node), (yyval.node));
       num_refs = (yyvsp[-3].number);
     }
-#line 6243 "/projects/git/fluffos/build/src/grammar.autogen.cc"
+#line 6323 "/projects/git/fluffos/build/src/grammar.autogen.cc"
     break;
 
-  case 261: /* @23: %empty  */
-#line 3481 "/projects/git/fluffos/src/compiler/internal/grammar.y"
+  case 268: /* @23: %empty  */
+#line 3527 "/projects/git/fluffos/src/compiler/internal/grammar.y"
     {
       (yyval.number) = context;
       (yyvsp[0].number) = num_refs;
       context |= ARG_LIST;
     }
-#line 6253 "/projects/git/fluffos/build/src/grammar.autogen.cc"
+#line 6333 "/projects/git/fluffos/build/src/grammar.autogen.cc"
     break;
 
-  case 262: /* function_call: '(' '*' comma_expr ')' '(' @23 expr_list ')'  */
-#line 3487 "/projects/git/fluffos/src/compiler/internal/grammar.y"
+  case 269: /* function_call: '(' '*' comma_expr ')' '(' @23 expr_list ')'  */
+#line 3533 "/projects/git/fluffos/src/compiler/internal/grammar.y"
     {
       parse_node_t *expr;
 
@@ -6275,11 +6355,11 @@ yyreduce:
       (yyval.node) = check_refs(num_refs - (yyvsp[-3].number), (yyvsp[-1].node), (yyval.node));
       num_refs = (yyvsp[-3].number);
     }
-#line 6279 "/projects/git/fluffos/build/src/grammar.autogen.cc"
+#line 6359 "/projects/git/fluffos/build/src/grammar.autogen.cc"
     break;
 
-  case 263: /* efun_override: L_EFUN L_COLON_COLON identifier  */
-#line 3512 "/projects/git/fluffos/src/compiler/internal/grammar.y"
+  case 270: /* efun_override: L_EFUN L_COLON_COLON identifier  */
+#line 3558 "/projects/git/fluffos/src/compiler/internal/grammar.y"
     {
       svalue_t *res;
       ident_hash_elem_t *ihe;
@@ -6299,11 +6379,11 @@ yyreduce:
       }
       scratch_free((yyvsp[0].string));
     }
-#line 6303 "/projects/git/fluffos/build/src/grammar.autogen.cc"
+#line 6383 "/projects/git/fluffos/build/src/grammar.autogen.cc"
     break;
 
-  case 264: /* efun_override: L_EFUN L_COLON_COLON L_NEW  */
-#line 3532 "/projects/git/fluffos/src/compiler/internal/grammar.y"
+  case 271: /* efun_override: L_EFUN L_COLON_COLON L_NEW  */
+#line 3578 "/projects/git/fluffos/src/compiler/internal/grammar.y"
     {
       svalue_t *res;
 
@@ -6316,11 +6396,11 @@ yyreduce:
         (yyval.number) = -1;
       } else (yyval.number) = new_efun;
     }
-#line 6320 "/projects/git/fluffos/build/src/grammar.autogen.cc"
+#line 6400 "/projects/git/fluffos/build/src/grammar.autogen.cc"
     break;
 
-  case 266: /* function_name: L_COLON_COLON identifier  */
-#line 3549 "/projects/git/fluffos/src/compiler/internal/grammar.y"
+  case 273: /* function_name: L_COLON_COLON identifier  */
+#line 3595 "/projects/git/fluffos/src/compiler/internal/grammar.y"
     {
       int l = strlen((yyvsp[0].string)) + 1;
       char *p;
@@ -6334,11 +6414,11 @@ yyreduce:
         *(p+3) = *p;
       strncpy((yyval.string), ":::", 3);
     }
-#line 6338 "/projects/git/fluffos/build/src/grammar.autogen.cc"
+#line 6418 "/projects/git/fluffos/build/src/grammar.autogen.cc"
     break;
 
-  case 267: /* function_name: L_BASIC_TYPE L_COLON_COLON identifier  */
-#line 3563 "/projects/git/fluffos/src/compiler/internal/grammar.y"
+  case 274: /* function_name: L_BASIC_TYPE L_COLON_COLON identifier  */
+#line 3609 "/projects/git/fluffos/src/compiler/internal/grammar.y"
     {
       int z, l = strlen((yyvsp[0].string)) + 1;
       char *p;
@@ -6353,11 +6433,11 @@ yyreduce:
       (yyval.string)[z-2] = ':';
       (yyval.string)[z-1] = ':';
     }
-#line 6357 "/projects/git/fluffos/build/src/grammar.autogen.cc"
+#line 6437 "/projects/git/fluffos/build/src/grammar.autogen.cc"
     break;
 
-  case 268: /* function_name: identifier L_COLON_COLON identifier  */
-#line 3578 "/projects/git/fluffos/src/compiler/internal/grammar.y"
+  case 275: /* function_name: identifier L_COLON_COLON identifier  */
+#line 3624 "/projects/git/fluffos/src/compiler/internal/grammar.y"
     {
       int l = strlen((yyvsp[-2].string));
       /* "ob" and "name" -> ":ob::name" */
@@ -6369,11 +6449,11 @@ yyreduce:
       scratch_free((yyvsp[-2].string));
       scratch_free((yyvsp[0].string));
     }
-#line 6373 "/projects/git/fluffos/build/src/grammar.autogen.cc"
+#line 6453 "/projects/git/fluffos/build/src/grammar.autogen.cc"
     break;
 
-  case 269: /* cond: L_IF '(' comma_expr ')' statement optional_else_part  */
-#line 3593 "/projects/git/fluffos/src/compiler/internal/grammar.y"
+  case 276: /* cond: L_IF '(' comma_expr ')' statement optional_else_part  */
+#line 3639 "/projects/git/fluffos/src/compiler/internal/grammar.y"
     {
       /* x != 0 -> x */
       if (IS_NODE((yyvsp[-3].node), NODE_BINARY_OP, F_NE)) {
@@ -6404,27 +6484,27 @@ yyreduce:
       }
       CREATE_IF((yyval.node), (yyvsp[-3].node), (yyvsp[-1].node), (yyvsp[0].node));
     }
-#line 6408 "/projects/git/fluffos/build/src/grammar.autogen.cc"
+#line 6488 "/projects/git/fluffos/build/src/grammar.autogen.cc"
     break;
 
-  case 270: /* optional_else_part: %empty  */
-#line 3627 "/projects/git/fluffos/src/compiler/internal/grammar.y"
+  case 277: /* optional_else_part: %empty  */
+#line 3673 "/projects/git/fluffos/src/compiler/internal/grammar.y"
     {
       (yyval.node) = 0;
     }
-#line 6416 "/projects/git/fluffos/build/src/grammar.autogen.cc"
+#line 6496 "/projects/git/fluffos/build/src/grammar.autogen.cc"
     break;
 
-  case 271: /* optional_else_part: L_ELSE statement  */
-#line 3631 "/projects/git/fluffos/src/compiler/internal/grammar.y"
+  case 278: /* optional_else_part: L_ELSE statement  */
+#line 3677 "/projects/git/fluffos/src/compiler/internal/grammar.y"
     {
       (yyval.node) = (yyvsp[0].node);
     }
-#line 6424 "/projects/git/fluffos/build/src/grammar.autogen.cc"
+#line 6504 "/projects/git/fluffos/build/src/grammar.autogen.cc"
     break;
 
 
-#line 6428 "/projects/git/fluffos/build/src/grammar.autogen.cc"
+#line 6508 "/projects/git/fluffos/build/src/grammar.autogen.cc"
 
         default: break;
       }
@@ -6659,5 +6739,5 @@ yyreturnlab:
   return yyresult;
 }
 
-#line 3635 "/projects/git/fluffos/src/compiler/internal/grammar.y"
+#line 3681 "/projects/git/fluffos/src/compiler/internal/grammar.y"
 

--- a/src/compiler/internal/grammar.autogen.h
+++ b/src/compiler/internal/grammar.autogen.h
@@ -105,10 +105,13 @@ extern int yydebug;
     L_NEW = 306,                   /* L_NEW  */
     L_PARAMETER = 307,             /* L_PARAMETER  */
     L_TREE = 308,                  /* L_TREE  */
-    L_PREPROCESSOR_COMMAND = 309,  /* L_PREPROCESSOR_COMMAND  */
-    LOWER_THAN_ELSE = 310,         /* LOWER_THAN_ELSE  */
-    L_EQ = 311,                    /* L_EQ  */
-    L_NE = 312                     /* L_NE  */
+    L_TEMPLATE_HEAD = 309,         /* L_TEMPLATE_HEAD  */
+    L_TEMPLATE_MIDDLE = 310,       /* L_TEMPLATE_MIDDLE  */
+    L_TEMPLATE_TAIL = 311,         /* L_TEMPLATE_TAIL  */
+    L_PREPROCESSOR_COMMAND = 312,  /* L_PREPROCESSOR_COMMAND  */
+    LOWER_THAN_ELSE = 313,         /* LOWER_THAN_ELSE  */
+    L_EQ = 314,                    /* L_EQ  */
+    L_NE = 315                     /* L_NE  */
   };
   typedef enum yytokentype yytoken_kind_t;
 #endif
@@ -117,7 +120,7 @@ extern int yydebug;
 #if ! defined YYSTYPE && ! defined YYSTYPE_IS_DECLARED
 union YYSTYPE
 {
-#line 131 "/projects/git/fluffos/src/compiler/internal/grammar.y"
+#line 134 "/projects/git/fluffos/src/compiler/internal/grammar.y"
 
   LPC_INT number; /* 8 */
   LPC_FLOAT real; /* 8 */
@@ -138,7 +141,7 @@ union YYSTYPE
     uint16_t save_exact_types;
   } func_block; /* 8 */
 
-#line 142 "/projects/git/fluffos/build/src/grammar.autogen.h"
+#line 145 "/projects/git/fluffos/build/src/grammar.autogen.h"
 
 };
 typedef union YYSTYPE YYSTYPE;

--- a/src/compiler/internal/grammar.y
+++ b/src/compiler/internal/grammar.y
@@ -87,6 +87,9 @@ int yyparse (void);
 // only in DEBUG
 %token L_TREE
 
+// Template literals
+%token L_TEMPLATE_HEAD L_TEMPLATE_MIDDLE L_TEMPLATE_TAIL
+
 // Only ever used in lpcfmt
 %token L_PREPROCESSOR_COMMAND
 
@@ -171,6 +174,7 @@ int yyparse (void);
 
 /* holds a string constant */
 %type <string> L_STRING string_con1 string_con2
+%type <string> L_TEMPLATE_HEAD L_TEMPLATE_MIDDLE L_TEMPLATE_TAIL
 
 /* Holds the number of elements in a list and whether it must be a prototype */
 %type <argument> argument_list argument
@@ -193,7 +197,7 @@ int yyparse (void);
 
 /* The following return a parse node */
 %type <node> optional_default_arg_value
-%type <node> number real string expr0 comma_expr for_expr sscanf catch
+%type <node> number real string string_like template_literal template_parts expr0 comma_expr for_expr sscanf catch
 %type <node> parse_command time_expression expr_list expr_list2 expr_list3
 %type <node> expr_list4 assoc_pair expr4 lvalue function_call lvalue_list
 %type <node> new_local_def statement while cond do switch case
@@ -2691,7 +2695,7 @@ expr4:
         }
       } else $$->type = TYPE_ANY;
     }
-  | string
+  | string_like
   | '(' comma_expr ')'
     {
       $$ = $2;
@@ -3049,6 +3053,48 @@ string_con2:
   | string_con2 L_STRING
     {
       $$ = scratch_join($1, $2);
+    }
+;
+
+template_literal:
+  L_TEMPLATE_HEAD expr0 template_parts
+    {
+      parse_node_t *head, *tmp, *coerced;
+      CREATE_STRING(head, $1);
+      scratch_free($1);
+      CREATE_UNARY_OP(coerced, F_TEMPLATE_COERCE, TYPE_STRING, $2);
+      CREATE_BINARY_OP(tmp, F_ADD, TYPE_STRING, head, coerced);
+      CREATE_BINARY_OP($$, F_ADD, TYPE_STRING, tmp, $3);
+    }
+;
+
+template_parts:
+  L_TEMPLATE_TAIL
+    {
+      CREATE_STRING($$, $1);
+      scratch_free($1);
+    }
+  | L_TEMPLATE_MIDDLE expr0 template_parts
+    {
+      parse_node_t *mid, *tmp, *coerced;
+      CREATE_STRING(mid, $1);
+      scratch_free($1);
+      CREATE_UNARY_OP(coerced, F_TEMPLATE_COERCE, TYPE_STRING, $2);
+      CREATE_BINARY_OP(tmp, F_ADD, TYPE_STRING, mid, coerced);
+      CREATE_BINARY_OP($$, F_ADD, TYPE_STRING, tmp, $3);
+    }
+;
+
+string_like:
+  string
+  | template_literal
+  | string_like string
+    {
+      CREATE_BINARY_OP($$, F_ADD, TYPE_STRING, $1, $2);
+    }
+  | string_like template_literal
+    {
+      CREATE_BINARY_OP($$, F_ADD, TYPE_STRING, $1, $2);
     }
 ;
 

--- a/src/compiler/internal/lex.cc
+++ b/src/compiler/internal/lex.cc
@@ -126,6 +126,15 @@ typedef struct incstate_s {
 
 static incstate_t *inctop = nullptr;
 
+/* Template literal state tracking.
+ * When the lexer encounters a backtick, it enters template literal mode.
+ * template_brace_depth tracks nested {} within ${...} expressions.
+ * template_nesting tracks nested template literals (backtick within backtick).
+ */
+#define MAX_TEMPLATE_NESTING 16
+static int template_nesting = 0;
+static int template_brace_depth[MAX_TEMPLATE_NESTING];
+
 /* prevent unbridled recursion */
 #define MAX_INCLUDE_DEPTH 32
 static int incnum;
@@ -1808,6 +1817,8 @@ static int old_func() {
    at this function */
 static void lex_breakpoint() {}
 
+static int parseTemplateLiteralFragment(bool is_continuation);
+
 int yylex() {
   static char partial[MAXLINE + 5]; /* extra 5 for safety buffer */
   static char terminator[MAXLINE + 5];
@@ -2119,8 +2130,20 @@ int yylex() {
         return L_PARAMETER;
       }
       case ')':
+        return c;
       case '{':
+        if (template_nesting > 0) {
+          template_brace_depth[template_nesting]++;
+        }
+        return c;
       case '}':
+        if (template_nesting > 0 && template_brace_depth[template_nesting] == 0) {
+          return parseTemplateLiteralFragment(true);
+        }
+        if (template_nesting > 0) {
+          template_brace_depth[template_nesting]--;
+        }
+        return c;
       case '[':
       case ']':
       case ';':
@@ -2463,6 +2486,8 @@ int yylex() {
       } break;
       case '"':
         return parseStringLiteral(c);
+      case '`':
+        return parseTemplateLiteralFragment(false);
       case '0':
         c = *outp++;
         if (c == 'X' || c == 'x') {
@@ -3074,6 +3099,150 @@ int parseStringLiteral(unsigned char c) {
   }
 }
 
+/*
+ * Scan a template literal string fragment.
+ * Called when:
+ *   - The lexer encounters a backtick (start of template literal)
+ *   - The lexer encounters } that closes a ${...} interpolation
+ *
+ * Scans characters into yytext until it hits:
+ *   - ${ : end of fragment, start of interpolation (returns L_TEMPLATE_HEAD or L_TEMPLATE_MIDDLE)
+ *   - `  : end of template literal (returns L_STRING or L_TEMPLATE_TAIL)
+ *
+ * Uses scratch_large_alloc for the result to avoid scratch buffer corruption
+ * when string literals appear inside ${...} interpolation expressions.
+ *
+ * is_continuation: false if this is the start (after backtick), true if after }
+ */
+static int parseTemplateLiteralFragment(bool is_continuation) {
+  char *yyp = yytext;
+  bool has_interpolation = false;
+
+  for (;;) {
+    unsigned char c = *outp++;
+
+    switch (c) {
+      case LEX_EOF:
+        lexerror("End of file in template literal");
+        return YYEOF;
+
+      case '\n':
+        current_line++;
+        total_lines++;
+        if (outp == last_nl + 1) {
+          refill_buffer();
+        }
+        continue;
+
+      case '\\':
+        c = *outp++;
+        switch (c) {
+          case '\n':
+            current_line++;
+            total_lines++;
+            if (outp == last_nl + 1) {
+              refill_buffer();
+            }
+            continue;
+          case 'n': *yyp++ = '\n'; break;
+          case 't': *yyp++ = '\t'; break;
+          case 'r': *yyp++ = '\r'; break;
+          case 'b': *yyp++ = '\b'; break;
+          case 'a': *yyp++ = '\x07'; break;
+          case 'e': *yyp++ = '\x1b'; break;
+          case '`': *yyp++ = '`'; break;
+          case '$': *yyp++ = '$'; break;
+          case '\\': *yyp++ = '\\'; break;
+          case '0': case '1': case '2': case '3':
+          case '4': case '5': case '6': case '7': {
+            int val = c - '0';
+            c = *outp;
+            if (c >= '0' && c <= '7') {
+              val = (val << 3) + c - '0';
+              outp++;
+              c = *outp;
+              if (c >= '0' && c <= '7') {
+                val = (val << 3) + c - '0';
+                outp++;
+              }
+            }
+            *yyp++ = (char)val;
+            break;
+          }
+          case 'x': {
+            int val = 0;
+            c = *outp;
+            if ((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F')) {
+              val = (c >= '0' && c <= '9') ? c - '0' : (c >= 'a' ? c - 'a' + 10 : c - 'A' + 10);
+              outp++;
+              c = *outp;
+              if ((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F')) {
+                val = (val << 4) + ((c >= '0' && c <= '9') ? c - '0' : (c >= 'a' ? c - 'a' + 10 : c - 'A' + 10));
+                outp++;
+              }
+            }
+            *yyp++ = (char)val;
+            break;
+          }
+          default:
+            *yyp++ = c;
+            break;
+        }
+        break;
+
+      case '$':
+        if (*outp == '{') {
+          outp++;
+          has_interpolation = true;
+          goto done;
+        }
+        *yyp++ = '$';
+        break;
+
+      case '`':
+        goto done;
+
+      default:
+        *yyp++ = c;
+        break;
+    }
+
+    if (yyp >= yytext + MAXLINE - 5) {
+      lexerror("Template literal string too long");
+      return YYerror;
+    }
+  }
+
+done:
+  *yyp = '\0';
+  if (!u8_validate(yytext)) {
+    lexerror("Invalid UTF8 in template literal");
+    return YYerror;
+  }
+  {
+    int slen = yyp - yytext + 1;
+    char *res = scratch_large_alloc(slen);
+    memcpy(res, yytext, slen);
+    yylval.string = res;
+  }
+  if (has_interpolation) {
+    if (!is_continuation) {
+      template_nesting++;
+      if (template_nesting >= MAX_TEMPLATE_NESTING) {
+        lexerror("Template literal nesting too deep");
+        return YYerror;
+      }
+    }
+    template_brace_depth[template_nesting] = 0;
+    return is_continuation ? L_TEMPLATE_MIDDLE : L_TEMPLATE_HEAD;
+  } else {
+    if (is_continuation) {
+      template_nesting--;
+    }
+    return is_continuation ? L_TEMPLATE_TAIL : L_STRING;
+  }
+}
+
 extern YYSTYPE yylval;
 
 void end_new_file() {
@@ -3324,6 +3493,7 @@ void start_new_file(std::unique_ptr<LexStream> stream) {
   }
   current_stream = std::move(stream);
   lex_fatal = 0;
+  template_nesting = 0;
   last_function_context = -1;
   current_function_context = nullptr;
   cur_lbuf = &head_lbuf;
@@ -3510,6 +3680,9 @@ static void init_instrs() {
 #endif
 #ifdef F_ASSIGN_VALUE
   add_instr_name("assign_value", 0, F_ASSIGN_VALUE, -1);
+#endif
+#ifdef F_TEMPLATE_COERCE
+  add_instr_name("template_coerce", 0, F_TEMPLATE_COERCE, T_STRING);
 #endif
   add_instr_name("-=", "f_sub_eq();\n", F_SUB_EQ, T_ANY);
 #ifdef F_JUMP

--- a/src/include/opcodes_extra.h
+++ b/src/include/opcodes_extra.h
@@ -20,3 +20,7 @@
 #ifndef F_ASSIGN_VALUE
 #define F_ASSIGN_VALUE 234  // Assign with (value, lvalue) stack order
 #endif
+
+#ifndef F_TEMPLATE_COERCE
+#define F_TEMPLATE_COERCE 235  // Coerce value to string for template literals (%g for floats)
+#endif

--- a/src/packages/core/sprintf.cc
+++ b/src/packages/core/sprintf.cc
@@ -99,6 +99,7 @@ using format_info = unsigned int;
 #define INFO_T_HEX 0xB
 #define INFO_T_C_HEX 0xC
 #define INFO_T_FLOAT 0xD
+#define INFO_T_GFLOAT 0xE
 
 #define INFO_J 0x30
 #define INFO_J_CENTRE 0x10
@@ -965,6 +966,9 @@ char *string_print_formatted(const char *format_str, int argc, svalue_t *argv) {
           case 'f':
             finfo |= INFO_T_FLOAT;
             break;
+          case 'g':
+            finfo |= INFO_T_GFLOAT;
+            break;
           case 'c':
             finfo |= INFO_T_CHAR;
             break;
@@ -1279,6 +1283,9 @@ char *string_print_formatted(const char *format_str, int argc, svalue_t *argv) {
               cheat[i++] = 'l';
               cheat[i++] = 'f';
               break;
+            case INFO_T_GFLOAT:
+              cheat[i++] = 'g';
+              break;
             case INFO_T_OCT:
               cheat[i++] = 'l';
               cheat[i++] = 'l';
@@ -1297,7 +1304,7 @@ char *string_print_formatted(const char *format_str, int argc, svalue_t *argv) {
             default:
               SPRINTF_ERROR(ERR_BAD_INT_TYPE);
           }
-          if ((cheat[i - 1] == 'f' && carg->type == T_NUMBER)) {
+          if (((cheat[i - 1] == 'f' || cheat[i - 1] == 'g') && carg->type == T_NUMBER)) {
             // convert to T_REAL
             LPC_FLOAT temp = carg->u.number;
             carg->type = T_REAL;
@@ -1307,8 +1314,8 @@ char *string_print_formatted(const char *format_str, int argc, svalue_t *argv) {
             LPC_INT temp = floor(carg->u.real);
             carg->type = T_NUMBER;
             carg->u.number = temp;
-          } else if ((cheat[i - 1] == 'f' && carg->type != T_REAL) ||
-              (cheat[i - 1] != 'f' && carg->type != T_NUMBER)) {
+          } else if (((cheat[i - 1] == 'f' || cheat[i - 1] == 'g') && carg->type != T_REAL) ||
+              (cheat[i - 1] != 'f' && cheat[i - 1] != 'g' && carg->type != T_NUMBER)) {
             error("ERROR: (s)printf(): Incorrect argument type to %%%c.\n", cheat[i - 1]);
           }
           cheat[i] = '\0';

--- a/src/vm/internal/base/interpret.cc
+++ b/src/vm/internal/base/interpret.cc
@@ -3034,6 +3034,54 @@ void eval_instruction(char *p) {
         free_svalue(sp--, "F_ASSIGN_VALUE");
         break;
       }
+      case F_TEMPLATE_COERCE: {
+        /* Coerce top-of-stack value to string for template literal interpolation.
+         * Uses %g for floats (strips trailing zeros), %d-style for ints,
+         * pass-through for strings. */
+        switch (sp->type) {
+          case T_STRING:
+            /* already a string, nothing to do */
+            break;
+          case T_NUMBER: {
+            char buff[100];
+            sprintf(buff, "%" LPC_INT_FMTSTR_P, sp->u.number);
+            char *res = string_copy(buff, "F_TEMPLATE_COERCE");
+            sp->type = T_STRING;
+            sp->subtype = STRING_MALLOC;
+            sp->u.string = res;
+            break;
+          }
+          case T_REAL: {
+            char buff[400];
+            sprintf(buff, "%g", sp->u.real);
+            char *res = string_copy(buff, "F_TEMPLATE_COERCE");
+            sp->type = T_STRING;
+            sp->subtype = STRING_MALLOC;
+            sp->u.string = res;
+            break;
+          }
+          default: {
+            outbuffer_t outbuf;
+            outbuf_zero(&outbuf);
+            svalue_to_string(sp, &outbuf, 0, 0, 1);
+            outbuf_fix(&outbuf);
+            free_svalue(sp, "F_TEMPLATE_COERCE");
+            if (outbuf.buffer) {
+              char *res = string_copy(outbuf.buffer, "F_TEMPLATE_COERCE");
+              FREE(outbuf.buffer);
+              sp->type = T_STRING;
+              sp->subtype = STRING_MALLOC;
+              sp->u.string = res;
+            } else {
+              sp->type = T_STRING;
+              sp->subtype = STRING_MALLOC;
+              sp->u.string = string_copy("", "F_TEMPLATE_COERCE");
+            }
+            break;
+          }
+        }
+        break;
+      }
       case F_VOID_ASSIGN_LOCAL:
         if (sp->type != T_INVALID) {
           lval = fp + EXTRACT_UCHAR(pc++);

--- a/testsuite/single/tests/compiler/template_literal.c
+++ b/testsuite/single/tests/compiler/template_literal.c
@@ -1,0 +1,104 @@
+void do_tests() {
+  string name;
+  int count;
+  float price;
+  string result;
+
+  // Basic template literal with no interpolation
+  result = `hello world`;
+  ASSERT_EQ(result, "hello world");
+
+  // Simple variable interpolation
+  name = "Alice";
+  result = `Hello, ${name}!`;
+  ASSERT_EQ(result, "Hello, Alice!");
+
+  // Integer interpolation
+  count = 42;
+  result = `You have ${count} items.`;
+  ASSERT_EQ(result, "You have 42 items.");
+
+  // Float interpolation (should use %g coercion)
+  price = 3.14;
+  result = `Price: ${price}`;
+  ASSERT_EQ(result, "Price: 3.14");
+
+  // Multiple interpolations
+  name = "Bob";
+  count = 5;
+  result = `${name} has ${count} apples.`;
+  ASSERT_EQ(result, "Bob has 5 apples.");
+
+  // Expression in interpolation
+  count = 10;
+  result = `Double: ${count + count}`;
+  ASSERT_EQ(result, "Double: 20");
+
+  // Empty interpolation parts
+  name = "World";
+  result = `${name}`;
+  ASSERT_EQ(result, "World");
+
+  // Escape sequences
+  result = `hello\tworld`;
+  ASSERT_EQ(result, "hello\tworld");
+
+  // Escaped backtick
+  result = `hello \` world`;
+  ASSERT_EQ(result, "hello ` world");
+
+  // Escaped dollar-brace
+  result = `hello \${name} world`;
+  ASSERT_EQ(result, "hello ${name} world");
+
+  // Adjacent template literals collapse (like strings)
+  result = `hello`
+  `world`;
+  ASSERT_EQ(result, "helloworld");
+
+  // Adjacent: template with interpolation + plain template
+  name = "X";
+  result = `a${name}b`
+  `cd`;
+  ASSERT_EQ(result, "aXbcd");
+
+  // Adjacent: template with interpolation + template with interpolation
+  count = 1;
+  result = `${name}` `${count}`;
+  ASSERT_EQ(result, "X1");
+
+  // Adjacent: string + template with interpolation
+  result = "hi " `${name}!`;
+  ASSERT_EQ(result, "hi X!");
+
+  // Adjacent: template with interpolation + string
+  result = `${name}: ` "done";
+  ASSERT_EQ(result, "X: done");
+
+  // Function call in interpolation (no string arg)
+  count = 4;
+  result = `${count + 0} chars`;
+  ASSERT_EQ(result, "4 chars");
+
+  // Function call with parens
+  result = `len: ${strlen("hi")}`;
+  ASSERT_EQ(result, "len: 2");
+
+  // Function call with string arg and text after
+  result = `${strlen("hi")} chars`;
+  ASSERT_EQ(result, "2 chars");
+
+  // Template literal + template literal
+  name = "A";
+  count = 1;
+  result = `${name}` + `${count}`;
+  ASSERT_EQ(result, "A1");
+
+  // Template literal + string
+  result = `hi ${name}` + " there";
+  ASSERT_EQ(result, "hi A there");
+
+  // Adjacent template literals (no interpolation)
+  result = `foo` `bar`;
+  ASSERT_EQ(result, "foobar");
+}


### PR DESCRIPTION
Introduce template literals for string interpolation and a new %g format specifier for sprintf to handle floating-point numbers without trailing zeros. Update documentation to reflect these changes and ensure proper type coercion behavior.