### PR TITLE
vm: reversible explode keeps fields when the string is all delimiters

### DIFF
--- a/src/tests/test_lpc.cc
+++ b/src/tests/test_lpc.cc
@@ -144,3 +144,28 @@ TEST_F(DriverTest, TestLPC_FunctionInherit) {
   }
   pop_context(&econ);
 }
+
+// issue #968: with "reversible explode string" semantics, a string made
+// entirely of delimiters must still split into n+1 empty fields so that
+// implode(explode(s, d), d) == s.
+TEST_F(DriverTest, ExplodeReversibleAllDelimiters) {
+  array_t* v = explode_string("a", 1, "a", 1, true);
+  ASSERT_EQ(v->size, 2);
+  EXPECT_STREQ(v->item[0].u.string, "");
+  EXPECT_STREQ(v->item[1].u.string, "");
+  char* joined = implode_string(v, "a", 1);
+  EXPECT_STREQ(joined, "a");
+  FREE_MSTR(joined);
+  free_array(v);
+
+  v = explode_string("abab", 4, "ab", 2, true);
+  ASSERT_EQ(v->size, 3);
+  joined = implode_string(v, "ab", 2);
+  EXPECT_STREQ(joined, "abab");
+  FREE_MSTR(joined);
+  free_array(v);
+
+  // Non-reversible behavior is unchanged: no fields at all.
+  v = explode_string("a", 1, "a", 1, false);
+  EXPECT_EQ(v->size, 0);
+}

--- a/src/vm/internal/base/array.cc
+++ b/src/vm/internal/base/array.cc
@@ -299,6 +299,24 @@ array_t* explode_string(const char* str, int slen, const char* del, int dellen, 
   }
 
   if (!sourcelen || source[0] == '\0') {
+    // In reversible mode the leading pass may have consumed the entire
+    // string: n delimiters still split into n+1 empty fields so that
+    // implode(explode(s, d), d) == s holds (issue #968).
+    if (reversible && num_leading) {
+      auto num = num_leading + 1;
+      if (num > max_array_size) {
+        num = max_array_size;
+      }
+      auto* ret = int_allocate_empty_array(num);
+      for (int i = 0; i < num; i++) {
+        ret->item[i].type = T_STRING;
+        ret->item[i].subtype = STRING_MALLOC;
+        auto* dest = new_string(0, "explode_string: empty field");
+        dest[0] = '\0';
+        ret->item[i].u.string = dest;
+      }
+      return ret;
+    }
     return &the_null_array;
   }
 


### PR DESCRIPTION
With the "reversible explode string" runtime option, `explode(a, a)` returned `({ })`, so `implode(explode(a, a), a)` produced `""` instead of `a` — breaking the option's documented invariant (`implode(explode(x, y), y) == x`). Acknowledged as a bug in the issue thread.

Cause: when the leading-delimiter pass consumes the entire input, `explode_string()` hit the `!sourcelen` early-return and returned the empty array unconditionally, dropping the accumulated leading fields. In reversible mode, n delimiters now split into n+1 empty fields (`explode("a", "a")` → `({ "", "" })`, `explode("abab", "ab")` → 3 empties), so the round-trip holds. Non-reversible (sane/legacy) behavior is unchanged — still `({ })`.

Test: `DriverTest.ExplodeReversibleAllDelimiters` in `src/tests/test_lpc.cc` exercises `explode_string(..., reversible=true)` directly (the testsuite config runs with the option off, so an LPC-level test can't reach this path) and pins the implode round-trip plus the unchanged non-reversible result. All GTest units and the full LPC testsuite pass.

Fixes #968

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016FMBJLkpkpVpZdz6PWzeWe

---
_Generated by [Claude Code](https://claude.ai/code/session_016FMBJLkpkpVpZdz6PWzeWe)_