### PR TITLE
Fixed typo in code example

### DIFF
--- a/docs/stdlib/mappings/element_of_weighted.md
+++ b/docs/stdlib/mappings/element_of_weighted.md
@@ -29,7 +29,7 @@ title: stdlib / element_of_weighted
 
 ```c
 mapping colors = ([ "red" : 50, "green" : 25, "blue" : 25 ]);
-string result = element_weighted( colors );
+string result = element_of_weighted( colors );
 // High chance of "red" being returned while lower, and equal chances
 // of green and blue being returned.
 ```


### PR DESCRIPTION
The example in the code missed the word "of" in the function title.

Very simple PR.