### PR TITLE
vm: don't truncate foreach iteration count to 16 bits

### DIFF
--- a/src/vm/internal/base/interpret.cc
+++ b/src/vm/internal/base/interpret.cc
@@ -2773,7 +2773,10 @@ void eval_instruction(char* p) {
           STACK_INC;
           sp->type = T_NUMBER;
           sp->u.lvalue = (sp - 1)->u.arr->item;
-          sp->subtype = (sp - 1)->u.arr->size;
+          // The remaining-iterations bound lives as a pointer comparison in
+          // F_NEXT_FOREACH: subtype is an unsigned short and silently
+          // truncates sizes > 65535 (issue #1127).
+          sp->subtype = 0;
 
           STACK_INC;
           sp->type = T_LVALUE;
@@ -2800,7 +2803,7 @@ void eval_instruction(char* p) {
           STACK_INC;
           sp->type = T_NUMBER;
           sp->u.lvalue = (sp - 1)->u.arr->item;
-          sp->subtype = (sp - 1)->u.arr->size;
+          sp->subtype = 0;
         }
 
         if (flags & FOREACH_RIGHT_GLOBAL) {
@@ -2837,7 +2840,7 @@ void eval_instruction(char* p) {
       case F_NEXT_FOREACH:
         if ((sp - 1)->type == T_LVALUE) {
           /* mapping */
-          if ((sp - 2)->subtype--) {
+          if ((sp - 2)->u.lvalue < (sp - 3)->u.arr->item + (sp - 3)->u.arr->size) {
             svalue_t* key = (sp - 2)->u.lvalue++;
             svalue_t* value = find_in_mapping((sp - 4)->u.map, *key);
 
@@ -2876,7 +2879,7 @@ void eval_instruction(char* p) {
             break;
           }
         } else { /* array */
-          if ((sp - 1)->subtype--) {
+          if ((sp - 1)->u.lvalue < (sp - 2)->u.arr->item + (sp - 2)->u.arr->size) {
             if (sp->type == T_REF) {
               sp->u.ref->lvalue = (sp - 1)->u.lvalue;
             } else {

--- a/testsuite/etc/config.test
+++ b/testsuite/etc/config.test
@@ -86,13 +86,13 @@ maximum call depth : 30
 maximum evaluation cost : 300000000
 
 # This is the maximum array size allowed for one single array.
-maximum array size : 15000
+maximum array size : 100000
 
 # This is the maximum allowed size of a variable of type 'buffer'.
 maximum buffer size : 400000
 
 # Max size for a mapping
-maximum mapping size : 15000
+maximum mapping size : 100000
 
 # Max inherit chain size
 inherit chain size : 30

--- a/testsuite/single/tests/operators/foreach.lpc
+++ b/testsuite/single/tests/operators/foreach.lpc
@@ -52,4 +52,36 @@ void do_tests() {
     ASSERT_EQ("abcdefg", str); // not suppose to change
   }
 
+  // Issue #1127: the iteration count used to be stored in a 16-bit field,
+  // so containers with more than 65535 entries iterated size % 65536 times
+  // (65536 entries iterated zero times).
+  {
+    int i, bigcount;
+    mixed *big;
+    mapping bigmap = ([]);
+
+    big = allocate(65536, 1);
+    bigcount = 0;
+    foreach(int v in big) {
+      bigcount += v;
+    }
+    ASSERT_EQ(65536, bigcount);
+
+    big = allocate(70000, 1);
+    bigcount = 0;
+    foreach(int v in big) {
+      bigcount += v;
+    }
+    ASSERT_EQ(70000, bigcount);
+
+    for (i = 0; i < 70000; i++) {
+      bigmap[i] = 1;
+    }
+    ASSERT_EQ(70000, sizeof(bigmap));
+    bigcount = 0;
+    foreach(int k, int v in bigmap) {
+      bigcount += v;
+    }
+    ASSERT_EQ(70000, bigcount);
+  }
 }


### PR DESCRIPTION
`F_FOREACH` stored the container size in the loop-counter svalue's `subtype` field — an `unsigned short` — so `foreach` over an array or mapping with more than 65535 entries silently iterated `size % 65536` times (a 65536-entry mapping iterated **zero** times). With the default `maximum mapping size` of 150000 this is reachable by ordinary LPC code, causing silent data loss.

The counter slot can't hold a 64-bit count (its union member is already the element cursor), so the loop is now bounded by a pointer comparison against the end of the source array, which sits directly below the cursor on the stack (`F_NEXT_FOREACH` array and mapping paths). The string path is untouched.

Tests: extended `testsuite/single/tests/operators/foreach.lpc` with 65536- and 70000-entry array and mapping loops (the 65536 case iterated zero times before this fix), and raised the testsuite config's max array/mapping sizes to 100000 so the test can run. Full LPC testsuite and all 297 GTest units pass.

Fixes #1127

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016FMBJLkpkpVpZdz6PWzeWe

---
_Generated by [Claude Code](https://claude.ai/code/session_016FMBJLkpkpVpZdz6PWzeWe)_