### PR TITLE
vm: don't leak the source fd when a compile aborts via error()

### DIFF
--- a/src/vm/internal/simulate.cc
+++ b/src/vm/internal/simulate.cc
@@ -16,6 +16,7 @@
 #endif
 
 #include "base/internal/tracing.h"
+#include "thirdparty/scope_guard/scope_guard.hpp"
 
 #include "applies_table.autogen.h"
 #include "backend.h"      // for clear_tick_events , FIXME
@@ -508,13 +509,17 @@ object_t* load_object(const char* lname, int callcreate) {
     error("Could not read the file '/%s'.\n", real_name);
   }
   save_command_giver(command_giver);
-  // Zero-copy load: compile_file_fd reads the file straight into the
-  // arena block the scanner reads in place -- no intermediate string.
-  prog = compile_file_fd(f, obname);
+  {
+    // An error() during the compile unwinds past this frame; guard the fd
+    // or every failed compile leaks one descriptor (issue #162).
+    DEFER { close(f); };
+    // Zero-copy load: compile_file_fd reads the file straight into the
+    // arena block the scanner reads in place -- no intermediate string.
+    prog = compile_file_fd(f, obname);
+  }
   restore_command_giver();
   update_compile_av(total_lines);
   total_lines = 0;
-  close(f);
 
   /* Sorry, can't handle objects without programs yet. */
   if (inherit_file == nullptr && (num_parse_error > 0 || prog == nullptr)) {


### PR DESCRIPTION
`load_object()` opened the source file and only closed it *after* `compile_file_fd()` returned. Any `error()` unwind during the compile — a master apply erroring during `#include` resolution, the eval limit firing, "Object cannot be loaded during compilation" — skipped the `close()`, leaking one descriptor per failed compile until the driver exhausted its fd table (the "mud is fubar" failure mode from #162).

The fd is now closed by a `DEFER` scope guard (per the repo's AGENTS.md §4 guidance — `error()` unwinds via C++ exception, so the guard runs), scoped so it closes before inherit resolution recurses. Include-file descriptors were already fixed as part of the lexer rewrite (slurped and closed immediately); the main file's fd was the remaining leak.

No new test: the leak only manifests on mid-compile `error()` unwinds that need driver-level conditions (master-apply failure, eval limit) not reproducible in the test harness; the guard is structurally exactly-once and replaces the manual close. Full LPC testsuite passes.

Fixes #162

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016FMBJLkpkpVpZdz6PWzeWe

---
_Generated by [Claude Code](https://claude.ai/code/session_016FMBJLkpkpVpZdz6PWzeWe)_