### PR TITLE
fix 4-byte data loss on wss:// output bursts larger than 2048 bytes

### DIFF
--- a/src/net/ws_ascii.cc
+++ b/src/net/ws_ascii.cc
@@ -153,12 +153,18 @@ int ws_ascii_callback(struct lws *wsi, enum lws_callback_reasons reason, void *u
         // TODO: we could use LWS_WRITE_TEXT , however it is much safer to use binary mode, its
         // better to let client deal with incorrect encoding.
         auto m = lws_write(wsi, buf + LWS_PRE, numbytes, LWS_WRITE_BINARY);
-        if (m < 0) {
+        // Per lws docs, a return less than the requested length means the
+        // connection has failed. On success lws consumed the entire payload
+        // (truncated sends are buffered and flushed internally), and the
+        // return can exceed numbytes under encapsulation (TLS), so it must
+        // NOT be used as a drain count: doing so silently drops the start
+        // of the next chunk on wss connections.
+        if (m < static_cast<int>(numbytes)) {
           lwsl_warn("ERROR %d writing to ws socket.\n", m);
           return -1;
         }
-        evbuffer_drain(pss->buffer, m);
-        total -= m;
+        evbuffer_drain(pss->buffer, numbytes);
+        total -= numbytes;
         // May have more text to write.
         if (total > 0) {
           lws_callback_on_writable(wsi);

--- a/src/net/ws_telnet.cc
+++ b/src/net/ws_telnet.cc
@@ -141,12 +141,18 @@ int ws_telnet_callback(struct lws *wsi, enum lws_callback_reasons reason, void *
       auto numbytes = evbuffer_copyout(pss->buffer, &buf[LWS_PRE], sizeof(buf) - LWS_PRE);
       if (numbytes > 0) {
         auto m = lws_write(wsi, buf + LWS_PRE, numbytes, LWS_WRITE_BINARY);
-        if (m < 0) {
+        // Per lws docs, a return less than the requested length means the
+        // connection has failed. On success lws consumed the entire payload
+        // (truncated sends are buffered and flushed internally), and the
+        // return can exceed numbytes under encapsulation (TLS), so it must
+        // NOT be used as a drain count: doing so silently drops the start
+        // of the next chunk on wss connections.
+        if (m < static_cast<int>(numbytes)) {
           lwsl_warn("ERROR %d writing to ws socket.\n", m);
           return -1;
         }
-        evbuffer_drain(pss->buffer, m);
-        total -= m;
+        evbuffer_drain(pss->buffer, numbytes);
+        total -= numbytes;
         // May have more text to write.
         if (total > 0) {
           lws_callback_on_writable(wsi);


### PR DESCRIPTION
# Fix 4-byte data loss on wss:// output bursts larger than 2048 bytes

`ws_telnet.cc` and `ws_ascii.cc` use the return value of `lws_write()` as the
number of bytes to drain from the outgoing evbuffer. That return is not a
payload count: per the lws API contract (`lws-write.h`), on success it is "at
least the number of bytes requested to send (under some encapsulation
scenarios, it can indicate more than you asked was sent)".

That encapsulation scenario is real here: **websocket over HTTP/2 (RFC 8441)**,
which browsers negotiate on `wss://` ports via ALPN. On that path
`lws_write()` returns `numbytes + 4` for a 2048-byte chunk, and the
`evbuffer_drain(pss->buffer, m)` that follows discards the first 4 bytes of
the next chunk. Any burst over 2048 bytes loses 4 bytes at every 2048-byte
seam — mangled GMCP JSON, corrupted ANSI (xterm.js "Parsing error" spam),
missing text. Plain `ws://` is unaffected (no ALPN → no h2 → return equals
`numbytes` exactly).

## Mechanism (vendored lws sources)

1. FluffOS builds lws with `LWS_WITH_HTTP2 ON` (`src/CMakeLists.txt:250`), and
   lws stock settings advertise `H2SET_ENABLE_CONNECT_PROTOCOL = 1`
   (`lib/roles/h2/ops-h2.c:89`), so browsers upgrade wss connections to
   ws-over-h2 (`rops_check_upgrades_h2`, `ops-h2.c:503`).
2. `rops_write_role_protocol_ws` prepends a 4-byte frame header to a
   2048-byte payload (16-bit extended length form), then delegates to the h2
   role with `len + pre` = 2052 bytes (`lib/roles/ws/ops-ws.c:1846`).
3. `rops_write_role_protocol_h2` returns the length it was passed — **2052**
   (`lib/roles/h2/ops-h2.c:499`) — which propagates back as the `lws_write()`
   return.
4. The callback drains 2052 from an evbuffer it copied only 2048 out of.

Confirmed in production (browser over `wss://`, OpenSSL 3.x): repeated GMCP
payload captures each lost exactly 4 bytes at the 2048-byte stream offset,
matching the frame-header size.

## Fix

Use the lws-documented return check — less than requested means the
connection failed (`lws-write.h:192`) — and drain `numbytes`, i.e. what was
actually copied out. This is safe because on success lws has consumed the
whole payload: truncated sends are buffered internally on `buflist_out` and
flushed autonomously. Also fixes a latent `size_t` underflow in `total -= m`
when `m > total`.

Same change in both `ws_telnet.cc` and `ws_ascii.cc`.

## Visual Testing

Left is Merentha MUD running unpatched fluffos. Right is Merentha Builders MUD running patched fluffos.

<img width="1434" height="1156" alt="image" src="https://github.com/user-attachments/assets/6ae34606-35d1-477b-a4d7-c5128d9da4dd" />
