### PR TITLE
Fix max_eval_cost() return type in docs: void → int

### DIFF
--- a/docs/efun/system/max_eval_cost.md
+++ b/docs/efun/system/max_eval_cost.md
@@ -10,7 +10,7 @@ title: system / max_eval_cost
 
 ### SYNOPSIS
 
-    void max_eval_cost()
+    int max_eval_cost()
 
 ### DESCRIPTION
 


### PR DESCRIPTION
## Summary
- The English docs for `max_eval_cost()` incorrectly listed the return type as `void` in the synopsis, despite the description saying it "returns the number of instructions"
- The spec (`int max_eval_cost set_eval_limit(int default: 1)`), the C++ implementation, and the zh-CN translation all correctly use `int`
- Fixed the synopsis from `void max_eval_cost()` to `int max_eval_cost()`

## Test plan
- [ ] Verify the docs render correctly with VitePress

_Recreated from #1188 (closed when fork was deleted)_

🤖 Generated with [Claude Code](https://claude.com/claude-code)