### PR TITLE
db: fix double sqlite3_finalize after a failed statement execution

### DIFF
--- a/src/packages/db/db.cc
+++ b/src/packages/db/db.cc
@@ -915,6 +915,7 @@ static int SQLite3_connect(dbconn_t* c, const char* host, const char* database,
 static int SQLite3_close(dbconn_t* c) {
   if (c->SQLite3.results) {
     sqlite3_finalize(c->SQLite3.results);
+    c->SQLite3.results = 0;
   }
 
   sqlite3_close(c->SQLite3.handle);
@@ -958,6 +959,12 @@ static int SQLite3_execute(dbconn_t* c, const char* s) {
                           NULL) != SQLITE_OK) {
       sqlite3_free_table(result);
       sqlite3_finalize(c->SQLite3.results);
+      // Clear the handle, or the next cleanup/close finalizes it a second
+      // time and crashes inside sqlite3_finalize (issue #1036).
+      c->SQLite3.results = 0;
+      c->SQLite3.nrows = 0;
+      c->SQLite3.last_row = 0;
+      c->SQLite3.step_res = 0;
       return 0;
     }
 

--- a/testsuite/single/tests/efuns/db.lpc
+++ b/testsuite/single/tests/efuns/db.lpc
@@ -53,6 +53,21 @@ void do_tests() {
     rows = db_exec(conn, "drop table tbl1;");
     ASSERT_EQ(0, rows);
 
+    // Issue #1036: a statement that prepares fine but fails during
+    // execution (UNIQUE violation) used to leave a dangling prepared
+    // statement behind; the next db_exec/db_close then finalized it a
+    // second time and crashed inside sqlite3_finalize().
+    rows = db_exec(conn, "create table IF NOT EXISTS tbl2(one varchar(10) UNIQUE);");
+    ASSERT_EQ(0, rows);
+    rows = db_exec(conn, "insert into tbl2 values('dup');");
+    ASSERT_EQ(0, rows);
+    db_exec(conn, "insert into tbl2 values('dup');"); // fails mid-execution
+    rows = db_exec(conn, "select * from tbl2;");      // must not double-finalize
+    ASSERT_EQ(1, rows);
+    ASSERT_EQ(({ "dup" }), db_fetch(conn, 1));
+    rows = db_exec(conn, "drop table tbl2;");
+    ASSERT_EQ(0, rows);
+
     db_close(conn);
 
 #ifndef __PACKAGE_ASYNC__


### PR DESCRIPTION
When `sqlite3_get_table()` failed inside `SQLite3_execute()` (e.g. a UNIQUE violation, or `SQLITE_BUSY` from a second connection — the reproduction in #1036), the code finalized the prepared statement but left the stale pointer in `c->SQLite3.results`. The next `db_exec()` (via `SQLite3_cleanup`) or `db_close()` then finalized the already-freed statement a second time and crashed inside `sqlite3_finalize()` — matching the reported backtrace.

Changes:
- clear `c->SQLite3.results` (and row state) after the error-path finalize in `SQLite3_execute()`;
- clear it in `SQLite3_close()` after finalizing, for symmetry.

Test: extended `testsuite/single/tests/efuns/db.lpc` with a statement that prepares fine but fails mid-execution (UNIQUE violation), followed by further `db_exec`/`db_fetch`/`db_close` on the same handle — the exact sequence that used to double-finalize. Full LPC testsuite passes.

Fixes #1036

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016FMBJLkpkpVpZdz6PWzeWe

---
_Generated by [Claude Code](https://claude.ai/code/session_016FMBJLkpkpVpZdz6PWzeWe)_