### PR TITLE
docs: gitignore Docusaurus build artifacts

### DIFF
--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -4,3 +4,5 @@
 /node_modules
 /.vitepress/cache
 /.vitepress/dist
+/build
+/.docusaurus


### PR DESCRIPTION
The docs migrated to Docusaurus 3, but `docs/.gitignore` still only covered the
previous generators (Jekyll: `/vendor`, `/_site`; VitePress: `/.vitepress/*`).
As a result, a local `npm run build` leaves `docs/build/` and `docs/.docusaurus/`
showing up as untracked files.

These are generated output (rebuilt by the CD workflow on deploy), so they
should never be committed. This adds them to `docs/.gitignore`:

```gitignore
/build
/.docusaurus
```

Trivial, no content changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)