### PR TITLE
docs: correct pcre_replace_callback documentation

### DIFF
--- a/docs/efun/pcre/pcre_replace_callback.md
+++ b/docs/efun/pcre/pcre_replace_callback.md
@@ -6,21 +6,96 @@ title: pcre / pcre_replace_callback
 
 ### NAME
 
-    pcre_replace_callback() - string replace uses a callback to get the replace string
+    pcre_replace_callback() - replace captured groups using a callback
 
 ### SYNOPSIS
 
-    string pcre_replace_callback(string input, string pattern, string|function, mixed *args..., void|int pcre_flags);
+    string pcre_replace_callback(string subject, string pattern,
+                                 function fun,
+                                 mixed extra..., void|int pcre_flags);
+
+    string pcre_replace_callback(string subject, string pattern,
+                                 string fun, object|string ob,
+                                 mixed extra..., void|int pcre_flags);
 
 ### DESCRIPTION
 
-    returns a string where all captured groups have been replaced by the return
-    value of function pointer fun or function fun in object ob. (called with
-    the matched string and match number, starting with 0).
+    Returns a copy of `subject` in which each captured group of
+    `pattern` has been replaced by the value returned from invoking
+    `fun`.
 
-    The optional `pcre_flags` sets PCRE options (e.g., `PCRE_I` for
-    case-insensitive, `PCRE_M` for multiline). Defaults to 0.
+    The callback is called once for each capture group in the
+    pattern, left-to-right. Group 0 (the whole match) is never
+    passed. Each invocation receives:
+
+      string  matched   - the text captured by this group
+      int     index     - the 0-based index of this capture group
+                          (PCRE group 1 -> 0, group 2 -> 1, ...)
+      ...extra          - any additional arguments supplied at the
+                          call site, forwarded verbatim
+
+    The callback's return value replaces the captured text in the
+    output. If the callback returns a non-string value (including 0),
+    the original captured text is used unchanged.
+
+    When `fun` is a function pointer, no `ob` argument is supplied.
+    When `fun` is a string, the next argument must name an object
+    (either an `object` value or its filename) in which to look up
+    the function.
+
+    If `pattern` does not match `subject`, the callback is not
+    invoked and `subject` is returned unchanged.
+
+    The optional `pcre_flags` argument sets PCRE options:
+
+      PCRE_I   case-insensitive matching
+      PCRE_M   multiline (^ and $ match at line breaks)
+      PCRE_S   dotall (`.` also matches newline)
+      PCRE_U   ungreedy quantifiers
+      PCRE_X   extended (ignore unescaped whitespace and `#` comments)
+      PCRE_A   anchored matching
+
+    Flags may be combined with `|`. Defaults to 0. When supplied,
+    `pcre_flags` must be the final argument and an int. Because a
+    trailing int is always consumed as `pcre_flags`, an extra
+    argument intended for the callback must not be a bare int at the
+    tail of the argument list.
+
+### EXAMPLES
+
+    // One match, multiple capture groups; callback fires per group.
+    string label(string found, int group_index) {
+        return sprintf("[%d:%s]", group_index, found);
+    }
+
+    string s = pcre_replace_callback("foo-bar-baz",
+                                     "(\\w+)-(\\w+)-(\\w+)",
+                                     "label", this_object());
+    // s == "[0:foo]-[1:bar]-[2:baz]"
+
+    // Function-pointer form (no `ob` argument).
+    string s = pcre_replace_callback("foo-bar-baz",
+                                     "(\\w+)-(\\w+)-(\\w+)",
+                                     (: sprintf("[%d:%s]", $2, $1) :));
+    // s == "[0:foo]-[1:bar]-[2:baz]"
+
+    // Forwarding extra arguments to the callback.
+    string wrap(string found, int idx, string prefix, string suffix) {
+        return prefix + found + suffix;
+    }
+
+    string s = pcre_replace_callback("hello world",
+                                     "(world)",
+                                     "wrap", this_object(),
+                                     "<", ">");
+    // s == "hello <world>"
+
+    // No match returns the subject unchanged.
+    string s = pcre_replace_callback("hello", "(xyz)",
+                                     "wrap", this_object());
+    // s == "hello"
 
 ### SEE ALSO
 
-    pcre_assoc(3), pcre_cache(3), pcre_extract(3), pcre_replace(3)
+    pcre_assoc(3), pcre_cache(3), pcre_extract(3), pcre_match(3),
+    pcre_match_all(3), pcre_replace(3), pcre_version(3)


### PR DESCRIPTION
## Summary

The existing `docs/efun/pcre/pcre_replace_callback.md` did not match the implementation in `src/packages/pcre/pcre.cc`. This PR rewrites the doc to reflect actual behavior.

### Issues with the previous doc

- **Wrong synopsis** — showed `string|function` followed directly by `mixed *args...`, but when the callback is a string, an `object|string ob` argument is required between them (enforced by `process_efun_callback` in `interpret.cc`).
- **Callback contract undocumented** — the description said only "called with the matched string and match number". The second argument is actually the **0-based index of the capture group being processed** (PCRE group 1 → 0, group 2 → 1, ...), and the callback is invoked once per capture group with group 0 (the whole match) excluded. Extra arguments at the call site are forwarded to the callback after the index — this wasn't mentioned at all.
- **Fallback behavior undocumented** — if the callback returns a non-string value (including 0), the original captured text is reused (`pcre.cc:360-364`).
- **No-match behavior undocumented** — when the pattern doesn't match, the callback is never invoked and the subject string is returned unchanged (`pcre.cc:326-329`).
- **Incomplete flag list** — only `PCRE_I` and `PCRE_M` were mentioned. The driver also supports `PCRE_S`, `PCRE_U`, `PCRE_X`, and `PCRE_A` (per `src/include/pcre_flags.h`).
- **Trailing-int gotcha** — because `pcre_flags` is detected by checking whether the final argument is an int, an extra argument intended for the callback must not be a bare int at the tail. Now called out explicitly.

### What changed

- Synopsis split into two forms (function-pointer vs string-with-object).
- Callback signature `(string matched, int index, ...extra)` documented, including how `index` maps to PCRE group numbers.
- Added sections covering fallback on non-string return, no-match behavior, complete flag list, and the trailing-int caveat.
- Added four worked examples: string-callback form, function-pointer form, extras forwarding, no-match.
- Expanded SEE ALSO to include `pcre_match`, `pcre_match_all`, `pcre_version`.

The Chinese translation at `docs/zh-CN/efun/pcre_replace_callback.md` was left untouched and may want a follow-up update.

## Test plan

- [ ] Verify documentation builds with VitePress (`cd docs && npm run dev`)
- [ ] Verify examples compile and run as described against current driver
- [ ] Spot-check rendered output for formatting