### PR TITLE
Don't reject pending call_out handles below the allocation counter

### DIFF
--- a/src/packages/core/call_out.cc
+++ b/src/packages/core/call_out.cc
@@ -314,7 +314,11 @@ int remove_call_out_by_handle(object_t* ob, LPC_INT handle) {
   DBG_CALLOUT("remove_call_out_by_handle: ob: %s, handle: %" LPC_INT_FMTSTR_P ".\n", ob->obname,
               handle);
 
-  if (handle == 0 || handle < unique) {
+  // 0 is the common mistake of passing an uninitialized variable (real
+  // handles start at 1); anything else is settled by the map lookup below.
+  // Comparing against the allocation counter here is wrong: it grows past
+  // older-but-still-pending handles as new call_outs are created.
+  if (handle == 0) {
     DBG_CALLOUT("  invalid handle, ignored.\n");
     return -1;
   }
@@ -338,7 +342,8 @@ int find_call_out_by_handle(object_t* ob, LPC_INT handle) {
   DBG_CALLOUT("find_call_out_by_handle: ob: %s, handle: %" LPC_INT_FMTSTR_P "\n", ob->obname,
               handle);
 
-  if (handle == 0 || handle < unique) {
+  // See remove_call_out_by_handle for why only 0 is pre-filtered.
+  if (handle == 0) {
     DBG_CALLOUT("  invalid handle, ignored.\n");
     return -1;
   }
@@ -346,7 +351,10 @@ int find_call_out_by_handle(object_t* ob, LPC_INT handle) {
   auto iter = g_callout_handle_map.find(handle);
   if (iter != g_callout_handle_map.end()) {
     auto* cop = iter->second;
-    if (cop->handle == handle && (cop->ob == ob || cop->function.f->hdr.owner == ob)) {
+    // function is a union: function.f is only valid when ob is null
+    // (string-named callouts store function.s).
+    object_t* owner = cop->ob ? cop->ob : cop->function.f->hdr.owner;
+    if (owner == ob) {
       auto remaining_time = time_left(cop);
       DBG_CALLOUT("  found: remaining time %d.\n", remaining_time);
       return remaining_time;

--- a/testsuite/single/tests/efuns/find_call_out.lpc
+++ b/testsuite/single/tests/efuns/find_call_out.lpc
@@ -1,7 +1,30 @@
+int probe(int handle) {
+    return find_call_out(handle);
+}
+
 void do_tests() {
+    int h, i;
+    object clone;
+
     ASSERT(find_call_out("foo") == -1);
     call_out("foo", 10);
     ASSERT_EQ(10, find_call_out("foo"));
     ASSERT_EQ(-1, find_call_out("bar"));
     remove_call_out("foo");
+
+    // Handle-based lookup must survive newer call_outs bumping the
+    // driver's internal allocation counter (PR #1068), and reject 0.
+    h = call_out("foo", 10);
+    for (i = 0; i < 150; i++) {
+        remove_call_out(call_out("foo", 10));
+    }
+    ASSERT_EQ(10, find_call_out(h));
+    ASSERT_EQ(-1, find_call_out(0));
+
+    // Another object's handle is not visible to us.
+    clone = clone_object(__FILE__);
+    ASSERT_EQ(-1, clone->probe(h));
+    destruct(clone);
+
+    remove_call_out(h);
 }

--- a/testsuite/single/tests/efuns/remove_call_out.lpc
+++ b/testsuite/single/tests/efuns/remove_call_out.lpc
@@ -16,15 +16,31 @@ void second_call() {
 }
 
 void do_tests() {
-    int h;
+    int h, i, old;
+    int *newer;
 
     called = 0;
     h = call_out( "first_call", 0);
     ASSERT(remove_call_out(h) != -1);
     ASSERT(remove_call_out(12345) == -1);
+    ASSERT(remove_call_out(0) == -1);
 
     call_out( "first_call", 0);
     call_out( "second_call", 1);
     ASSERT(remove_call_out("first_call") != -1);
     ASSERT(remove_call_out("foo") == -1);
+
+    // A handle must stay removable no matter how many newer call_outs were
+    // created after it: the driver used to reject any handle below its
+    // internal allocation counter as invalid (PR #1068).
+    old = call_out("first_call", 100);
+    newer = ({});
+    for (i = 0; i < 150; i++) {
+        newer += ({ call_out("first_call", 100) });
+    }
+    ASSERT(remove_call_out(old) != -1);
+    ASSERT(remove_call_out(old) == -1);
+    for (i = 0; i < sizeof(newer); i++) {
+        ASSERT(remove_call_out(newer[i]) != -1);
+    }
 }


### PR DESCRIPTION
## Summary

Fixes the bug reported in #1068 (with credit to @SirCyan for the report and repro), taking the approach the author himself recommended in that PR's description rather than the patch as posted. Supersedes #1068.

## The bug

`remove_call_out(handle)` and `find_call_out(handle)` pre-filter handles with `handle < unique`, comparing a handle — `g_current_gametick + counter-value-at-creation` — against the **current** allocation counter. Every `call_out()` increments that counter, so older-but-still-pending handles fall below it and are rejected as "invalid" before the hash map is even consulted. Once newer call_outs exist, older ones can no longer be found or removed by handle. @SirCyan's repro in #1068 shows handles created moments earlier being ignored.

## Why not #1068's patch

The posted change (`handle > g_current_gametick + unique`) fixes the common case but reintroduces the same class of bug when `unique` wraps at `0xffffffff` (`new_call_out` deliberately wraps it back to 1) — as the PR description itself notes. Its suggested alternative is the correct one: the handle is only a key into `g_callout_handle_map`, and the O(1) map lookup is already authoritative. Any range-based pre-filter is at best redundant and at worst wrong.

## Change

- `remove_call_out_by_handle()` / `find_call_out_by_handle()`: the pre-filter now rejects only `handle == 0` — the documented quick filter for the common mistake of passing an uninitialized variable (real handles start at 1, which is exactly why `unique` is initialized to 1). Everything else is settled by the map lookup.
- `find_call_out_by_handle()` ownership check: `cop->ob == ob || cop->function.f->hdr.owner == ob` read `function.f` from the union even when the callout was string-named (`function.s` active) — dereferencing a shared string as a `funptr_t` whenever `cop->ob` was set but didn't match `ob`. The owner is now resolved from the correct union member before comparing.

## Testing

- `testsuite/single/tests/efuns/remove_call_out.lpc`: creates a handle, buries it under 150 newer call_outs, then removes it (plus a double-remove and handle-0 rejection check). **Fails 150 checks on the unfixed driver**, passes with this fix — verified A/B against the same tree.
- `testsuite/single/tests/efuns/find_call_out.lpc`: same burial scenario for lookup, handle-0 rejection, and that another object's handle is not visible through `find_call_out()` (exercises the fixed union path via a clone).
- Full LPC testsuite passes.

## Note for reviewers

`remove_call_out_by_handle()` performs no ownership check at all — any object can remove any other object's callout by (sequential, guessable) handle, while `find_call_out_by_handle()` does check ownership. That asymmetry predates this change; tightening it could break mudlibs that intentionally pass handles across objects, so it's left as-is and flagged here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LWdzCk4VAH6R8voiuXbdXV

---
_Generated by [Claude Code](https://claude.ai/code/session_01LWdzCk4VAH6R8voiuXbdXV)_