### PR TITLE
pcre: don't loop forever on zero-width matches in pcre_match_all

### DIFF
--- a/src/packages/pcre/pcre.cc
+++ b/src/packages/pcre/pcre.cc
@@ -504,9 +504,23 @@ auto pcre_match_all(const char* subject, size_t subject_len, const char* pattern
 
   int rc = 0;
   int offset = 0;
-  while (offset < run->s_length &&
-         (rc = pcre_exec(run->re, nullptr, run->subject, run->s_length, offset, run->exec_flags,
-                         run->ovector, run->ovecsize)) >= 0) {
+  int retry_flags = 0;
+  while (offset < run->s_length) {
+    rc = pcre_exec(run->re, nullptr, run->subject, run->s_length, offset,
+                   run->exec_flags | retry_flags, run->ovector, run->ovecsize);
+    if (rc < 0) {
+      if (retry_flags == 0) {
+        break;
+      }
+      // The previous match was empty and nothing non-empty matches at this
+      // position: advance one UTF-8 character and continue scanning.
+      offset++;
+      while (offset < run->s_length && (run->subject[offset] & 0xC0) == 0x80) {
+        offset++;
+      }
+      retry_flags = 0;
+      continue;
+    }
     std::vector<svalue_t> match;
     for (int i = 0; i < rc; ++i) {
       unsigned int start, length;
@@ -523,6 +537,9 @@ auto pcre_match_all(const char* subject, size_t subject_len, const char* pattern
       match.push_back(item);
     }
     matches.push_back(match);
+    // An empty match would rescan the same offset forever; require the next
+    // match at this position to be non-empty (the standard pcredemo idiom).
+    retry_flags = (run->ovector[1] == run->ovector[0]) ? (PCRE_NOTEMPTY_ATSTART | PCRE_ANCHORED) : 0;
     offset = run->ovector[1];
   }
 

--- a/testsuite/aw_test.txt
+++ b/testsuite/aw_test.txt
@@ -46,3 +46,5 @@ async write payload
 async write payload
 async write payload
 async write payload
+async write payload
+async write payload

--- a/testsuite/single/tests/efuns/pcre_match_all.lpc
+++ b/testsuite/single/tests/efuns/pcre_match_all.lpc
@@ -2,4 +2,24 @@ void do_tests() {
     mixed r = pcre_match_all("a1 b2 c3", "([a-z])([0-9])");
     ASSERT_EQ(3, sizeof(r));
     ASSERT_EQ(({ "a1", "a", "1" }), r[0]);
+
+    // Patterns that can match the empty string must not loop forever
+    // at the same offset (issue #927).
+    r = pcre_match_all("hi there", "(\\w*)");
+    ASSERT_EQ(3, sizeof(r));
+    ASSERT_EQ(({ "hi", "hi" }), r[0]);
+    ASSERT_EQ(({ "", "" }), r[1]);
+    ASSERT_EQ(({ "there", "there" }), r[2]);
+
+    // All-empty matches terminate too.
+    r = pcre_match_all("abc", "x*");
+    ASSERT_EQ(3, sizeof(r));
+    ASSERT_EQ(({ "" }), r[0]);
+
+    // Zero-width advance is UTF-8 aware: multibyte character between matches.
+    r = pcre_match_all("a中b", "([ab]*)");
+    ASSERT_EQ(3, sizeof(r));
+    ASSERT_EQ(({ "a", "a" }), r[0]);
+    ASSERT_EQ(({ "", "" }), r[1]);
+    ASSERT_EQ(({ "b", "b" }), r[2]);
 }

--- a/testsuite/trace_test.json
+++ b/testsuite/trace_test.json
@@ -1,3 +1,3 @@
 [
-{"pid":1976608,"tid":129006360494528,"ts":0,"dur":0,"ph":"M","cat":"DEFAULT","name":"thread_name","args":{"name":"FluffOS Main"}}
+{"pid":27054,"tid":139895457211968,"ts":0,"dur":0,"ph":"M","cat":"DEFAULT","name":"thread_name","args":{"name":"FluffOS Main"}}
 ]


### PR DESCRIPTION
A pattern that can match the empty string (e.g. `"(\\w*)"`) left the scan offset unchanged in `pcre_match_all()`, so the loop appended empty matches forever until the driver was OOM-killed — exactly the "Killed" behavior reported in #927, triggerable from any LPC code with a common regex.

This applies the standard pcredemo idiom:
- after an empty match, retry the same offset with `PCRE_NOTEMPTY_ATSTART | PCRE_ANCHORED` so a non-empty match at the same position is still found;
- if nothing non-empty matches there, advance one character (UTF-8 aware — skips continuation bytes, since `PCRE_UTF8` is always set) and continue scanning.

Empty matches are still reported (matching Perl `//g` semantics); the scan simply always terminates now.

Tests added to `testsuite/single/tests/efuns/pcre_match_all.lpc`:
- `pcre_match_all("hi there", "(\\w*)")` → `hi`, `""`, `there` (previously hung)
- all-empty matches (`"x*"` on `"abc"`) terminate
- zero-width advance across a multibyte (CJK) character

Full LPC testsuite passes (`Checks succeeded.`).

Fixes #927

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016FMBJLkpkpVpZdz6PWzeWe

---
_Generated by [Claude Code](https://claude.ai/code/session_016FMBJLkpkpVpZdz6PWzeWe)_