### PR TITLE
Don't negotiate MCCP (COMPRESS2) on websocket connections

### DIFF
--- a/src/net/telnet.cc
+++ b/src/net/telnet.cc
@@ -249,7 +249,17 @@ static inline void on_telnet_do(unsigned char cmd, interactive_t *ip) {
       ip->iflags |= USING_ZMP;
       break;
     case TELNET_TELOPT_COMPRESS2:
-      telnet_begin_compress2(ip->telnet);
+      // MCCP is implemented inside libtelnet, but on a websocket connection
+      // game text is sent straight to the socket and bypasses libtelnet (see
+      // add_message() in comm.cc). Beginning compression here would make us
+      // advertise a compressed stream the bulk of our output never joins,
+      // desyncing the client's inflate. Refuse instead. Websockets already
+      // have their own permessage-deflate, so nothing is lost.
+      if (ip->connection_type == PORT_TYPE_WEBSOCKET) {
+        telnet_negotiate(ip->telnet, TELNET_WONT, TELNET_TELOPT_COMPRESS2);
+      } else {
+        telnet_begin_compress2(ip->telnet);
+      }
       break;
     case TELNET_TELOPT_MSP:
       on_telnet_do_msp(ip);
@@ -518,9 +528,13 @@ void send_initial_telnet_negotiations(struct interactive_t *user) {
   // Also newenv
   telnet_negotiate(user->telnet, TELNET_DO, TELNET_TELOPT_NEW_ENVIRON);
 
-/* We support COMPRESS2 */
+/* We support COMPRESS2, except on websockets: their output bypasses libtelnet
+ * (see add_message()), so MCCP can't compress it, and they already carry their
+ * own permessage-deflate. */
 #ifdef HAVE_ZLIB  // come from libtelnet
-  telnet_negotiate(user->telnet, TELNET_WILL, TELNET_TELOPT_COMPRESS2);
+  if (user->connection_type != PORT_TYPE_WEBSOCKET) {
+    telnet_negotiate(user->telnet, TELNET_WILL, TELNET_TELOPT_COMPRESS2);
+  }
 #endif
 
   // Ask them if they support mxp.


### PR DESCRIPTION
## Summary

Websocket clients that accept MCCP get a burst of garbage followed by a dropped connection. This disables MCCP/COMPRESS2 negotiation on websocket connections, where it is both broken and redundant.

## Root cause

MCCP compression is implemented **inside** libtelnet — specifically `_send()`, which deflates outgoing bytes once `telnet_begin_compress2()` has run. Any byte that passes through libtelnet gets compressed; any byte that doesn't, doesn't.

On a `PORT_TYPE_TELNET` connection all output flows through libtelnet (`add_message()` → `telnet_send_text()`), so this is consistent. On a `PORT_TYPE_WEBSOCKET` connection it is **not**: game text is written straight to the socket via `websocket_send_text()` and bypasses libtelnet entirely (`add_message()`, the `PORT_TYPE_WEBSOCKET` branch in `comm.cc`). Only telnet negotiations/subnegotiations still route through libtelnet (via `TELNET_EV_SEND` → `on_telnet_send`).

Those two facts collide as soon as COMPRESS2 is accepted:

1. `send_initial_telnet_negotiations()` offers `IAC WILL COMPRESS2` to **every** connection, websockets included.
2. A conforming client (e.g. a browser MUD client) replies `IAC DO COMPRESS2`.
3. `on_telnet_do()` calls `telnet_begin_compress2()`, which emits the `IAC SB COMPRESS2 IAC SE` start marker and turns libtelnet's deflate stream on. From here the client treats the stream as zlib.
4. But the server's real output — the login prompt and all game text — goes out **uncompressed** through `websocket_send_text()`, while the occasional subnegotiation that *does* pass through libtelnet is genuinely deflated.

The client's inflate stream is handed a mixture of raw plaintext and real zlib bytes, desyncs on the first non-zlib byte, renders garbage, and the session falls apart.

**Reproduction:** connect a websocket MUD client with MCCP enabled → garbage characters then a dropped connection. Same client with MCCP disabled → normal login. (Observed with the mudix browser client against a FluffOS driver over `ws://`.)

## Why disable rather than "fix" compression on websockets

Two independent reasons:

- **Redundant.** The websocket transport already offers compression via the `permessage-deflate` extension (enabled in `websocket.cc`). Layering MCCP's zlib inside an already-deflated frame buys nothing.
- **Structurally mismatched.** The reason websocket output bypasses libtelnet in the first place is that a websocket is a clean, message-framed binary transport that doesn't need telnet's byte-stuffing. Routing game text back through libtelnet just to enable MCCP would reintroduce that layer (and double-compress with permessage-deflate) — strictly worse than doing nothing.

So the correct behavior is simply to never activate COMPRESS2 on a websocket.

## Change

`src/net/telnet.cc`, two guards on `ip->connection_type`:

- `send_initial_telnet_negotiations()` — don't offer `WILL COMPRESS2` to websocket connections. (This is the actual fix: it stops the negotiation that triggers the bug.)
- `on_telnet_do()` — if a websocket client requests `DO COMPRESS2` unprompted, reply `WONT COMPRESS2` instead of beginning compression. (Defensive; cheap.)

Telnet and other connection types are unaffected — MCCP continues to work exactly as before for them.

## Testing

- Incremental `cmake --build . --target driver` compiles cleanly (`PORT_TYPE_WEBSOCKET` is already in scope in `telnet.cc` via `base/std.h` → `external_port.h`; no new includes).
- Manually verified the failing websocket-client login now succeeds with MCCP enabled.