### PR TITLE
Fix new Coverity Scan defects (CIDs 1663736–1663755)

### DIFF
--- a/src/compiler/internal/grammar_rules.cc
+++ b/src/compiler/internal/grammar_rules.cc
@@ -219,7 +219,8 @@ void rule_func(parse_node_t** function, LPC_INT type, LPC_INT optional_star, con
           if (local.funcptr_default) {
             have_default_args = true;
             if (i > default_args_limit || argument.num_arg > default_args_limit) {
-              yyerror("Functions with default arguments can only have %d args", default_args_limit);
+              yyerror("Functions with default arguments can only have %d args",
+                      static_cast<int>(default_args_limit));
               return;
             }
             FUNCTION_DEF(fun)->min_arg--;

--- a/src/compiler/internal/grammar_rules_exprs.cc
+++ b/src/compiler/internal/grammar_rules_exprs.cc
@@ -866,8 +866,8 @@ void rule_primary_expr_functional_2(parse_node_t** result, LPC_INT val,
       int* argp;
       int f = val >> 8;
       int num = opt_arg_list->kind;
-      int max_arg = predefs[f].max_args;
       if (f != -1) {
+        int max_arg = predefs[f].max_args;
         if (num > max_arg && max_arg != -1) {
           parse_node_t* pn = opt_arg_list;
           while (pn) {
@@ -975,7 +975,7 @@ void rule_function_call_new(parse_node_t** result, parse_node_t* opt_arg_list,
   context = saved_context;
   ihe = lookup_ident("clone_object");
 
-  if ((f = ihe->dn.simul_num) != -1) {
+  if (ihe != nullptr && (f = ihe->dn.simul_num) != -1) {
     *result = opt_arg_list;
     (*result)->kind = NODE_CALL_1;
     (*result)->v.number = F_SIMUL_EFUN;

--- a/src/compiler/internal/lexer.autogen.cc
+++ b/src/compiler/internal/lexer.autogen.cc
@@ -5575,6 +5575,9 @@ int lpc_lex_buffer_extents(void *yyscanner, int i, const char **base, const char
 void lpc_lex_set_source(char *base, size_t size, void *yyscanner) {
   struct yyguts_t *yyg = (struct yyguts_t *)yyscanner;
   yyensure_buffer_stack(yyscanner);
+  if (yyg->yy_buffer_stack == NULL) {
+    lpc_lex_fatal("lpc_lex_set_source: buffer stack allocation failed");
+  }
   if (YY_CURRENT_BUFFER) {
     yy_delete_buffer(YY_CURRENT_BUFFER, yyscanner);
     YY_CURRENT_BUFFER_LVALUE = NULL;

--- a/src/compiler/internal/lexer.l
+++ b/src/compiler/internal/lexer.l
@@ -968,6 +968,9 @@ int lpc_lex_buffer_extents(void *yyscanner, int i, const char **base, const char
 void lpc_lex_set_source(char *base, size_t size, void *yyscanner) {
   struct yyguts_t *yyg = (struct yyguts_t *)yyscanner;
   yyensure_buffer_stack(yyscanner);
+  if (yyg->yy_buffer_stack == NULL) {
+    lpc_lex_fatal("lpc_lex_set_source: buffer stack allocation failed");
+  }
   if (YY_CURRENT_BUFFER) {
     yy_delete_buffer(YY_CURRENT_BUFFER, yyscanner);
     YY_CURRENT_BUFFER_LVALUE = NULL;

--- a/src/compiler/internal/lexer_rules_pp.cc
+++ b/src/compiler/internal/lexer_rules_pp.cc
@@ -760,7 +760,7 @@ ScratchString lpc_lex_expand_string(std::string_view text, ScratchVector<Scratch
         if (!m.is_function_like) {
           auto g2 = guard;
           g2.emplace_back(id);
-          result += lpc_lex_expand_string(m.body, g2);
+          result += lpc_lex_expand_string(m.body, std::move(g2));
         } else {
           size_t j = i;
           while (j < text.size() && (text[j] == ' ' || text[j] == '\t')) j++;
@@ -774,7 +774,7 @@ ScratchString lpc_lex_expand_string(std::string_view text, ScratchVector<Scratch
             // Argument pre-expansion deliberately passes no
             for (const auto& a : args) expanded_args.push_back(lpc_lex_expand_string(a, guard));
             ScratchString subst = substitute(m.body, m.params, expanded_args);
-            result += lpc_lex_expand_string(subst, g2);
+            result += lpc_lex_expand_string(subst, std::move(g2));
           } else {
             // Function-like macro name with no argument list in
             // this text: left literal and NOT counted -- if its

--- a/src/main_lpcshell.cc
+++ b/src/main_lpcshell.cc
@@ -219,6 +219,8 @@ bool RunAttempt(Session* session, const std::string& body_src, bool want_result,
   // render compiler_diags ourselves, only for the attempt that mattered.
   compiler_diags_quiet = true;
   try {
+    // coverity[wrapper_escape] - the callee copies the name (shared string);
+    // the c_str() pointer is not retained past this call.
     ob = load_object_from_source(src, name.c_str(), 1);
   } catch (const char* e) {
     compiler_diags_quiet = false;
@@ -293,7 +295,7 @@ void Eval(Session* session, std::string stmt) {
     bool known = false;
     for (const auto& n : session->var_names) known |= (n == decl_name);
     if (!known) {
-      session->var_names.push_back(decl_name);
+      session->var_names.push_back(std::move(decl_name));
       session->saved_values.emplace_back();
     }
     stmt = rewritten;
@@ -320,8 +322,7 @@ void Eval(Session* session, std::string stmt) {
 
   // Fall back to statement form (e.g. `if (x) write(...)`, assignments,
   // loops -- anything that isn't itself an expression).
-  std::string stmt_body = stmt;
-  if (RunAttempt(session, stmt_body, /*want_result=*/false, &result, &error_message)) {
+  if (RunAttempt(session, stmt, /*want_result=*/false, &result, &error_message)) {
     // Success may still have produced warnings worth showing.
     for (const auto& d : compiler_diags) {
       if (d.is_warning) std::cout << render_diagnostic(d, isatty(1)) << "\n";
@@ -348,7 +349,7 @@ void Eval(Session* session, std::string stmt) {
 
 }  // namespace
 
-int main(int argc, char** argv) {
+int main(int argc, char** argv) try {
   if (argc != 2) {
     std::cerr << "Usage: lpcshell config_file" << std::endl;
     return 1;
@@ -384,4 +385,7 @@ int main(int argc, char** argv) {
 
   clear_state();
   return 0;
+} catch (const std::exception& e) {
+  std::cerr << "lpcshell: fatal: " << e.what() << std::endl;
+  return 1;
 }

--- a/src/packages/ffi/ffi.cc
+++ b/src/packages/ffi/ffi.cc
@@ -541,6 +541,8 @@ void f_ffi_call() {
   std::vector<void*> avalues(nargs);
   for (int i = 0; i < nargs; i++) {
     lpc_to_slot(fn->arg_codes[i], &args->item[i], &slots[i]);
+    // coverity[wrapper_escape] - slots outlives every use of avalues (both die
+    // together at function exit; ffi_call below is the only consumer).
     avalues[i] = &slots[i];
   }
 

--- a/src/tests/bench_compile.cc
+++ b/src/tests/bench_compile.cc
@@ -118,7 +118,7 @@ double avg(const std::vector<double>& v, size_t from, size_t to) {
 
 }  // namespace
 
-int main(int argc, char** argv) {
+int main(int argc, char** argv) try {
   int rounds = (argc > 1) ? atoi(argv[1]) : 2000;
   long chunk = (argc > 2) ? atol(argv[2]) : 0;  // e.g. 400: worst-case geometry
 
@@ -165,4 +165,7 @@ int main(int argc, char** argv) {
   printf("last-10%% / first-10%% ratio: %.3f (>1.10 would indicate lifetime degradation)\n",
          degradation);
   return degradation > 1.10 ? 1 : 0;
+} catch (const std::exception& e) {
+  fprintf(stderr, "bench_compile: fatal: %s\n", e.what());
+  return 1;
 }

--- a/src/tests/test_compiler.cc
+++ b/src/tests/test_compiler.cc
@@ -258,7 +258,7 @@ static std::vector<Token> TokenizeSession(bool keep_macros, const std::string& s
     ctx.is_char_literal = false;
     t.is_template = ctx.is_template;
     ctx.is_template = false;
-    toks.push_back(t);
+    toks.push_back(std::move(t));
   }
 
   yylex_destroy(scanner);
@@ -396,7 +396,7 @@ class LpcPreprocessor {
         result += t.text;
       }
     }
-    return NormalizedString{result};
+    return NormalizedString{std::move(result)};
   }
 
   const std::vector<std::string>& errors() const { return errors_; }
@@ -2018,6 +2018,8 @@ static void ensure_compile_env() {
 // Portable source-on-an-fd helper: tmpfile() works on every CI platform
 // (no /tmp, no mkstemp, auto-deleted).
 static FILE* source_as_file(const char* src) {
+  // coverity[secure_temp] - tmpfile() opens O_EXCL and unlinks immediately;
+  // there is no pathname window to exploit. Kept for Windows-CI portability.
   FILE* f = tmpfile();
   EXPECT_NE(f, nullptr);
   EXPECT_EQ(fwrite(src, 1, strlen(src), f), strlen(src));
@@ -2240,6 +2242,7 @@ TEST(CompileEntry, IncludeDepthLimitCleanError) {
 static std::string run_stage_dump(const char* src, bool pp_form) {
   ensure_compile_env();
   FILE* in = source_as_file(src);
+  // coverity[secure_temp] - see source_as_file.
   FILE* out = tmpfile();  // portable capture (open_memstream is not)
   EXPECT_NE(out, nullptr);
   bool ok = lpc_dump_stage_tokens(fileno(in), "/stage_test", pp_form, out);
@@ -2273,6 +2276,7 @@ TEST(StageOutput, TokensFormOnePerLineWithPositions) {
 
 TEST(StageOutput, LoadFailureReturnsFalseAndCleansUp) {
   ensure_compile_env();
+  // coverity[secure_temp] - see source_as_file.
   FILE* out = tmpfile();
   ASSERT_NE(out, nullptr);
   EXPECT_FALSE(lpc_dump_stage_tokens(-1, "/nope", true, out));


### PR DESCRIPTION
## Summary

Addresses the 20 defects shown in the latest Coverity Scan report. Every reachable finding is either fixed or explicitly annotated as intentional; the four findings inside bison's generated skeleton are documented below as needing console dismissal.

## Real bugs fixed

- **CID 1663746 (REVERSE_NEGATIVE)** — `grammar_rules_exprs.cc`: `rule_primary_expr_functional_2` indexed `predefs[f]` before checking `f != -1`. The `max_arg` load is now inside the guard.
- **CID 1663740 (NULL_RETURNS)** — `grammar_rules_exprs.cc`: `rule_function_call_new` dereferenced `lookup_ident("clone_object")` unchecked. A null result now falls through to the efun form via `lookup_predef`.
- **CID 1663741 (PRINTF_ARGS)** — `grammar_rules.cc`: `yyerror("... %d args", default_args_limit)` passed a `size_t` to `%d`; now cast to `int`.
- **CID 1663743 (FORWARD_NULL)** — `lexer.l`: `lpc_lex_set_source` now fails fatally if the flex buffer stack could not be allocated before it is dereferenced (`lexer.autogen.cc` regenerated).
- **CIDs 1663739, 1663742 (UNCAUGHT_EXCEPT)** — `main_lpcshell.cc`, `bench_compile.cc`: `main()` now catches `std::exception` (e.g. `fmt::format_error`) and reports it instead of calling `std::terminate`.

## Performance (COPY_INSTEAD_OF_MOVE)

- **CID 1663748** — `lexer_rules_pp.cc`: the macro-expansion guard vectors `g2` are now moved into the recursive `lpc_lex_expand_string` calls.
- **CIDs 1663750, 1663752** — `main_lpcshell.cc`: `var_names.push_back` now moves `decl_name`; the pointless `stmt_body` copy in `Eval` is removed entirely (`RunAttempt` takes a const reference).
- **CIDs 1663736, 1663745** — `test_compiler.cc`: token `push_back` and `NormalizedString` return now move.

## Intentional, annotated with `// coverity[...]`

- **CIDs 1663755, 1663754 (WRAPPER_ESCAPE)** — `ffi.cc`: `avalues[i] = &slots[i]` where both vectors die together at function exit and `ffi_call` is the only consumer; `main_lpcshell.cc`: `name.c_str()` passed to `load_object_from_source`, which copies it into a shared string and does not retain the pointer.
- **CIDs 1663749, 1663744, 1663737 (SECURE_TEMP)** — `test_compiler.cc`: `tmpfile()` opens `O_EXCL` and unlinks immediately, so there is no exploitable pathname window; it is kept deliberately for Windows-CI portability (no `/tmp`, no `mkstemp`).

## Not addressable in source

- **CIDs 1663753, 1663751, 1663747, 1663738** (`yypush_parse` OVERRUN / ARRAY_VS_SINGLETON / RESOURCE_LEAK) are in bison's generated skeleton in `grammar.autogen.cc`. CI regenerates that file from `grammar.y` with the platform's bison on every build, so a source patch would be overwritten; these are long-known skeleton false positives and should be dismissed in the Coverity console (or suppressed via a modeling file).

The remaining 18 of the 38 reported defects were not included in the report excerpt; happy to follow up once their details are visible.

## Testing

- Full build (driver, lpcshell, all test binaries) compiles cleanly; scanner regenerated from the modified `lexer.l`.
- All 297 GTest unit tests pass; the LPC testsuite passes on two consecutive runs (lexer change rule).
- lpcshell REPL smoke-tested: expression eval, variable declaration (moved-string path), and statement fallback (removed-copy path) all behave as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LWdzCk4VAH6R8voiuXbdXV

---
_Generated by [Claude Code](https://claude.ai/code/session_01LWdzCk4VAH6R8voiuXbdXV)_