### PR TITLE
Document sort_array extra args forwarded to comparator

### DIFF
--- a/docs/efun/arrays/sort_array.md
+++ b/docs/efun/arrays/sort_array.md
@@ -10,8 +10,9 @@ title: arrays / sort_array
 
 ### SYNOPSIS
 
-    mixed *sort_array( mixed *arr, string fun, object ob );
-    mixed *sort_array( mixed *arr, function f );
+    mixed *sort_array( mixed *arr, string fun, object ob,
+                       mixed extra, ... );
+    mixed *sort_array( mixed *arr, function f, mixed extra, ... );
     mixed *sort_array( mixed *arr, int direction );
 
 ### DESCRIPTION
@@ -24,6 +25,12 @@ title: arrays / sort_array
 
     The second form does the same thing but allows a function pointer to be
     used instead.
+
+    For the first and second forms, any additional arguments  passed  after
+    the comparison function are forwarded to it on each call, appearing af‐
+    ter  the  two  elements  being  compared.  This is useful for threading
+    context (such as a lookup mapping) through to the comparator without  a
+    closure.
 
     The third form returns an array with the same elements  as  'arr',  but
     quicksorted using built-in sort routines.  A 'direction' of 1 or 0 will


### PR DESCRIPTION
## Summary

The efun spec ([core.spec L222](https://github.com/fluffos/fluffos/blob/master/src/packages/core/core.spec#L222)):

```c
mixed *sort_array(mixed *, int | string | function, ...);
```

…and `f_sort_array` ([array.cc L1184](https://github.com/fluffos/fluffos/blob/master/src/vm/internal/base/array.cc#L1184)) using `process_efun_callback` both support trailing extra arguments that are forwarded to the comparison function on each call — the same mechanism `map_array` and `filter_array` use. But [docs/efun/arrays/sort_array.md](https://github.com/fluffos/fluffos/blob/master/docs/efun/arrays/sort_array.md) only showed the three base forms, with no mention of extra args.

This patch updates the synopsis to match the style already used in [map_array.md](https://github.com/fluffos/fluffos/blob/master/docs/efun/arrays/map_array.md) and [filter_array.md](https://github.com/fluffos/fluffos/blob/master/docs/efun/arrays/filter_array.md), and adds a paragraph describing the behaviour.

## Test plan

- [x] Diff renders cleanly against neighbouring `map_array.md`/`filter_array.md` style
- [ ] No code changes; doc-only