### PR TITLE
Generate driver config docs and a starter config from rc.cc tables

### DIFF
--- a/.github/workflows/config-docs.yml
+++ b/.github/workflows/config-docs.yml
@@ -1,0 +1,34 @@
+name: Config Docs
+
+# Verifies that docs/driver/config.md is regenerated whenever the runtime config
+# tables in rc.cc change. The doc is generated from INT_FLAGS[] / STR_FLAGS[] by
+# docs/gen_config_docs.py; if a contributor edits the tables without re-running
+# the generator, this job fails and tells them what to run.
+
+on:
+  push:
+    branches: [master]
+    paths:
+      - 'src/base/internal/rc.cc'
+      - 'src/base/internal/options_internal.h'
+      - 'docs/gen_config_docs.py'
+      - 'docs/driver/config.md'
+  pull_request:
+    branches: [master]
+    paths:
+      - 'src/base/internal/rc.cc'
+      - 'src/base/internal/options_internal.h'
+      - 'docs/gen_config_docs.py'
+      - 'docs/driver/config.md'
+
+jobs:
+  check:
+    name: config.md is up to date
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - name: Verify generated config docs
+        run: python3 docs/gen_config_docs.py --check

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -128,7 +128,8 @@ cd testsuite
 
 ## Continuous Integration
 
-FluffOS uses GitHub Actions for comprehensive CI/CD across multiple platforms and configurations.
+FluffOS uses GitHub Actions for comprehensive CI/CD across multiple platforms
+and configurations.
 
 ### CI Matrix
 
@@ -147,7 +148,8 @@ FluffOS uses GitHub Actions for comprehensive CI/CD across multiple platforms an
 - **Environment Variables**:
   - `OPENSSL_ROOT_DIR=/usr/local/opt/openssl`
   - `ICU_ROOT=/opt/homebrew/opt/icu4c`
-- **Dependencies**: cmake, pkg-config, pcre, libgcrypt, openssl, jemalloc, icu4c, mysql, sqlite3, googletest
+- **Dependencies**: cmake, pkg-config, pcre, libgcrypt, openssl, jemalloc,
+  icu4c, mysql, sqlite3, googletest
 
 **Windows CI** (`.github/workflows/ci-windows.yml`)
 
@@ -158,7 +160,8 @@ FluffOS uses GitHub Actions for comprehensive CI/CD across multiple platforms an
   - `-DPACKAGE_CRYPTO=OFF`
   - `-DPACKAGE_DB_MYSQL=""` (disabled)
   - `-DPACKAGE_DB_SQLITE=1`
-- **Dependencies**: mingw-w64 toolchain, cmake, zlib, pcre, icu, sqlite3, jemalloc, gtest
+- **Dependencies**: mingw-w64 toolchain, cmake, zlib, pcre, icu, sqlite3,
+  jemalloc, gtest
 
 **Sanitizer CI** (`.github/workflows/ci-sanitizer.yml`)
 
@@ -177,8 +180,10 @@ FluffOS uses GitHub Actions for comprehensive CI/CD across multiple platforms an
 
 **Code Quality CI**
 
-- **CodeQL Analysis** (`.github/workflows/codeql-analysis.yml`): Security vulnerability detection
-- **Coverity Scan** (`.github/workflows/coverity-scan.yml`): Static analysis (weekly schedule + push)
+- **CodeQL Analysis** (`.github/workflows/codeql-analysis.yml`): Security
+  vulnerability detection
+- **Coverity Scan** (`.github/workflows/coverity-scan.yml`): Static analysis
+  (weekly schedule + push)
 
 **Documentation CI** (`.github/workflows/gh-pages.yml`)
 
@@ -330,9 +335,11 @@ brew install cmake pkg-config mysql pcre libgcrypt openssl jemalloc icu4c \
   sqlite3 googletest  # Added sqlite3 and googletest for testing
 
 # Build with environment variables (for Apple Silicon)
-OPENSSL_ROOT_DIR="/usr/local/opt/openssl" ICU_ROOT="/opt/homebrew/opt/icu4c" cmake ..
+OPENSSL_ROOT_DIR="/usr/local/opt/openssl" \
+  ICU_ROOT="/opt/homebrew/opt/icu4c" cmake ..
 # For Intel Macs, use:
-# OPENSSL_ROOT_DIR="/usr/local/opt/openssl" ICU_ROOT="/usr/local/opt/icu4c" cmake ..
+# OPENSSL_ROOT_DIR="/usr/local/opt/openssl" \
+#   ICU_ROOT="/usr/local/opt/icu4c" cmake ..
 ```
 
 ### Windows (MSYS2)
@@ -384,6 +391,24 @@ cmake -G "MSYS Makefiles" -DMARCH_NATIVE=OFF \
 1. Edit `src/compiler/grammar.y` for syntax changes
 2. Regenerate grammar with Bison if available
 3. Update corresponding compiler components
+
+### Modifying Runtime Config Options
+
+Runtime config options (the settings in a driver config file) are defined in
+the `INT_FLAGS[]` and `STR_FLAGS[]` tables in `src/base/internal/rc.cc`. These
+tables are the single source of truth: the driver parses config files from them,
+and `docs/driver/config.md` is generated from their `category`/`description`
+fields by `docs/gen_config_docs.py`.
+
+1. Add/change/remove the option's entry in the relevant table in `rc.cc`
+   (include a one-line `description` and a `category`)
+2. Regenerate the docs: `python3 docs/gen_config_docs.py`
+3. Commit `rc.cc` and the regenerated `docs/driver/config.md` together
+
+CI (`.github/workflows/config-docs.yml`) re-runs the generator with `--check`
+and fails if the doc is out of date. Options with irregular parsing (ports,
+external commands, the global include file, the default fail message) are
+hand-documented in the `SPECIAL_OPTIONS` section of `docs/gen_config_docs.py`.
 
 ### Debugging Memory Issues
 

--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -216,12 +216,35 @@ Brief description.
 Documentation about driver internals, architecture, and configuration.
 
 **Topics:**
-- `config.md` - Configuration file format and options
+- `config.md` - Configuration file format and options (**auto-generated**, see below)
 - `adding_efuns.md` - How to add new efuns
 - `stackmachine.md` - VM architecture
 - `parse_tree.md` - Compiler internals
 - `call_into_vm.md` - VM integration
 - `malloc.md` - Memory management
+
+**`config.md` is generated -- do not edit it by hand.** Runtime config options
+are the `INT_FLAGS[]` and `STR_FLAGS[]` tables in
+`src/base/internal/rc.cc`, which are the source of truth for both the parser and
+the docs. `docs/gen_config_docs.py` renders `config.md` from those tables
+(their `category`/`description` fields are the prose).
+
+**Finding/Updating Config Options in Source:**
+```bash
+# The recognized options and their docs (source of truth):
+#   src/base/internal/rc.cc  ->  INT_FLAGS[] (int), STR_FLAGS[] (string)
+# A few irregular ones (ports, external_cmd, global include file, default fail
+# message) are hand-documented in the SPECIAL_OPTIONS block of the generator.
+
+# Regenerate the doc after any rc.cc table change:
+python3 docs/gen_config_docs.py
+
+# Verify the committed doc is up to date (this is what CI runs):
+python3 docs/gen_config_docs.py --check
+```
+Never add an option to `config.md` that is not in `rc.cc` -- edit the table and
+regenerate instead. CI (`.github/workflows/config-docs.yml`) fails if the doc is
+stale.
 
 ### 5. Build Documentation (`/docs/`)
 
@@ -497,6 +520,7 @@ When updating documentation:
 - [ ] Check applies list matches `src/vm/internal/applies`
 - [ ] Verify efun specs match package `.spec` files
 - [ ] Confirm CLI tools match `CMakeLists.txt` executables
+- [ ] Regenerate config docs if `rc.cc` changed (`python3 docs/gen_config_docs.py --check`)
 - [ ] Validate all index files are up-to-date
 - [ ] Test code examples for correctness
 - [ ] Check cross-references aren't broken

--- a/docs/cli/driver.md
+++ b/docs/cli/driver.md
@@ -19,6 +19,7 @@ title: cli / driver
 | `-f<flag>`               | After initialization, before opening network connections, driver will call `void flag(string)` function on master object. |
 | `-d<category>`           | Enable debug logging, this flag can occur multiple times. This is same as calling `set_debug_level()` EFUN.               |
 | `--tracing <trace_file>` | Enable LPC tracing                                                                                                        |
+| `--generate-config`      | Print a starter config file (all options, with defaults and comments) to stdout and exit. Redirect to a file to use it.  |
 
 ## Debug logging Categories
 

--- a/docs/driver/config.md
+++ b/docs/driver/config.md
@@ -2,11 +2,21 @@
 layout: doc
 title: driver / config
 ---
+<!-- ===========================================================================
+     AUTO-GENERATED FILE -- DO NOT EDIT BY HAND.
+
+     This page is generated from the INT_FLAGS[] and STR_FLAGS[] tables in
+     src/base/internal/rc.cc by docs/gen_config_docs.py. To change an option's
+     documentation, edit its `category`/`description` in rc.cc and run:
+
+         python3 docs/gen_config_docs.py
+
+     CI (.github/workflows/config-docs.yml) verifies this file is up to date.
+=========================================================================== -->
 # Driver Configuration File
 
-FluffOS uses a runtime configuration file to specify various settings for the MUD server. This file is passed as an argument when starting the driver.
-
-## Basic Usage
+FluffOS reads a runtime configuration file at startup to configure the driver.
+The file is passed as the first argument to the `driver` executable.
 
 ```bash
 ./driver path/to/config.cfg
@@ -14,219 +24,217 @@ FluffOS uses a runtime configuration file to specify various settings for the MU
 
 ## File Format
 
-- Lines beginning with `#` are comments
-- Empty lines are ignored
-- Format: `setting_name : value`
-- Paths are relative to the mudlib directory (except mudlib directory itself)
+- Lines beginning with `#` are comments; blank lines are ignored.
+- One setting per line, in the form `setting name : value`.
+- Most mudlib paths are relative to the mudlib directory; exceptions are noted
+  per option (e.g. `mudlib directory` is an absolute OS path, and `log directory`
+  is a filesystem path relative to the driver's working directory).
+- Integer options out of range are reset to their default with a warning.
 
-## Core Settings
+For extended commentary and example values, see the annotated `src/Config.example`
+in the source tree. The tables below are generated directly from the driver, so
+they always match the options it actually recognizes.
+
+## Options
 
 ### Identity & Network
 
-| Setting | Description | Example |
-|---------|-------------|---------|
-| `name` | Name of your MUD | `name : My MUD` |
-| `mud ip` | IP address to bind to (0.0.0.0 for all) | `mud ip : 0.0.0.0` |
-| `port number` | Primary telnet port | `port number : 4000` |
-
-### External Ports
-
-FluffOS supports multiple external ports with different protocols:
-
-```
-# Basic telnet port
-external_port_1: telnet 5000
-
-# WebSocket port
-external_port_2: websocket 8080
-
-# WebSocket with TLS
-external_port_3: websocket 8443
-external_port_3_tls: cert=path/to/cert.pem key=path/to/key.pem
-
-# Telnet with TLS
-external_port_4: telnet 4443
-external_port_4_tls: cert=path/to/cert.pem key=path/to/key.pem
-```
-
-**WebSocket Support:**
-```
-websocket http dir : path/to/www
-```
-Specifies the directory containing the web client HTML/JS files.
+| Setting | Type | Default | Description |
+|---------|------|---------|-------------|
+| `name` | string | — | **Required.** Name of this MUD. |
+| `mud ip` | string | — | IP address to bind to; useful on hosts with multiple network addresses. |
 
 ### Directory Structure
 
-| Setting | Description | Example |
-|---------|-------------|---------|
-| `mudlib directory` | Absolute path to mudlib | `mudlib directory : /home/mud/lib` |
-| `log directory` | Where to store logs | `log directory : /log` |
-| `include directories` | Paths for #include <> | `include directories : /include:/sys` |
+| Setting | Type | Default | Description |
+|---------|------|---------|-------------|
+| `mudlib directory` | string | — | **Required.** Absolute path to the mudlib root (this path is not relative to the mudlib). |
+| `log directory` | string | — | **Required.** Filesystem directory for debug.log and stats files, resolved relative to the driver's working directory (leading slashes are stripped); not a mudlib virtual path. |
+| `include directories` | string | — | **Required.** Colon-separated list of directories searched by `#include <...>`. |
 
 ### Core Files
 
-| Setting | Description | Example |
-|---------|-------------|---------|
-| `master file` | Path to master object | `master file : /single/master` |
-| `simulated efun file` | Path to simul_efun object | `simulated efun file : /single/simul_efun` |
-| `global include file` | Auto-included in all objects | `global include file : <globals.h>` |
+| Setting | Type | Default | Description |
+|---------|------|---------|-------------|
+| `master file` | string | — | **Required.** Path to the object that defines the master object. |
+| `simulated efun file` | string | — | Path to the object that defines global simulated efuns. |
 
 ### Logging
 
-| Setting | Description | Example |
-|---------|-------------|---------|
-| `debug log file` | Debug output filename | `debug log file : debug.log` |
-| `log commands` | Log all player commands | `log commands : 0` |
+| Setting | Type | Default | Description |
+|---------|------|---------|-------------|
+| `debug log file` | string | — | **Recommended.** Filename (within the log directory) for the driver's debug log. |
 
 ### Error Handling
 
-| Setting | Description | Example |
-|---------|-------------|---------|
-| `default error message` | Message when no action matches | `default error message : What?` |
-| `default fail message` | Default notify_fail message | `default fail message : What?` |
+| Setting | Type | Default | Description |
+|---------|------|---------|-------------|
+| `mudlib error handler` | int | 1 | Pass runtime errors to the master object's error_handler() instead of handling them in the driver. |
+| `trap crashes` | int | 1 | Call crash() in the master object and shut down cleanly on signals that would otherwise crash the driver. |
+| `default error message` | string | — | Message shown to players when error() occurs. |
 
-### Memory Management
+### Timing & Lifecycle
 
-| Setting | Description | Example |
-|---------|-------------|---------|
-| `time to clean up` | Seconds before cleanup | `time to clean up : 600` |
-| `time to reset` | Seconds between resets | `time to reset : 1800` |
-| `time to swap` | Seconds before swap | `time to swap : 300` |
-| `evaluator stack size` | Max function call depth | `evaluator stack size : 65536` |
-| `inherit chain size` | Max inheritance depth | `inherit chain size : 30` |
+| Setting | Type | Default | Description |
+|---------|------|---------|-------------|
+| `time to clean up` | int | 600 | Seconds an object may be idle before clean_up() is called on it; should be well above 'time to swap'. |
+| `time to reset` | int | 900 | Seconds between successive reset() calls on an object. |
+| `time to swap` | int | 300 | Seconds an unused object stays in memory before being swapped out; 0 disables swapping. |
+| `gametick msec` | int | 1000 | Granularity of in-game time in milliseconds (the shortest visible time interval). |
+| `heartbeat interval msec` | int | 1000 | Heartbeat interval in milliseconds. |
 
-### Performance & Limits
+### Limits
 
-| Setting | Description | Example |
-|---------|-------------|---------|
-| `maximum array size` | Max array elements | `maximum array size : 15000` |
-| `maximum buffer size` | Max buffer size | `maximum buffer size : 400000` |
-| `maximum mapping size` | Max mapping size | `maximum mapping size : 150000` |
-| `maximum string length` | Max string length | `maximum string length : 200000` |
-| `maximum bits in a bitfield` | Max bitfield size | `maximum bits in a bitfield : 12000` |
-| `maximum byte transfer` | Max bytes per read/write | `maximum byte transfer : 200000` |
-| `maximum read file size` | Max file read size | `maximum read file size : 200000` |
+| Setting | Type | Default | Description |
+|---------|------|---------|-------------|
+| `evaluator stack size` | int | 65536 | Maximum size of the evaluator stack, which holds all local variables and call arguments. |
+| `inherit chain size` | int | 30 | Maximum depth of an object's inheritance chain. |
+| `maximum evaluation cost` | int | 30000000 | Maximum eval cost a single thread may consume before execution is aborted. |
+| `maximum local variables` | int | 64 | Maximum number of local variables in a single function. _(range 64-255)_ |
+| `maximum call depth` | int | 150 | Maximum nesting depth of LPC function calls. |
+| `maximum array size` | int | 15000 | Maximum number of elements in a single array. |
+| `maximum buffer size` | int | 1048576 | Maximum size, in bytes, of a single buffer variable. |
+| `maximum mapping size` | int | 150000 | Maximum number of entries in a single mapping. |
+| `maximum string length` | int | 1048576 | Maximum length, in bytes, of a single string variable. |
+| `maximum bits in a bitfield` | int | 12000 | Maximum number of bits in a bitfield (stored 6 bits per printable byte). |
+| `maximum byte transfer` | int | 262144 | Maximum number of bytes a single read_bytes()/write_bytes() call may transfer. |
+| `maximum read file size` | int | 262144 | Maximum size, in bytes, of a file that read_file() may read. |
 
-### Execution Limits
+### Hash Tables
 
-| Setting | Description | Example |
-|---------|-------------|---------|
-| `max eval cost` | Max ticks per execution | `max eval cost : 5000000` |
-| `max local variables` | Max local vars per function | `max local variables : 30` |
-| `max call depth` | Max nested calls | `max call depth : 150` |
+| Setting | Type | Default | Description |
+|---------|------|---------|-------------|
+| `hash table size` | int | 65536 | Size of the shared-string hash table; should be prime, roughly 1/5 of the number of distinct strings. _(min 7001)_ |
+| `object table size` | int | 4096 | Size of the object hash table; roughly 1/4 of the number of objects in the game. _(min 1024)_ |
+| `living hash table size` | int | 256 | Size of the find_living() hash table; must be one of 4, 16, 64, 256, 1024, or 4096. _(min 256)_ |
+
+### Reset Behavior
+
+| Setting | Type | Default | Description |
+|---------|------|---------|-------------|
+| `no resets` | int | 0 | Completely disable the periodic calling of reset(). |
+| `lazy resets` | int | 0 | Only call reset() when an object is touched via call_other() or move_object(). |
+| `randomized resets` | int | 1 | Spread reset() calls over a randomized interval rather than firing them all at once. |
+
+### Language Behavior
+
+| Setting | Type | Default | Description |
+|---------|------|---------|-------------|
+| `sane explode string` | int | 1 | explode() strips at most one leading delimiter (and still one trailing delimiter). |
+| `reversible explode string` | int | 0 | Make implode(explode(x, y), y) always equal x; overrides 'sane explode string'. |
+| `sane sorting` | int | 1 | Use a well-defined, stable ordering for the driver's sorting operations. |
+| `wombles` | int | 0 | Disallow spaces between the start/end token characters of arrays, mappings, and functionals. |
+| `this_player in call_out` | int | 1 | Make this_player() usable from within call_out() callbacks. |
+| `reverse defer` | int | 0 | Run deferred functions registered with defer() in reverse order. |
+| `old range behavior` | int | 0 | Treat negative range indices in strings/buffers as counting from the end (rvalue use only). |
+| `warn old range behavior` | int | 1 | Warn when code relies on 'old range behavior'. |
+| `enable_commands call init` | int | 1 | Call init() in an object when enable_commands() is invoked on it. |
+| `sprintf add_justified ignore ANSI colors` | int | 1 | Make sprintf() column justification ignore ANSI color codes when computing field width. |
+| `call_out(0) nest level` | int | 1000 | Maximum nesting level for chains of call_out(0) within a single backend cycle. |
+
+### Type Checking
+
+| Setting | Type | Default | Description |
+|---------|------|---------|-------------|
+| `call other type check` | int | 0 | Enable type checking for call_other() (the -> operator on objects). |
+| `call other warn` | int | 0 | Emit warnings instead of errors for call_other() type mismatches. |
+| `old type behavior` | int | 0 | Reintroduce a legacy type-checking bug for backwards compatibility. |
+
+### Player I/O
+
+| Setting | Type | Default | Description |
+|---------|------|---------|-------------|
+| `no ansi` | int | 1 | Replace ANSI escape characters (ASCII 27) in user input with a space before add_actions run. |
+| `strip before process input` | int | 1 | Strip ANSI before process_input() sees the input, rather than only before add_actions are called. |
+| `interactive catch tell` | int | 0 | Call catch_tell() on interactive users as well as on NPCs. |
+| `receive snoop` | int | 1 | Send snoop text to receive_snoop() in the snooper instead of directly via add_message(). |
+| `snoop shadowed` | int | 0 | Report snooped output even when the target's catch_tell() is shadowed (prefixed with $$). |
+| `noninteractive stderr write` | int | 0 | Write tells/messages sent to non-interactive objects to stderr, prefixed with ']' (legacy behavior). |
+
+### Diagnostics
+
+| Setting | Type | Default | Description |
+|---------|------|---------|-------------|
+| `warn tab` | int | 0 | Warn when source files are indented with tabs instead of spaces. |
+| `trace` | int | 1 | Enable the trace() and traceprefix() efuns (leaving it off runs slightly faster). |
+| `trace code` | int | 0 | Include the preceding lines of LPC code in error traces (slower). |
+| `has console` | int | 1 | Allow the driver's interactive console via the -C command-line argument. |
+| `suppress argument warnings` | int | 1 | Suppress unused-argument warnings, warning only about unused local variables. |
+| `trace lpc execution context` | int | 0 | Record LPC execution context for tracing and debugging. |
+| `trace lpc instructions` | int | 0 | Trace individual LPC instructions for debugging. |
 
 ### Protocol Support
 
-| Setting | Description | Example |
-|---------|-------------|---------|
-| `enable mxp` | Enable MXP protocol | `enable mxp : 1` |
-| `enable gmcp` | Enable GMCP protocol | `enable gmcp : 1` |
-| `enable zmp` | Enable ZMP protocol | `enable zmp : 1` |
-| `enable mssp` | Enable MSSP protocol | `enable mssp : 1` |
-| `enable msp` | Enable MSP protocol | `enable msp : 1` |
+| Setting | Type | Default | Description |
+|---------|------|---------|-------------|
+| `enable mxp` | int | 0 | Advertise and enable the MXP telnet protocol. |
+| `enable gmcp` | int | 0 | Advertise and enable the GMCP telnet protocol. |
+| `enable zmp` | int | 0 | Advertise and enable the ZMP telnet protocol. |
+| `enable mssp` | int | 1 | Advertise and enable the MSSP telnet protocol. |
+| `enable msp` | int | 1 | Advertise and enable the MSP telnet protocol. |
+| `enable msdp` | int | 0 | Advertise and enable the MSDP telnet protocol. |
 
-### Compression
+## Ports and Connections
 
-| Setting | Description | Example |
-|---------|-------------|---------|
-| `compress protocol` | Enable MCCP2 | `compress protocol : 1` |
-
-### Security
-
-| Setting | Description | Example |
-|---------|-------------|---------|
-| `valid bind` | Check valid_bind() apply | `valid bind : 1` |
-| `valid override` | Check valid_override() apply | `valid override : 1` |
-
-## Example Configuration
+The listening ports are configured with numbered `external_port_N` entries
+(N = 1 to 5). Each names a protocol and a port number:
 
 ```
-###############################################################################
-#                     FluffOS Configuration Example                          #
-###############################################################################
-
-# MUD Identity
-name : MyMUD
-mud ip : 0.0.0.0
-port number : 4000
-
-# Additional Ports
-external_port_1: websocket 8080
-external_port_2: telnet 5000
-
-# WebSocket Client
-websocket http dir : www
-
-# Directory Structure
-mudlib directory : /home/mud/lib
-log directory : /log
-include directories : /include:/sys
-
-# Core Files
-master file : /single/master
-simulated efun file : /single/simul_efun
-global include file : <globals.h>
-
-# Logging
-debug log file : debug.log
-
-# Memory & Performance
-time to clean up : 600
-time to reset : 1800
-max eval cost : 5000000
-evaluator stack size : 65536
-
-# Protocol Support
-enable gmcp : 1
-enable mxp : 1
-compress protocol : 1
-
-# Limits
-maximum array size : 15000
-maximum string length : 200000
-maximum mapping size : 150000
+external_port_1 : telnet 4000
+external_port_2 : binary 4001
+external_port_3 : websocket 8080
 ```
 
-## Tips
+Recognized protocols are `telnet`, `binary`, `ascii`, `MUD`, and `websocket`.
 
-**Development Config:**
-- Lower limits for faster testing
-- Enable debug logging
-- Shorter cleanup/reset times
+| Setting | Description |
+|---------|-------------|
+| `external_port_N` | Protocol and port for listener N, e.g. `telnet 4000`. |
+| `external_port_N_tls` | Enable TLS on listener N: `cert=path/to/cert.pem key=path/to/key.pem`. |
+| `websocket http dir` | Directory (under `src/www`) of static files served to web clients; required when a `websocket` port is defined. |
+| `port number` | Legacy single telnet port; equivalent to defining `external_port_1 : telnet <n>`. |
 
-**Production Config:**
-- Higher limits for performance
-- Minimal logging
-- Enable compression
-- Configure TLS for security
+A `websocket` port requires `websocket http dir` to be set. With TLS, point
+`cert=`/`key=` at a PEM certificate and key, for example:
 
-**WebSocket Setup:**
 ```
-# Serve web client on port 8080
-external_port_1: websocket 8080
-websocket http dir : www
-
-# Place your index.html in: mudlib/../www/
+external_port_1 : telnet 4443
+external_port_1_tls : cert=etc/cert.pem key=etc/key.pem
 ```
 
-**TLS Certificate Setup:**
-```
-# Generate self-signed cert (development only)
-openssl req -x509 -newkey rsa:4096 -keyout key.pem \
-  -out cert.pem -days 365 -nodes
+## External Commands
 
-# Use in config
-external_port_1: telnet 4443
-external_port_1_tls: cert=etc/cert.pem key=etc/key.pem
-```
+When the driver is built with `PACKAGE_EXTERNAL`, external programs callable via
+`external_start()` are declared with numbered entries:
+
+| Setting | Description |
+|---------|-------------|
+| `external_cmd_N` | Command line for external slot N (1-based). |
+
+## Other Options
+
+| Setting | Description |
+|---------|-------------|
+| `global include file` | Header automatically `#include`d in every compiled object, e.g. `"/include/globals.h"` or `<globals.h>`. Quotes are added if omitted. |
+| `default fail message` | Message used when an action returns 0 and no `notify_fail()` was set. Defaults to `What?`. |
+
+## Obsolete Options
+
+These settings are no longer used and should be removed. The driver prints a
+warning if any of these appear: `address server ip`, `address server port`,
+`reserved size`, `fd6 kind`, `fd6 port`, `binary directory`, `swap file`.
+
+These are accepted for backwards compatibility but silently ignored:
+`maximum users`, `compiler stack size`.
 
 ## See Also
 
 - [driver](../cli/driver.md) - Driver command-line options
-- [get_config](../efun/internals/get_config.md) - Query config at runtime
-- [set_config](../efun/internals/set_config.md) - Modify config at runtime
+- [get_config](../efun/internals/get_config.md) - Query a config value at runtime
+- [set_config](../efun/internals/set_config.md) - Modify a config value at runtime
 
 ## Reference Files
 
-- Example config: `testsuite/etc/config.test` in the source
-- All options: See `src/include/runtime_config.h`
+- `src/base/internal/rc.cc` - The `INT_FLAGS[]` / `STR_FLAGS[]` tables (source of truth)
+- `src/Config.example` - Annotated example configuration
+- `src/include/runtime_config.h` - Config slot constants

--- a/docs/gen_config_docs.py
+++ b/docs/gen_config_docs.py
@@ -1,0 +1,445 @@
+#!/usr/bin/env python3
+"""Generate docs/driver/config.md from the runtime-config tables in rc.cc.
+
+The driver's recognized runtime config options live in two tables in
+src/base/internal/rc.cc:
+
+  * INT_FLAGS[]  -- integer options (name, default, min, max, category, prose)
+  * STR_FLAGS[]  -- simple string options (name, required, category, prose)
+
+Those tables are the single source of truth for both the parser AND this
+document, so the docs cannot drift from the driver as long as this script is
+re-run after editing them.
+
+Usage:
+    python3 docs/gen_config_docs.py            # regenerate docs/driver/config.md
+    python3 docs/gen_config_docs.py --check     # exit 1 if the doc is stale (CI)
+
+A handful of options with irregular parsing (the external ports, external
+commands, the global include file, and the default fail message) are not in the
+tables; they are documented from the hand-maintained SPECIAL_OPTIONS section
+below. When you add or change one of those in rc.cc, update SPECIAL_OPTIONS too.
+"""
+
+import argparse
+import os
+import sys
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+ROOT = os.path.dirname(HERE)
+RC_CC = os.path.join(ROOT, "src", "base", "internal", "rc.cc")
+OPTIONS_H = os.path.join(ROOT, "src", "base", "internal", "options_internal.h")
+OUTPUT = os.path.join(HERE, "driver", "config.md")
+
+# Order in which categories are emitted. Categories found in the tables but not
+# listed here are appended at the end (with a warning) so nothing is dropped.
+CATEGORY_ORDER = [
+    "Identity & Network",
+    "Directory Structure",
+    "Core Files",
+    "Logging",
+    "Error Handling",
+    "Timing & Lifecycle",
+    "Limits",
+    "Hash Tables",
+    "Reset Behavior",
+    "Language Behavior",
+    "Type Checking",
+    "Player I/O",
+    "Diagnostics",
+    "Performance",
+    "Protocol Support",
+]
+
+# Built-in integer constants the table defaults may reference.
+BUILTIN_CONSTS = {
+    "INT_MAX": 2147483647,
+    "UINT8_MAX": 255,
+}
+
+
+# --------------------------------------------------------------------------- #
+# Minimal C++ initializer parsing
+# --------------------------------------------------------------------------- #
+def _extract_array_body(text, decl):
+    """Return the text between the outermost braces of `<decl> = { ... }`."""
+    marker = decl + "[] = {"
+    start = text.find(marker)
+    if start < 0:
+        raise SystemExit(f"could not find `{marker}` in {RC_CC}")
+    i = start + len(marker)
+    depth, in_str, esc = 1, False, False
+    body = []
+    while i < len(text):
+        ch = text[i]
+        if in_str:
+            body.append(ch)
+            if esc:
+                esc = False
+            elif ch == "\\":
+                esc = True
+            elif ch == '"':
+                in_str = False
+        elif ch == '"':
+            in_str = True
+            body.append(ch)
+        elif ch == "{":
+            depth += 1
+            body.append(ch)
+        elif ch == "}":
+            depth -= 1
+            if depth == 0:
+                return "".join(body)
+            body.append(ch)
+        else:
+            body.append(ch)
+        i += 1
+    raise SystemExit(f"unterminated `{decl}` table in {RC_CC}")
+
+
+def _split_top_level_braces(body):
+    """Yield the inner text of each top-level `{ ... }` group in `body`."""
+    depth, in_str, esc, cur = 0, False, False, []
+    for ch in body:
+        if in_str:
+            cur.append(ch)
+            if esc:
+                esc = False
+            elif ch == "\\":
+                esc = True
+            elif ch == '"':
+                in_str = False
+            continue
+        if ch == '"':
+            in_str = True
+            cur.append(ch)
+            continue
+        if ch == "{":
+            depth += 1
+            if depth == 1:
+                cur = []
+                continue
+        if ch == "}":
+            depth -= 1
+            if depth == 0:
+                yield "".join(cur)
+                continue
+        if depth >= 1:
+            cur.append(ch)
+
+
+def _split_fields(entry):
+    """Split one initializer's comma-separated fields (quote-aware)."""
+    fields, cur, in_str, esc = [], [], False, False
+    for ch in entry:
+        if in_str:
+            cur.append(ch)
+            if esc:
+                esc = False
+            elif ch == "\\":
+                esc = True
+            elif ch == '"':
+                in_str = False
+            continue
+        if ch == '"':
+            in_str = True
+            cur.append(ch)
+            continue
+        if ch == ",":
+            fields.append("".join(cur).strip())
+            cur = []
+            continue
+        cur.append(ch)
+    tail = "".join(cur).strip()
+    if tail:
+        fields.append(tail)
+    return fields
+
+
+def _unquote(field):
+    field = field.strip()
+    if field.startswith('"') and field.endswith('"'):
+        field = field[1:-1]
+    return field.replace('\\"', '"').replace("\\\\", "\\")
+
+
+# --------------------------------------------------------------------------- #
+# Default-value resolution
+# --------------------------------------------------------------------------- #
+def _load_cfg_consts():
+    consts = dict(BUILTIN_CONSTS)
+    with open(OPTIONS_H, encoding="utf-8") as fh:
+        for line in fh:
+            parts = line.split()
+            if len(parts) >= 3 and parts[0] == "#define" and parts[2].lstrip("-").isdigit():
+                consts[parts[1]] = int(parts[2])
+    return consts
+
+
+def _resolve_int(expr, consts):
+    """Evaluate a simple integer expression (literals, shifts, named consts)."""
+    expr = expr.strip()
+    try:
+        # Restricted: no builtins, names limited to resolved config constants.
+        return int(eval(expr, {"__builtins__": {}}, consts))  # noqa: S307
+    except Exception:
+        return None
+
+
+# --------------------------------------------------------------------------- #
+# Option model
+# --------------------------------------------------------------------------- #
+REQUIRED_LABELS = {
+    "kMustHave": "required",
+    "kOptional": "optional",
+    "kWarnMissing": "recommended",
+}
+
+
+def parse_options(text, consts):
+    options = []
+
+    for entry in _split_top_level_braces(_extract_array_body(text, "INT_FLAGS")):
+        f = _split_fields(entry)
+        if len(f) != 7:
+            raise SystemExit(f"INT_FLAGS entry has {len(f)} fields, expected 7:\n  {entry}")
+        key, _pos, default, low, high, category, desc = f
+        options.append({
+            "key": _unquote(key),
+            "type": "int",
+            "default": _resolve_int(default, consts),
+            "default_src": default.strip(),
+            "min": _resolve_int(low, consts),
+            "max": _resolve_int(high, consts),
+            "category": _unquote(category),
+            "description": _unquote(desc),
+            "required": None,
+        })
+
+    for entry in _split_top_level_braces(_extract_array_body(text, "STR_FLAGS")):
+        f = _split_fields(entry)
+        if len(f) != 6:
+            raise SystemExit(f"STR_FLAGS entry has {len(f)} fields, expected 6:\n  {entry}")
+        key, _pos, required, _tag, category, desc = f
+        options.append({
+            "key": _unquote(key),
+            "type": "string",
+            "default": None,
+            "default_src": None,
+            "min": None,
+            "max": None,
+            "category": _unquote(category),
+            "description": _unquote(desc),
+            "required": REQUIRED_LABELS.get(required.strip(), required.strip()),
+        })
+
+    return options
+
+
+# --------------------------------------------------------------------------- #
+# Rendering
+# --------------------------------------------------------------------------- #
+HEADER = """\
+---
+layout: doc
+title: driver / config
+---
+<!-- ===========================================================================
+     AUTO-GENERATED FILE -- DO NOT EDIT BY HAND.
+
+     This page is generated from the INT_FLAGS[] and STR_FLAGS[] tables in
+     src/base/internal/rc.cc by docs/gen_config_docs.py. To change an option's
+     documentation, edit its `category`/`description` in rc.cc and run:
+
+         python3 docs/gen_config_docs.py
+
+     CI (.github/workflows/config-docs.yml) verifies this file is up to date.
+=========================================================================== -->
+# Driver Configuration File
+
+FluffOS reads a runtime configuration file at startup to configure the driver.
+The file is passed as the first argument to the `driver` executable.
+
+```bash
+./driver path/to/config.cfg
+```
+
+## File Format
+
+- Lines beginning with `#` are comments; blank lines are ignored.
+- One setting per line, in the form `setting name : value`.
+- Most mudlib paths are relative to the mudlib directory; exceptions are noted
+  per option (e.g. `mudlib directory` is an absolute OS path, and `log directory`
+  is a filesystem path relative to the driver's working directory).
+- Integer options out of range are reset to their default with a warning.
+
+For extended commentary and example values, see the annotated `src/Config.example`
+in the source tree. The tables below are generated directly from the driver, so
+they always match the options it actually recognizes.
+"""
+
+FOOTER = """\
+## See Also
+
+- [driver](../cli/driver.md) - Driver command-line options
+- [get_config](../efun/internals/get_config.md) - Query a config value at runtime
+- [set_config](../efun/internals/set_config.md) - Modify a config value at runtime
+
+## Reference Files
+
+- `src/base/internal/rc.cc` - The `INT_FLAGS[]` / `STR_FLAGS[]` tables (source of truth)
+- `src/Config.example` - Annotated example configuration
+- `src/include/runtime_config.h` - Config slot constants
+"""
+
+# Options parsed with irregular/dynamic handling in rc.cc, documented by hand.
+# Keep in sync with read_config() in src/base/internal/rc.cc.
+SPECIAL_OPTIONS = """\
+## Ports and Connections
+
+The listening ports are configured with numbered `external_port_N` entries
+(N = 1 to 5). Each names a protocol and a port number:
+
+```
+external_port_1 : telnet 4000
+external_port_2 : binary 4001
+external_port_3 : websocket 8080
+```
+
+Recognized protocols are `telnet`, `binary`, `ascii`, `MUD`, and `websocket`.
+
+| Setting | Description |
+|---------|-------------|
+| `external_port_N` | Protocol and port for listener N, e.g. `telnet 4000`. |
+| `external_port_N_tls` | Enable TLS on listener N: `cert=path/to/cert.pem key=path/to/key.pem`. |
+| `websocket http dir` | Directory (under `src/www`) of static files served to web clients; required when a `websocket` port is defined. |
+| `port number` | Legacy single telnet port; equivalent to defining `external_port_1 : telnet <n>`. |
+
+A `websocket` port requires `websocket http dir` to be set. With TLS, point
+`cert=`/`key=` at a PEM certificate and key, for example:
+
+```
+external_port_1 : telnet 4443
+external_port_1_tls : cert=etc/cert.pem key=etc/key.pem
+```
+
+## External Commands
+
+When the driver is built with `PACKAGE_EXTERNAL`, external programs callable via
+`external_start()` are declared with numbered entries:
+
+| Setting | Description |
+|---------|-------------|
+| `external_cmd_N` | Command line for external slot N (1-based). |
+
+## Other Options
+
+| Setting | Description |
+|---------|-------------|
+| `global include file` | Header automatically `#include`d in every compiled object, e.g. `"/include/globals.h"` or `<globals.h>`. Quotes are added if omitted. |
+| `default fail message` | Message used when an action returns 0 and no `notify_fail()` was set. Defaults to `What?`. |
+
+## Obsolete Options
+
+These settings are no longer used and should be removed. The driver prints a
+warning if any of these appear: `address server ip`, `address server port`,
+`reserved size`, `fd6 kind`, `fd6 port`, `binary directory`, `swap file`.
+
+These are accepted for backwards compatibility but silently ignored:
+`maximum users`, `compiler stack size`.
+"""
+
+
+def _range_note(opt):
+    low, high = opt["min"], opt["max"]
+    if low is None or high is None:
+        return ""
+    if low == 0 and high == BUILTIN_CONSTS["INT_MAX"]:
+        return ""
+    if high == BUILTIN_CONSTS["INT_MAX"]:
+        return f" _(min {low})_"
+    if low == 0:
+        return f" _(max {high})_"
+    return f" _(range {low}-{high})_"
+
+
+def _description_cell(opt):
+    desc = opt["description"]
+    if opt["type"] == "string" and opt["required"] in ("required", "recommended"):
+        desc = f"**{opt['required'].capitalize()}.** {desc}"
+    desc += _range_note(opt)
+    return desc.replace("|", "\\|")
+
+
+def _default_cell(opt):
+    if opt["type"] != "int":
+        return "—"
+    if opt["default"] is None:
+        return f"`{opt['default_src']}`"
+    return str(opt["default"])
+
+
+def render(options):
+    by_category = {}
+    for opt in options:
+        by_category.setdefault(opt["category"], []).append(opt)
+
+    ordered = [c for c in CATEGORY_ORDER if c in by_category]
+    extra = [c for c in by_category if c not in CATEGORY_ORDER]
+    if extra:
+        print(f"warning: categories not in CATEGORY_ORDER: {', '.join(sorted(extra))}",
+              file=sys.stderr)
+    ordered += sorted(extra)
+
+    parts = [HEADER, "## Options\n"]
+    for category in ordered:
+        parts.append(f"### {category}\n")
+        parts.append("| Setting | Type | Default | Description |")
+        parts.append("|---------|------|---------|-------------|")
+        for opt in by_category[category]:
+            parts.append(
+                f"| `{opt['key']}` | {opt['type']} | {_default_cell(opt)} | {_description_cell(opt)} |"
+            )
+        parts.append("")
+
+    parts.append(SPECIAL_OPTIONS)
+    parts.append(FOOTER)
+    return "\n".join(parts).rstrip() + "\n"
+
+
+# --------------------------------------------------------------------------- #
+# Entry point
+# --------------------------------------------------------------------------- #
+def main():
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--check", action="store_true",
+                    help="exit non-zero if docs/driver/config.md is out of date")
+    args = ap.parse_args()
+
+    with open(RC_CC, encoding="utf-8") as fh:
+        rc_text = fh.read()
+    consts = _load_cfg_consts()
+    options = parse_options(rc_text, consts)
+    generated = render(options)
+
+    if args.check:
+        try:
+            with open(OUTPUT, encoding="utf-8") as fh:
+                current = fh.read()
+        except FileNotFoundError:
+            current = None
+        if current != generated:
+            print("docs/driver/config.md is out of date.", file=sys.stderr)
+            print("Regenerate it with: python3 docs/gen_config_docs.py", file=sys.stderr)
+            return 1
+        print("docs/driver/config.md is up to date.")
+        return 0
+
+    with open(OUTPUT, "w", encoding="utf-8") as fh:
+        fh.write(generated)
+    print(f"wrote {os.path.relpath(OUTPUT, ROOT)} ({len(options)} table options)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/Config.example
+++ b/src/Config.example
@@ -2,7 +2,7 @@
 #              Customizable runtime config file for FluffOS                   #
 ###############################################################################
 # NOTE: All paths specified here are relative to the mudlib directory except  #
-#       for mudlib directory, and binary directory.                           #
+#       for the mudlib directory itself.                                      #
 # Lines beginning with a # or a newline are ignored.                          #
 ###############################################################################
 
@@ -28,9 +28,6 @@ external_port_2 : binary 4001
 # absolute pathname of mudlib
 mudlib directory : /home/mmessier/mudos/mudos/beta/testsuite
 
-# absolute pathname of driver/config dir
-binary directory : /home/mmessier/mudos/mudos/beta/testsuite
-
 # ------------------------------------------------------------------------
 #
 # You shouldn't change anything below this point unless you know what
@@ -50,9 +47,6 @@ master file : /single/master
 
 # the file where all global simulated efuns are defined.
 simulated efun file : /single/simul_efun
-
-# file to swap out objects; not used if time to swap is 0
-swap file : /single/swapfile
 
 # alternate debug.log file name (assumed to be in specified 'log directory')
 debug log file : debug.log
@@ -96,6 +90,10 @@ maximum local variables : 50
 
 # Set the maximum call depth for functions.
 maximum call depth : 150
+
+# Set the maximum stack size of the stack machine. This stack will also
+# contain all local variables and arguments.
+evaluator stack size : 6000
 
 # This is the maximum array size allowed for one single array.
 maximum array size : 15000
@@ -310,22 +308,6 @@ enable_commands call init : 1
 #
 sprintf add_justified ignore ANSI colors : 1
 
-# Defines the number of bits to use in the call_other cache (in interpret.c).
-#
-# Memory overhead is (1 << APPLY_CACHE_BITS)*16.
-# [assuming 32 bit pointers and 16 bit shorts]
-#
-# ACB:     entries:     overhead:
-#   6           64            1k
-#   8          256            4k
-#  10        1,024           16k
-#  12        4,096           64k
-#  14       16,384          256k
-#  16       65,536            1M
-#  20    1,048,576           16M
-#  22    4,194,304           64M
-apply cache bits : 22
-
 # Maximum nesting level for chains of call_out(0) within a single backend cycle.
 call_out(0) nest level : 1000
 
@@ -336,19 +318,4 @@ enable zmp : 0
 enable mssp : 1
 enable msp : 1
 enable msdp : 0
-
-###############################################################################
-#          The following aren't currently used or implemented (yet)           #
-###############################################################################
-
-# maximum number of users in the game (unused currently)
-maximum users : 40
-
-# Set the maximum stack size of the stack machine. This stack will also
-# contain all local variables and arguments.
-evaluator stack size : 6000
-
-# Set the size of the compiler stack. This defines how complex expressions
-# the compiler can parse.  (unused currently)
-compiler stack size : 600
 

--- a/src/Config.example
+++ b/src/Config.example
@@ -241,6 +241,10 @@ trace : 1
 # this is not set (for the most common eoperators).
 trace code : 0
 
+# Low-level LPC tracing intended for driver debugging; normally left off.
+trace lpc execution context : 0
+trace lpc instructions : 0
+
 # Set this if you want catch_tell called on interactives as well as NPCs.  If
 # this is set, the user object will need a catch_tell(msg) method that calls
 # receive(msg);
@@ -322,8 +326,16 @@ sprintf add_justified ignore ANSI colors : 1
 #  22    4,194,304           64M
 apply cache bits : 22
 
-#
-call_out(0) next level : 1000
+# Maximum nesting level for chains of call_out(0) within a single backend cycle.
+call_out(0) nest level : 1000
+
+# Telnet protocol negotiation. Enable the protocols your mudlib supports.
+enable mxp : 0
+enable gmcp : 0
+enable zmp : 0
+enable mssp : 1
+enable msp : 1
+enable msdp : 0
 
 ###############################################################################
 #          The following aren't currently used or implemented (yet)           #

--- a/src/base/internal/rc.cc
+++ b/src/base/internal/rc.cc
@@ -9,6 +9,7 @@
 
 #include "base/internal/rc.h"
 
+#include <cstdio>   // for printf
 #include <cstring>  // for strlen
 #include <deque>
 #include <fstream>
@@ -31,79 +32,155 @@ namespace {
 const int K_MAX_CONFIG_LINE_LENGTH = 120;
 std::deque<std::string> config_lines;
 
+// ─────────────────────────────────────────────────────────────────────────────
+// SOURCE OF TRUTH for docs/driver/config.md.
+//
+// INT_FLAGS[] (below) and STR_FLAGS[] (further down) define every recognized
+// runtime config option together with its documentation. The driver parses
+// config files directly from these tables, and docs/gen_config_docs.py
+// generates docs/driver/config.md from them -- so the `category` and
+// `description` fields below ARE the documentation.
+//
+// After adding, removing, or changing an entry, regenerate the docs and commit
+// the result:
+//     python3 docs/gen_config_docs.py
+//
+// CI (.github/workflows/config-docs.yml) re-runs the generator with --check and
+// fails the build if docs/driver/config.md is out of date. Keep descriptions to
+// a single line and avoid the '|' character (it breaks the Markdown table).
+// ─────────────────────────────────────────────────────────────────────────────
 struct FlagEntry {
-  std::string key;
-  int pos;
-  int defaultValue;
-  int minValue = 0;
-  int maxValue = INT_MAX;
+  std::string key;          // recognized config-file setting name
+  int pos;                  // slot constant from runtime_config.h
+  int defaultValue;         // value used when the option is omitted
+  int minValue;             // inclusive lower bound (else reset to default)
+  int maxValue;             // inclusive upper bound (else reset to default)
+  std::string category;     // grouping heading in the generated docs
+  std::string description;  // doc prose: one line, no '|' characters
 };
 
 const FlagEntry INT_FLAGS[] = {
-    {"time to clean up", __TIME_TO_CLEAN_UP__, 600},
-    {"time to reset", __TIME_TO_RESET__, 900},
-    {"time to swap", __TIME_TO_SWAP__, 300},
+    {"time to clean up", __TIME_TO_CLEAN_UP__, 600, 0, INT_MAX, "Timing & Lifecycle",
+     "Seconds an object may be idle before clean_up() is called on it; should be well above 'time to swap'."},
+    {"time to reset", __TIME_TO_RESET__, 900, 0, INT_MAX, "Timing & Lifecycle",
+     "Seconds between successive reset() calls on an object."},
+    {"time to swap", __TIME_TO_SWAP__, 300, 0, INT_MAX, "Timing & Lifecycle",
+     "Seconds an unused object stays in memory before being swapped out; 0 disables swapping."},
 
-    // __COMPILER_STACK_SIZE__
-    {"evaluator stack size", __EVALUATOR_STACK_SIZE__, CFG_EVALUATOR_STACK_SIZE},
+    {"evaluator stack size", __EVALUATOR_STACK_SIZE__, CFG_EVALUATOR_STACK_SIZE, 0, INT_MAX, "Limits",
+     "Maximum size of the evaluator stack, which holds all local variables and call arguments."},
+    {"inherit chain size", __INHERIT_CHAIN_SIZE__, 30, 0, INT_MAX, "Limits",
+     "Maximum depth of an object's inheritance chain."},
+    {"maximum evaluation cost", __MAX_EVAL_COST__, 30000000, 0, INT_MAX, "Limits",
+     "Maximum eval cost a single thread may consume before execution is aborted."},
+    {"maximum local variables", __MAX_LOCAL_VARIABLES__, 64, 64, UINT8_MAX, "Limits",
+     "Maximum number of local variables in a single function."},
+    {"maximum call depth", __MAX_CALL_DEPTH__, CFG_MAX_CALL_DEPTH, 0, INT_MAX, "Limits",
+     "Maximum nesting depth of LPC function calls."},
 
-    {"inherit chain size", __INHERIT_CHAIN_SIZE__, 30},
-    {"maximum evaluation cost", __MAX_EVAL_COST__, 30000000},
-    {"maximum local variables", __MAX_LOCAL_VARIABLES__, 64, 64, UINT8_MAX},
-    {"maximum call depth", __MAX_CALL_DEPTH__, CFG_MAX_CALL_DEPTH},
+    {"maximum array size", __MAX_ARRAY_SIZE__, 15000, 0, INT_MAX, "Limits",
+     "Maximum number of elements in a single array."},
+    {"maximum buffer size", __MAX_BUFFER_SIZE__, 1 << 20, 0, INT_MAX, "Limits",
+     "Maximum size, in bytes, of a single buffer variable."},
+    {"maximum mapping size", __MAX_MAPPING_SIZE__, 150000, 0, INT_MAX, "Limits",
+     "Maximum number of entries in a single mapping."},
+    {"maximum string length", __MAX_STRING_LENGTH__, 1 << 20, 0, INT_MAX, "Limits",
+     "Maximum length, in bytes, of a single string variable."},
+    {"maximum bits in a bitfield", __MAX_BITFIELD_BITS__, 12000, 0, INT_MAX, "Limits",
+     "Maximum number of bits in a bitfield (stored 6 bits per printable byte)."},
+    {"maximum byte transfer", __MAX_BYTE_TRANSFER__, 1 << 18, 0, INT_MAX, "Limits",
+     "Maximum number of bytes a single read_bytes()/write_bytes() call may transfer."},
+    {"maximum read file size", __MAX_READ_FILE_SIZE__, 1 << 18, 0, INT_MAX, "Limits",
+     "Maximum size, in bytes, of a file that read_file() may read."},
 
-    {"maximum array size", __MAX_ARRAY_SIZE__, 15000},
-    {"maximum buffer size", __MAX_BUFFER_SIZE__, 1 << 20},
-    {"maximum mapping size", __MAX_MAPPING_SIZE__, 150000},
-    {"maximum string length", __MAX_STRING_LENGTH__, 1 << 20},
-    {"maximum bits in a bitfield", __MAX_BITFIELD_BITS__, 12000},
-    {"maximum byte transfer", __MAX_BYTE_TRANSFER__, 1 << 18},
-    {"maximum read file size", __MAX_READ_FILE_SIZE__, 1 << 18},
+    {"hash table size", __SHARED_STRING_HASH_TABLE_SIZE__, 65536, 7001, INT_MAX, "Hash Tables",
+     "Size of the shared-string hash table; should be prime, roughly 1/5 of the number of distinct strings."},
+    {"object table size", __OBJECT_HASH_TABLE_SIZE__, 4096, 1024, INT_MAX, "Hash Tables",
+     "Size of the object hash table; roughly 1/4 of the number of objects in the game."},
+    {"living hash table size", __LIVING_HASH_TABLE_SIZE__, 256, 256, INT_MAX, "Hash Tables",
+     "Size of the find_living() hash table; must be one of 4, 16, 64, 256, 1024, or 4096."},
 
-    {"hash table size", __SHARED_STRING_HASH_TABLE_SIZE__, 65536, 7001},
-    {"object table size", __OBJECT_HASH_TABLE_SIZE__, 4096, 1024},
-    {"living hash table size", __LIVING_HASH_TABLE_SIZE__, 256, 256},
-
-    {"gametick msec", __RC_GAMETICK_MSEC__, 1000},
-    {"heartbeat interval msec", __RC_HEARTBEAT_INTERVAL_MSEC__, 1000},
-    {"sane explode string", __RC_SANE_EXPLODE_STRING__, 1},
-    {"reversible explode string", __RC_REVERSIBLE_EXPLODE_STRING__, 0},
-    {"sane sorting", __RC_SANE_SORTING__, 1},
-    {"warn tab", __RC_WARN_TAB__, 0},
-    {"wombles", __RC_WOMBLES__, 0},
-    {"call other type check", __RC_CALL_OTHER_TYPE_CHECK__, 0},
-    {"call other warn", __RC_CALL_OTHER_WARN__, 0},
-    {"mudlib error handler", __RC_MUDLIB_ERROR_HANDLER__, 1},
-    {"no resets", __RC_NO_RESETS__, 0},
-    {"lazy resets", __RC_LAZY_RESETS__, 0},
-    {"randomized resets", __RC_RANDOMIZED_RESETS__, 1},
-    {"no ansi", __RC_NO_ANSI__, 1},
-    {"strip before process input", __RC_STRIP_BEFORE_PROCESS_INPUT__, 1},
-    {"this_player in call_out", __RC_THIS_PLAYER_IN_CALL_OUT__, 1},
-    {"trace", __RC_TRACE__, 1},
-    {"trace code", __RC_TRACE_CODE__, 0},
-    {"interactive catch tell", __RC_INTERACTIVE_CATCH_TELL__, 0},
-    {"receive snoop", __RC_RECEIVE_SNOOP__, 1},
-    {"snoop shadowed", __RC_SNOOP_SHADOWED__, 0},
-    {"reverse defer", __RC_REVERSE_DEFER__, 0},
-    {"has console", __RC_HAS_CONSOLE__, 1},
-    {"noninteractive stderr write", __RC_NONINTERACTIVE_STDERR_WRITE__, 0},
-    {"trap crashes", __RC_TRAP_CRASHES__, 1},
-    {"old type behavior", __RC_OLD_TYPE_BEHAVIOR__, 0},
-    {"old range behavior", __RC_OLD_RANGE_BEHAVIOR__, 0},
-    {"warn old range behavior", __RC_WARN_OLD_RANGE_BEHAVIOR__, 1},
-    {"suppress argument warnings", __RC_SUPPRESS_ARGUMENT_WARNINGS__, 1},
-    {"enable_commands call init", __RC_ENABLE_COMMANDS_CALL_INIT__, 1},
-    {"sprintf add_justified ignore ANSI colors", __RC_SPRINTF_ADD_JUSTFIED_IGNORE_ANSI_COLORS__, 1},
-    {"call_out(0) nest level", __RC_CALL_OUT_ZERO_NEST_LEVEL__, 1000},
-    {"trace lpc execution context", __RC_TRACE_CONTEXT__, 0},
-    {"trace lpc instructions", __RC_TRACE_INSTR__, 0},
-    {"enable mxp", __RC_ENABLE_MXP__, 0},
-    {"enable gmcp", __RC_ENABLE_GMCP__, 0},
-    {"enable zmp", __RC_ENABLE_ZMP__, 0},
-    {"enable mssp", __RC_ENABLE_MSSP__, 1},
-    {"enable msp", __RC_ENABLE_MSP__, 1},
-    {"enable msdp", __RC_ENABLE_MSDP__, 0},
+    {"gametick msec", __RC_GAMETICK_MSEC__, 1000, 0, INT_MAX, "Timing & Lifecycle",
+     "Granularity of in-game time in milliseconds (the shortest visible time interval)."},
+    {"heartbeat interval msec", __RC_HEARTBEAT_INTERVAL_MSEC__, 1000, 0, INT_MAX, "Timing & Lifecycle",
+     "Heartbeat interval in milliseconds."},
+    {"sane explode string", __RC_SANE_EXPLODE_STRING__, 1, 0, INT_MAX, "Language Behavior",
+     "explode() strips at most one leading delimiter (and still one trailing delimiter)."},
+    {"reversible explode string", __RC_REVERSIBLE_EXPLODE_STRING__, 0, 0, INT_MAX, "Language Behavior",
+     "Make implode(explode(x, y), y) always equal x; overrides 'sane explode string'."},
+    {"sane sorting", __RC_SANE_SORTING__, 1, 0, INT_MAX, "Language Behavior",
+     "Use a well-defined, stable ordering for the driver's sorting operations."},
+    {"warn tab", __RC_WARN_TAB__, 0, 0, INT_MAX, "Diagnostics",
+     "Warn when source files are indented with tabs instead of spaces."},
+    {"wombles", __RC_WOMBLES__, 0, 0, INT_MAX, "Language Behavior",
+     "Disallow spaces between the start/end token characters of arrays, mappings, and functionals."},
+    {"call other type check", __RC_CALL_OTHER_TYPE_CHECK__, 0, 0, INT_MAX, "Type Checking",
+     "Enable type checking for call_other() (the -> operator on objects)."},
+    {"call other warn", __RC_CALL_OTHER_WARN__, 0, 0, INT_MAX, "Type Checking",
+     "Emit warnings instead of errors for call_other() type mismatches."},
+    {"mudlib error handler", __RC_MUDLIB_ERROR_HANDLER__, 1, 0, INT_MAX, "Error Handling",
+     "Pass runtime errors to the master object's error_handler() instead of handling them in the driver."},
+    {"no resets", __RC_NO_RESETS__, 0, 0, INT_MAX, "Reset Behavior",
+     "Completely disable the periodic calling of reset()."},
+    {"lazy resets", __RC_LAZY_RESETS__, 0, 0, INT_MAX, "Reset Behavior",
+     "Only call reset() when an object is touched via call_other() or move_object()."},
+    {"randomized resets", __RC_RANDOMIZED_RESETS__, 1, 0, INT_MAX, "Reset Behavior",
+     "Spread reset() calls over a randomized interval rather than firing them all at once."},
+    {"no ansi", __RC_NO_ANSI__, 1, 0, INT_MAX, "Player I/O",
+     "Replace ANSI escape characters (ASCII 27) in user input with a space before add_actions run."},
+    {"strip before process input", __RC_STRIP_BEFORE_PROCESS_INPUT__, 1, 0, INT_MAX, "Player I/O",
+     "Strip ANSI before process_input() sees the input, rather than only before add_actions are called."},
+    {"this_player in call_out", __RC_THIS_PLAYER_IN_CALL_OUT__, 1, 0, INT_MAX, "Language Behavior",
+     "Make this_player() usable from within call_out() callbacks."},
+    {"trace", __RC_TRACE__, 1, 0, INT_MAX, "Diagnostics",
+     "Enable the trace() and traceprefix() efuns (leaving it off runs slightly faster)."},
+    {"trace code", __RC_TRACE_CODE__, 0, 0, INT_MAX, "Diagnostics",
+     "Include the preceding lines of LPC code in error traces (slower)."},
+    {"interactive catch tell", __RC_INTERACTIVE_CATCH_TELL__, 0, 0, INT_MAX, "Player I/O",
+     "Call catch_tell() on interactive users as well as on NPCs."},
+    {"receive snoop", __RC_RECEIVE_SNOOP__, 1, 0, INT_MAX, "Player I/O",
+     "Send snoop text to receive_snoop() in the snooper instead of directly via add_message()."},
+    {"snoop shadowed", __RC_SNOOP_SHADOWED__, 0, 0, INT_MAX, "Player I/O",
+     "Report snooped output even when the target's catch_tell() is shadowed (prefixed with $$)."},
+    {"reverse defer", __RC_REVERSE_DEFER__, 0, 0, INT_MAX, "Language Behavior",
+     "Run deferred functions registered with defer() in reverse order."},
+    {"has console", __RC_HAS_CONSOLE__, 1, 0, INT_MAX, "Diagnostics",
+     "Allow the driver's interactive console via the -C command-line argument."},
+    {"noninteractive stderr write", __RC_NONINTERACTIVE_STDERR_WRITE__, 0, 0, INT_MAX, "Player I/O",
+     "Write tells/messages sent to non-interactive objects to stderr, prefixed with ']' (legacy behavior)."},
+    {"trap crashes", __RC_TRAP_CRASHES__, 1, 0, INT_MAX, "Error Handling",
+     "Call crash() in the master object and shut down cleanly on signals that would otherwise crash the driver."},
+    {"old type behavior", __RC_OLD_TYPE_BEHAVIOR__, 0, 0, INT_MAX, "Type Checking",
+     "Reintroduce a legacy type-checking bug for backwards compatibility."},
+    {"old range behavior", __RC_OLD_RANGE_BEHAVIOR__, 0, 0, INT_MAX, "Language Behavior",
+     "Treat negative range indices in strings/buffers as counting from the end (rvalue use only)."},
+    {"warn old range behavior", __RC_WARN_OLD_RANGE_BEHAVIOR__, 1, 0, INT_MAX, "Language Behavior",
+     "Warn when code relies on 'old range behavior'."},
+    {"suppress argument warnings", __RC_SUPPRESS_ARGUMENT_WARNINGS__, 1, 0, INT_MAX, "Diagnostics",
+     "Suppress unused-argument warnings, warning only about unused local variables."},
+    {"enable_commands call init", __RC_ENABLE_COMMANDS_CALL_INIT__, 1, 0, INT_MAX, "Language Behavior",
+     "Call init() in an object when enable_commands() is invoked on it."},
+    {"sprintf add_justified ignore ANSI colors", __RC_SPRINTF_ADD_JUSTFIED_IGNORE_ANSI_COLORS__, 1, 0, INT_MAX,
+     "Language Behavior",
+     "Make sprintf() column justification ignore ANSI color codes when computing field width."},
+    {"call_out(0) nest level", __RC_CALL_OUT_ZERO_NEST_LEVEL__, 1000, 0, INT_MAX, "Language Behavior",
+     "Maximum nesting level for chains of call_out(0) within a single backend cycle."},
+    {"trace lpc execution context", __RC_TRACE_CONTEXT__, 0, 0, INT_MAX, "Diagnostics",
+     "Record LPC execution context for tracing and debugging."},
+    {"trace lpc instructions", __RC_TRACE_INSTR__, 0, 0, INT_MAX, "Diagnostics",
+     "Trace individual LPC instructions for debugging."},
+    {"enable mxp", __RC_ENABLE_MXP__, 0, 0, INT_MAX, "Protocol Support",
+     "Advertise and enable the MXP telnet protocol."},
+    {"enable gmcp", __RC_ENABLE_GMCP__, 0, 0, INT_MAX, "Protocol Support",
+     "Advertise and enable the GMCP telnet protocol."},
+    {"enable zmp", __RC_ENABLE_ZMP__, 0, 0, INT_MAX, "Protocol Support",
+     "Advertise and enable the ZMP telnet protocol."},
+    {"enable mssp", __RC_ENABLE_MSSP__, 1, 0, INT_MAX, "Protocol Support",
+     "Advertise and enable the MSSP telnet protocol."},
+    {"enable msp", __RC_ENABLE_MSP__, 1, 0, INT_MAX, "Protocol Support",
+     "Advertise and enable the MSP telnet protocol."},
+    {"enable msdp", __RC_ENABLE_MSDP__, 0, 0, INT_MAX, "Protocol Support",
+     "Advertise and enable the MSDP telnet protocol."},
 };
 
 /*
@@ -122,6 +199,43 @@ const int kMustHave = 1;
 const int kOptional = 0;
 const int kWarnMissing = -1;
 const int K_WARN_FOUND = -2;
+
+// String config options. Like INT_FLAGS, this table is the source of truth for
+// both parsing and docs/driver/config.md: the simple "key : <text>" options are
+// parsed directly from it in read_config(). A few string-valued options with
+// special handling (the external ports, external commands, the global include
+// file, and the default fail message) are parsed separately but still
+// documented -- that hand-maintained section lives in docs/gen_config_docs.py.
+// After editing this table, regenerate the docs (python3 docs/gen_config_docs.py).
+struct StrFlagEntry {
+  std::string key;          // recognized config-file setting name
+  int pos;                  // slot constant from runtime_config.h
+  int required;             // kMustHave / kOptional / kWarnMissing
+  std::string tag;          // allocation label (debugging aid)
+  std::string category;     // grouping heading in the generated docs
+  std::string description;  // doc prose: one line, no '|' characters
+};
+
+const StrFlagEntry STR_FLAGS[] = {
+    {"name", __MUD_NAME__, kMustHave, "config file: mn", "Identity & Network",
+     "Name of this MUD."},
+    {"mudlib directory", __MUD_LIB_DIR__, kMustHave, "config file: mld", "Directory Structure",
+     "Absolute path to the mudlib root (this path is not relative to the mudlib)."},
+    {"log directory", __LOG_DIR__, kMustHave, "config file: ld", "Directory Structure",
+     "Filesystem directory for debug.log and stats files, resolved relative to the driver's working directory (leading slashes are stripped); not a mudlib virtual path."},
+    {"include directories", __INCLUDE_DIRS__, kMustHave, "config file: id", "Directory Structure",
+     "Colon-separated list of directories searched by `#include <...>`."},
+    {"master file", __MASTER_FILE__, kMustHave, "config file: mf", "Core Files",
+     "Path to the object that defines the master object."},
+    {"simulated efun file", __SIMUL_EFUN_FILE__, kOptional, "config file: sef", "Core Files",
+     "Path to the object that defines global simulated efuns."},
+    {"debug log file", __DEBUG_LOG_FILE__, kWarnMissing, "config file: dlf", "Logging",
+     "Filename (within the log directory) for the driver's debug log."},
+    {"default error message", __DEFAULT_ERROR_MESSAGE__, kOptional, "config file: dem", "Error Handling",
+     "Message shown to players when error() occurs."},
+    {"mud ip", __MUD_IP__, kOptional, "config file: mi", "Identity & Network",
+     "IP address to bind to; useful on hosts with multiple network addresses."},
+};
 
 bool scan_config_line(const char *fmt, void *dest, int required) {
   /* zero the destination.  It is either a pointer to an int or a char
@@ -237,29 +351,13 @@ void read_config(const char *filename) {
     }
   }
 
-  scan_config_line("name : %[^\n]", tmp, 1);
-  CONFIG_STR(__MUD_NAME__) = alloc_cstring(tmp, "config file: mn");
-
-  scan_config_line("mudlib directory : %[^\n]", tmp, 1);
-  CONFIG_STR(__MUD_LIB_DIR__) = alloc_cstring(tmp, "config file: mld");
-
-  scan_config_line("log directory : %[^\n]", tmp, 1);
-  CONFIG_STR(__LOG_DIR__) = alloc_cstring(tmp, "config file: ld");
-
-  scan_config_line("include directories : %[^\n]", tmp, 1);
-  CONFIG_STR(__INCLUDE_DIRS__) = alloc_cstring(tmp, "config file: id");
-
-  scan_config_line("master file : %[^\n]", tmp, 1);
-  CONFIG_STR(__MASTER_FILE__) = alloc_cstring(tmp, "config file: mf");
-
-  scan_config_line("simulated efun file : %[^\n]", tmp, 0);
-  CONFIG_STR(__SIMUL_EFUN_FILE__) = alloc_cstring(tmp, "config file: sef");
-
-  scan_config_line("debug log file : %[^\n]", tmp, -1);
-  CONFIG_STR(__DEBUG_LOG_FILE__) = alloc_cstring(tmp, "config file: dlf");
-
-  scan_config_line("default error message : %[^\n]", tmp, 0);
-  CONFIG_STR(__DEFAULT_ERROR_MESSAGE__) = alloc_cstring(tmp, "config file: dem");
+  // Process the simple string options from the STR_FLAGS table.
+  for (const auto &flag : STR_FLAGS) {
+    char buf[256];
+    sprintf(buf, "%s : %%[^\n]", flag.key.c_str());
+    scan_config_line(buf, tmp, flag.required);
+    CONFIG_STR(flag.pos) = alloc_cstring(tmp, flag.tag.c_str());
+  }
 
   {
     scan_config_line("default fail message : %[^\n]", tmp, 0);
@@ -271,9 +369,6 @@ void read_config(const char *filename) {
     }
     CONFIG_STR(__DEFAULT_FAIL_MESSAGE__) = alloc_cstring(tmp, "config file: dfm");
   }
-
-  scan_config_line("mud ip : %[^\n]", tmp, 0);
-  CONFIG_STR(__MUD_IP__) = alloc_cstring(tmp, "config file: mi");
 
   /* Process ports */
   {
@@ -409,4 +504,116 @@ void print_rc_table() {
       debug_message("%s : %d\n", flag.key.c_str(), val);
     }
   }
+}
+
+// Starter values for the required/recommended string options. Integer options
+// emit their compiled-in defaults; these paths and the MUD name have no sensible
+// default, so they get obvious placeholders the operator must edit.
+namespace {
+// Print `text` as one or more "# ..." comment lines, wrapped on whitespace.
+// The config parser drops any line >= K_MAX_CONFIG_LINE_LENGTH chars (it trips
+// failbit and stops reading the file), so comment lines must stay short.
+void print_comment(const std::string &text) {
+  const size_t width = 76;
+  std::istringstream words(text);
+  std::string word, line;
+  while (words >> word) {
+    if (!line.empty() && line.size() + 1 + word.size() > width) {
+      printf("# %s\n", line.c_str());
+      line.clear();
+    }
+    line += line.empty() ? word : " " + word;
+  }
+  if (!line.empty()) {
+    printf("# %s\n", line.c_str());
+  }
+}
+
+std::string template_str_value(const std::string &key) {
+  if (key == "name") return "CHANGE_ME";
+  if (key == "mudlib directory") return "/path/to/your/mudlib";
+  if (key == "log directory") return "log";
+  if (key == "include directories") return "/include";
+  if (key == "master file") return "/single/master";
+  if (key == "debug log file") return "debug.log";
+  if (key == "simulated efun file") return "/single/simul_efun";
+  if (key == "mud ip") return "127.0.0.1";
+  return "";
+}
+}  // namespace
+
+void print_config_template() {
+  static const char *const CATEGORY_ORDER[] = {
+      "Identity & Network", "Directory Structure", "Core Files",    "Logging",
+      "Error Handling",     "Timing & Lifecycle",  "Limits",        "Hash Tables",
+      "Reset Behavior",     "Language Behavior",    "Type Checking", "Player I/O",
+      "Diagnostics",        "Performance",          "Protocol Support",
+  };
+
+  printf(
+      "###############################################################################\n"
+      "# FluffOS configuration file - generated by `driver --generate-config`.\n"
+      "#\n"
+      "# Integer options are shown at their compiled-in defaults. Required values\n"
+      "# with no sensible default (the MUD name, the mudlib path) use placeholders\n"
+      "# you must edit. Options that need external resources (websocket, TLS,\n"
+      "# external commands) are commented out -- uncomment and edit to enable them.\n"
+      "###############################################################################\n\n");
+
+  for (const auto *category : CATEGORY_ORDER) {
+    bool header_printed = false;
+    auto ensure_header = [&]() {
+      if (!header_printed) {
+        printf("# ----- %s -----\n\n", category);
+        header_printed = true;
+      }
+    };
+
+    for (const auto &s : STR_FLAGS) {
+      if (s.category != category) {
+        continue;
+      }
+      ensure_header();
+      const char *tag = s.required == kMustHave      ? " (required)"
+                        : s.required == kWarnMissing ? " (recommended)"
+                                                     : " (optional)";
+      print_comment(s.description + tag);
+      std::string const value = template_str_value(s.key);
+      if (s.required == kOptional) {
+        printf("# %s : %s\n\n", s.key.c_str(), value.c_str());
+      } else {
+        printf("%s : %s\n\n", s.key.c_str(), value.c_str());
+      }
+    }
+
+    for (const auto &f : INT_FLAGS) {
+      if (f.category != category) {
+        continue;
+      }
+      ensure_header();
+      print_comment(f.description);
+      printf("%s : %d\n\n", f.key.c_str(), f.defaultValue);
+    }
+
+    // The listening ports belong conceptually with Identity & Network.
+    if (std::string(category) == "Identity & Network") {
+      printf("# ----- Ports & Connections -----\n\n");
+      printf("# Plain telnet listener.\n");
+      printf("external_port_1 : telnet 4000\n\n");
+      printf("# Optional extra listeners -- uncomment and edit to enable:\n");
+      printf("# external_port_2 : binary 4001\n");
+      printf("# external_port_3 : websocket 8080\n");
+      printf("# websocket http dir : www                # a websocket port requires this\n");
+      printf("# external_port_3_tls : cert=etc/cert.pem key=etc/key.pem\n\n");
+    }
+  }
+
+  // Options parsed specially in read_config() (not in the tables above).
+  printf("# ----- Other -----\n\n");
+  printf("# Header automatically #include'd in every compiled object (optional).\n");
+  printf("# global include file : \"/include/globals.h\"\n\n");
+  printf("# Message used when an action returns 0 and no notify_fail() was set.\n");
+  printf("default fail message : What?\n\n");
+  printf("# External programs callable via external_start() (requires PACKAGE_EXTERNAL).\n");
+  printf("# external_cmd_1 : /bin/cat\n\n");
 }

--- a/src/base/internal/rc.h
+++ b/src/base/internal/rc.h
@@ -20,6 +20,9 @@ extern char *external_cmd[g_num_external_cmds];
 void config_init();
 void read_config(const char *);
 void print_rc_table();
+// Emit a starter config file (with all options) to stdout; used by
+// `driver --generate-config`.
+void print_config_template();
 
 extern int config_int[NUM_CONFIG_INTS];
 extern char *config_str[NUM_CONFIG_STRS];

--- a/src/mainlib.cc
+++ b/src/mainlib.cc
@@ -300,6 +300,14 @@ int driver_main(int argc, char **argv);
 }
 
 int driver_main(int argc, char **argv) {
+  // Emit a starter config to stdout and exit, before any startup output.
+  for (int i = 1; i < argc; i++) {
+    if (strcmp(argv[i], "--generate-config") == 0) {
+      print_config_template();
+      return 0;
+    }
+  }
+
 #ifdef HAVE_JEMALLOC
   {
     bool var = true;


### PR DESCRIPTION
## Summary

Makes the runtime-config option tables in `src/base/internal/rc.cc` the **single source of truth** for the config documentation, so `docs/driver/config.md` can no longer drift from what the driver actually recognizes. Also adds a `driver --generate-config` command that emits a complete, bootable starter config.

Motivation: `docs/driver/config.md` previously documented only about half of the recognized options and contained a few stale/nonexistent settings (e.g. `compress protocol`, `valid bind`) and name mismatches (`max eval cost` vs `maximum evaluation cost`).

## What changed

- **`rc.cc`**: added `category`/`description` fields to the int-option table (`INT_FLAGS`), and introduced a `STR_FLAGS` table for the simple string options — `read_config()` now parses those directly from the table. The tables carry the docs, so prose can't desync from the parser.
- **`docs/gen_config_docs.py`** (new): generates `docs/driver/config.md` from those tables, resolving expression/macro defaults (`1 << 20`, `CFG_*`, etc.). `--check` mode fails if the committed doc is stale.
- **`.github/workflows/config-docs.yml`** (new): runs the generator with `--check` when `rc.cc`, `options_internal.h`, the generator, or the doc change — drift fails CI.
- **`docs/driver/config.md`**: regenerated; now covers all recognized options accurately, plus dynamic (ports, `external_cmd`) and obsolete options.
- **`driver --generate-config`**: prints a full starter config to stdout and exits — integer options at their defaults, required paths as placeholders, and websocket/TLS/external-command sections commented out so the result boots as-is.
- **`Config.example`**: added the 9 previously-missing options (the protocol enables, `trace lpc *`, `call_out(0) nest level`) and fixed the `next level` → `nest level` typo.
- **`CLAUDE.md` / `docs/CLAUDE.md` / `docs/cli/driver.md`**: document the source of truth, the regeneration workflow, and the new flag.

## Testing

- `rc.cc` compiles; full `driver` builds clean.
- LPC testsuite passes (`driver etc/config.test -ftest`, exit 0).
- `driver --generate-config` output boots a real mudlib (the testsuite lib) through simul_efun/master load and "Initializations complete."
- `python3 docs/gen_config_docs.py --check` is green.

## Note

While building the starter-config generator I found that the config parser (`istream::getline` with a 120-char buffer) silently stops reading the rest of the file when it hits a line ≥120 chars. The generator works around it by wrapping comment lines; the underlying parser limitation is left as-is (out of scope here) but worth flagging.