### PR TITLE
Fix crash and leak when taking a `ref` into a mapping element

### DIFF
--- a/src/vm/internal/base/interpret.cc
+++ b/src/vm/internal/base/interpret.cc
@@ -160,9 +160,11 @@ void kill_ref(ref_t *ref) {
     ref_t *r = global_ref_list;
 
     /* if some other ref references this mapping, it needs to remain
-       locked */
+       locked.  Skip the ref being killed: it is still linked into
+       global_ref_list at this point, so matching it would wrongly keep
+       the mapping locked and leak its deferred nodes. */
     while (r) {
-      if (r->sv.u.map == ref->sv.u.map) {
+      if (r != ref && r->sv.u.map == ref->sv.u.map) {
         break;
       }
       r = r->next;
@@ -598,8 +600,9 @@ void push_indexed_lvalue(int reverse) {
   if (sp->type == T_LVALUE) {
     lv = sp->u.lvalue;
     if (!reverse && lv->type == T_MAPPING) {
+      mapping_t *owner = lv->u.map;
       sp--;
-      if (!(lv = find_for_insert(lv->u.map, sp, 0))) {
+      if (!(lv = find_for_insert(owner, sp, 0))) {
         mapping_too_large();
       }
       free_svalue(sp, "push_indexed_lvalue: 1");
@@ -607,7 +610,7 @@ void push_indexed_lvalue(int reverse) {
       sp->u.lvalue = lv;
 #ifdef REF_RESERVED_WORD
       lv_owner_type = T_MAPPING;
-      lv_owner = reinterpret_cast<refed_t *>(lv->u.map);
+      lv_owner = reinterpret_cast<refed_t *>(owner);
 #endif
       return;
     }

--- a/testsuite/single/tests/operators/mapping.c
+++ b/testsuite/single/tests/operators/mapping.c
@@ -1,9 +1,22 @@
+// Removes every occurrence of `val` from the array referenced by `arr`,
+// writing the shrunken array back through the reference on each pass. This
+// mirrors the eject_value()/shift()/pop() reassignment pattern that exercises
+// a `ref` taken into a mapping element.
+private void eject_all(mixed ref *arr, mixed val) {
+  int i;
+
+  while((i = member_array(val, arr)) != -1)
+    arr = arr[0..i - 1] + arr[i + 1..];
+}
+
 void do_tests() {
   int x = 100;
   string* tmp1 = ({ "x", "y", "z" });
   mapping tmp = ([ "ab": 10, 20: "ab", tmp1: "abc" ]);
   string str = "(ab)"; // String to run through sscanf()
   string fail = "";
+  mapping roles_map;
+  mapping nested_map;
 
   ASSERT_EQ(10, tmp["ab"]);
   ASSERT_EQ(10, tmp["a" + "b"]);
@@ -17,4 +30,20 @@ void do_tests() {
   ASSERT_EQ("ab", tmp[20]);
   ASSERT_EQ("ab", tmp[10 * 2]);
   ASSERT_EQ("ab", tmp[x/5]);
+
+  // Taking a `ref` into a mapping element whose value is not itself a mapping
+  // (here, an array) used to compute the wrong keep-alive owner in
+  // push_indexed_lvalue(): it captured the indexed value instead of the
+  // containing mapping, tagged it T_MAPPING, and later freed the array as a
+  // mapping in kill_ref() -> a type-confusion crash. The reference must mutate
+  // the final element and leave the rest of the mapping intact.
+  roles_map = ([ "roles": ({ "a", "b", "a", "c", "a" }), "keep": 1 ]);
+  eject_all(ref roles_map["roles"], "a");
+  ASSERT_EQ(({ "b", "c" }), roles_map["roles"]);
+  ASSERT_EQ(1, roles_map["keep"]);
+
+  // Same path one level deeper: ref into a mapping nested inside a mapping.
+  nested_map = ([ "grp": ([ "roles": ({ "x", "y", "x" }) ]) ]);
+  eject_all(ref nested_map["grp"]["roles"], "x");
+  ASSERT_EQ(({ "y" }), nested_map["grp"]["roles"]);
 }


### PR DESCRIPTION
## Summary

Taking a reference into a mapping element — e.g. `eject_value_all(ref m["roles"], …)` or simply `ref m[key]` — could crash the driver with a SIGSEGV in `dealloc_mapping()`. This fixes that, plus a refcount leak the crash was masking.

## Root cause

**1. Wrong keep-alive owner (the crash).** In `push_indexed_lvalue()`, the mapping branch read `lv_owner` from `lv->u.map` *after* `find_for_insert()` had already advanced `lv` to the value slot. So the "owner" became the indexed **value** (often a non-mapping, e.g. an array) instead of the **containing mapping**, while still being tagged `T_MAPPING`. When the ref was later torn down, `kill_ref() → free_svalue() → dealloc_mapping()` walked that value as a mapping:

```
mapping_t::table      ← array_t::size + item bytes   → e.g. 0x10004 (non-pointer)
mapping_t::table_size ← garbage
a[j] → SIGSEGV
```

The fix captures the container mapping **before** `lv` is reassigned. Compare the sibling array branch (and the other mapping branch), which already capture the container correctly.

**2. Leaked deferred nodes (exposed by fix 1).** Once the real mapping actually gets `MAP_LOCKED`, `free_node()` defers freed nodes onto `locked_map_nodes` to be cleaned up by `unlock_mapping()`. But `kill_ref()`'s "is any *other* ref still using this map?" scan walked `global_ref_list` from the head and matched the ref being killed **itself** (it is not unlinked from the list until later in the function), so `unlock_mapping()` was never called — the deferred values leaked. Fixed by skipping `self` in that scan.

Both bugs only affect the `ref` reserved word whose outermost index lands on a mapping element. Plain indexed assignment (`m[a][b] = v`), and pure-array refs (`ref arr[i][j]`), were never affected — `lv_owner` is only consumed by `F_MAKE_REF`, and the array branch captures its owner correctly.

## Test

Adds a regression test in `testsuite/single/tests/operators/mapping.c` that mutates an array reached via `ref m["roles"]` and nested `ref m["grp"]["roles"]`, asserting the array is mutated correctly and the rest of the mapping is intact. It lives in a normal (non-crasher) test dir so it is covered by **both** the assertion and the leak checker — the two failure modes here.

Verified locally:
- Targeted test: `Checks succeeded.`, exit 0, no leak.
- Full `-ftest` suite: `Checks succeeded.`, exit 0 (the `kill_ref` change touches every ref-into-mapping path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)