### PR TITLE
websocket: keep protocol units whole across ws messages, refuse MCCP …

### DIFF
--- a/src/net/telnet.cc
+++ b/src/net/telnet.cc
@@ -33,11 +33,32 @@ static const telnet_telopt_t my_telopts[] = {{TELNET_TELOPT_TM, TELNET_WILL, TEL
                                              {TELNET_TELOPT_MSDP, TELNET_WILL, TELNET_DO},
                                              {-1, 0, 0}};
 
+// Websocket connections: same table, but refuse MCCP (COMPRESS2). The
+// websocket layer has its own compression (permessage-deflate), so MCCP would
+// only re-wrap the stream in a second deflate and hide the telnet framing
+// from the ws message-boundary logic.
+static const telnet_telopt_t my_telopts_ws[] = {{TELNET_TELOPT_TM, TELNET_WILL, TELNET_DO},
+                                                {TELNET_TELOPT_SGA, TELNET_WILL, TELNET_DO},
+                                                {TELNET_TELOPT_NAWS, TELNET_WILL, TELNET_DO},
+                                                {TELNET_TELOPT_LINEMODE, TELNET_WONT, TELNET_DO},
+                                                {TELNET_TELOPT_ECHO, TELNET_WILL, TELNET_DO},
+                                                {TELNET_TELOPT_TTYPE, TELNET_WONT, TELNET_DO},
+                                                {TELNET_TELOPT_NEW_ENVIRON, TELNET_WONT, TELNET_DO},
+                                                {TELNET_TELOPT_COMPRESS2, TELNET_WONT, TELNET_DONT},
+                                                {TELNET_TELOPT_ZMP, TELNET_WILL, TELNET_DO},
+                                                {TELNET_TELOPT_MSSP, TELNET_WILL, TELNET_DO},
+                                                {TELNET_TELOPT_GMCP, TELNET_WILL, TELNET_DO},
+                                                {TELNET_TELOPT_CHARSET, TELNET_WILL, TELNET_DO},
+                                                {TELNET_TELOPT_MSP, TELNET_WILL, TELNET_DO},
+                                                {TELNET_TELOPT_BINARY, TELNET_WILL, TELNET_DO},
+                                                {TELNET_TELOPT_MSDP, TELNET_WILL, TELNET_DO},
+                                                {-1, 0, 0}};
+
 // Telnet event handler
 static void telnet_event_handler(telnet_t* /*telnet*/, telnet_event_t* /*ev*/, void* /*user_data*/);
 
 struct telnet_t* net_telnet_init(interactive_t* user) {
-  return telnet_init(my_telopts, telnet_event_handler, 0, user);
+  return telnet_init(user->lws ? my_telopts_ws : my_telopts, telnet_event_handler, 0, user);
 }
 
 static inline void on_telnet_data(const char* buffer, unsigned long size, interactive_t* ip) {
@@ -250,7 +271,12 @@ static inline void on_telnet_do(unsigned char cmd, interactive_t* ip) {
       ip->iflags |= USING_ZMP;
       break;
     case TELNET_TELOPT_COMPRESS2:
-      telnet_begin_compress2(ip->telnet);
+      // MCCP is refused on websocket connections (see my_telopts_ws);
+      // libtelnet answers WONT for them and this event never fires, but
+      // guard anyway so compression can't start on a ws stream.
+      if (!ip->lws) {
+        telnet_begin_compress2(ip->telnet);
+      }
       break;
     case TELNET_TELOPT_MSP:
       on_telnet_do_msp(ip);
@@ -519,9 +545,12 @@ void send_initial_telnet_negotiations(struct interactive_t* user) {
   // Also newenv
   telnet_negotiate(user->telnet, TELNET_DO, TELNET_TELOPT_NEW_ENVIRON);
 
-/* We support COMPRESS2 */
+/* We support COMPRESS2, but not on websocket connections: the websocket
+ * layer compresses on its own (permessage-deflate). */
 #ifdef HAVE_ZLIB  // come from libtelnet
-  telnet_negotiate(user->telnet, TELNET_WILL, TELNET_TELOPT_COMPRESS2);
+  if (!user->lws) {
+    telnet_negotiate(user->telnet, TELNET_WILL, TELNET_TELOPT_COMPRESS2);
+  }
 #endif
 
   // Ask them if they support mxp.

--- a/src/net/ws_ascii.cc
+++ b/src/net/ws_ascii.cc
@@ -137,12 +137,17 @@ int ws_ascii_callback(struct lws* wsi, enum lws_callback_reasons reason, void* u
       static unsigned char buf[LWS_PRE + 2048];
       auto numbytes = evbuffer_copyout(pss->buffer, &buf[LWS_PRE], sizeof(buf) - LWS_PRE);
       if (numbytes > 0) {
-        auto new_numbytes = u8_truncate(&buf[LWS_PRE], numbytes);
-        if (new_numbytes != numbytes) {
-          auto rest = new_numbytes - numbytes;
-          evbuffer_prepend(pss->buffer, &buf[LWS_PRE + new_numbytes], rest);
-          numbytes = new_numbytes;
+        // Hold back a trailing incomplete UTF-8 sequence so a codepoint is
+        // never split across ws messages. evbuffer_copyout() does not drain,
+        // so the held-back bytes stay at the front of pss->buffer and go out
+        // with the next write.
+        auto new_numbytes = static_cast<ev_ssize_t>(u8_truncate(&buf[LWS_PRE], numbytes));
+        if (new_numbytes == 0) {
+          // Only an incomplete codepoint is buffered; wait for the rest of it
+          // instead of re-arming the writeable callback in a busy loop.
+          break;
         }
+        numbytes = new_numbytes;
 #ifdef DEBUG
         if (!u8_validate(&buf[LWS_PRE], numbytes)) {
           char buf1[sizeof(buf) + 1] = {};

--- a/src/net/ws_telnet.cc
+++ b/src/net/ws_telnet.cc
@@ -11,6 +11,7 @@
 #include "net/ws_telnet.h"
 #include "interactive.h"
 #include "net/telnet.h"
+#include "net/sys_telnet.h"  // IAC / SB / SE / WILL / DONT
 
 // from comm.cc
 interactive_t* new_user(port_def_t* port, evutil_socket_t fd, sockaddr* addr, socklen_t addrlen);
@@ -30,6 +31,54 @@ struct per_vhost_data {
 
   ws_telnet_session* pss_list; /* linked-list of live pss*/
 };
+
+// Find how many bytes of an outgoing telnet window can be sent without
+// splitting an IAC sequence (command, option negotiation, or subnegotiation)
+// across websocket messages. A subnegotiation larger than a full window has
+// to be split to make progress; in that case (window_full) cut inside it, on
+// an IAC-pair boundary.
+size_t telnet_truncate(const unsigned char* data, size_t len, bool window_full) {
+  size_t safe = 0;
+  size_t i = 0;
+  while (i < len) {
+    if (data[i] != IAC) {
+      safe = ++i;
+      continue;
+    }
+    if (i + 1 >= len) break;  // trailing lone IAC
+    auto cmd = data[i + 1];
+    if (cmd == SB) {
+      // subnegotiation runs until IAC SE; IAC IAC inside is escaped data
+      size_t j = i + 2;
+      size_t end = 0;
+      while (j < len) {
+        if (data[j] != IAC) {
+          j++;
+          continue;
+        }
+        if (j + 1 >= len) break;  // trailing lone IAC inside the subnegotiation
+        if (data[j + 1] == SE) {
+          end = j + 2;
+          break;
+        }
+        j += 2;  // IAC IAC escape (or any other IAC pair)
+      }
+      if (!end) {
+        if (safe == 0 && window_full) {
+          safe = j;
+        }
+        break;
+      }
+      safe = i = end;
+    } else if (cmd >= WILL && cmd <= DONT) {
+      if (i + 2 >= len) break;  // option byte not in the window yet
+      safe = i += 3;
+    } else {
+      safe = i += 2;  // two-byte command, including the IAC IAC escape
+    }
+  }
+  return safe;
+}
 
 }  // namespace
 
@@ -140,6 +189,22 @@ int ws_telnet_callback(struct lws* wsi, enum lws_callback_reasons reason, void* 
       static unsigned char buf[LWS_PRE + 2048];
       auto numbytes = evbuffer_copyout(pss->buffer, &buf[LWS_PRE], sizeof(buf) - LWS_PRE);
       if (numbytes > 0) {
+        // Hold back a trailing incomplete telnet IAC sequence so a command,
+        // negotiation, or subnegotiation is never split across ws messages.
+        // evbuffer_copyout() does not drain, so the held-back bytes stay at
+        // the front of pss->buffer and go out with the next write. Once MCCP
+        // (COMPRESS2) is active the stream is deflated binary, not telnet
+        // framing: it must go out verbatim, without IAC scanning or hold-back.
+        if (pss->user && !(pss->user->iflags & USING_COMPRESS)) {
+          auto new_numbytes = static_cast<ev_ssize_t>(telnet_truncate(
+              &buf[LWS_PRE], numbytes, numbytes == static_cast<ev_ssize_t>(sizeof(buf) - LWS_PRE)));
+          if (new_numbytes == 0) {
+            // Only an incomplete sequence is buffered; wait for the rest of it
+            // instead of re-arming the writeable callback in a busy loop.
+            break;
+          }
+          numbytes = new_numbytes;
+        }
         auto m = lws_write(wsi, buf + LWS_PRE, numbytes, LWS_WRITE_BINARY);
         // Per lws docs, a return less than the requested length means the
         // connection has failed. On success lws consumed the entire payload


### PR DESCRIPTION
…on ws

Fixes in the websocket output path around the 2048-byte write window:

- ws_ascii: the UTF-8 hold-back for bursts larger than the window computed the held-back length backwards (the unsigned subtraction underflowed to ~2^64 and was passed to evbuffer_prepend as a size), and the prepend itself duplicated bytes that evbuffer_copyout had never drained. A multi-byte codepoint straddling the window corrupted the session. Truncate to the last complete codepoint and simply drain that much: the tail stays at the front of the buffer and leads the next write. A lone incomplete codepoint now waits for its continuation instead of re-arming the writeable callback in a busy loop.

- ws_telnet: apply the equivalent hold-back to telnet framing, so an IAC command, option negotiation, IAC IAC escape, or subnegotiation is never split across ws messages by the window cut. A subnegotiation larger than a full window (large GMCP payloads) is still split to guarantee progress, but only on an IAC-pair boundary. The scan is skipped once MCCP is active, since the stream is then deflated binary, not telnet framing.

- telnet: refuse MCCP (COMPRESS2) on websocket connections - a dedicated telopt table answers WONT, the proactive WILL COMPRESS2 advertisement is skipped, and the begin_compress2 call is guarded. The websocket layer has its own compression (permessage-deflate); MCCP would only re-wrap the stream in a second deflate. Plain telnet ports are unchanged.

The lws_write() usage itself is unchanged and matches the vendored lws 4.2.1 contract: LWS_PRE-padded buffer, return < requested means the connection died, drain by bytes written (never by the return value, which exceeds the payload under encapsulation), and truncated sends are buffered and flushed by lws internally.

Verified: driver builds clean, the telnet truncation logic passes a 14-case standalone edge test (lone IAC, split negotiation, IAC IAC escape, complete/split/oversized subnegotiations, escaped IAC inside a split SB), and the LPC testsuite passes.