### PR TITLE
vm: repair instead of crash on value-stack underflow in restore_context

### DIFF
--- a/src/vm/internal/base/interpret.cc
+++ b/src/vm/internal/base/interpret.cc
@@ -5142,8 +5142,22 @@ void restore_context(error_context_t* econ) {
     restore_command_giver();
   }
   DEBUG_CHECK(csp < econ->save_csp, "csp is below econ->csp before unwinding.\n");
+  DEBUG_CHECK(sp < econ->save_sp, "sp is below econ->save_sp before unwinding.\n");
 
-  pop_n_elems(sp - econ->save_sp);
+  if (sp > econ->save_sp) {
+    pop_n_elems(sp - econ->save_sp);
+  } else if (sp < econ->save_sp) {
+    // An error path with broken stack accounting (e.g. issue #1014) left sp
+    // below the saved mark; a negative pop count would walk garbage and
+    // crash. Re-point sp at the mark and neutralize the revived slots so
+    // later pops don't free stale pointers.
+    debug_message("restore_context: value stack underflow by %" PRIdPTR
+                  " elements, repairing.\n",
+                  static_cast<intptr_t>(econ->save_sp - sp));
+    while (sp < econ->save_sp) {
+      *++sp = const0;
+    }
+  }
   refp = global_ref_list;
   while (refp) {
     if (refp->csp >= csp) {

--- a/testsuite/aw_test.txt
+++ b/testsuite/aw_test.txt
@@ -46,3 +46,4 @@ async write payload
 async write payload
 async write payload
 async write payload
+async write payload

--- a/testsuite/trace_test.json
+++ b/testsuite/trace_test.json
@@ -1,3 +1,3 @@
 [
-{"pid":1976608,"tid":129006360494528,"ts":0,"dur":0,"ph":"M","cat":"DEFAULT","name":"thread_name","args":{"name":"FluffOS Main"}}
+{"pid":14338,"tid":140379981133376,"ts":0,"dur":0,"ph":"M","cat":"DEFAULT","name":"thread_name","args":{"name":"FluffOS Main"}}
 ]


### PR DESCRIPTION
`restore_context()` computed `pop_n_elems(sp - econ->save_sp)` with no sign check. When an error path with broken stack accounting leaves `sp` below the saved mark — reported in #1014 from PACKAGE_PARSER `direct_*` applies that throw, with `n = -215` — `pop_n_elems` walks garbage svalues and segfaults in release builds (`DEBUG_CHECK` only catches it in debug builds).

This guards the negative case: log a diagnostic, re-point `sp` at the saved mark, and zero the revived slots so later pops don't free stale pointers. Debug builds now `DEBUG_CHECK` the sp condition as well (matching the existing csp check).

This is deliberately a hardening net, not the root-cause fix: the parser-package stack accounting that produces the underflow (args pushed by `push_real_names` vs. what the erroring apply consumed) still deserves its own investigation, so this PR uses "Ref" rather than closing #1014 outright — happy to switch to `Fixes` if you'd rather track the parser follow-up separately.

Full LPC testsuite passes.

Ref #1014

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016FMBJLkpkpVpZdz6PWzeWe

---
_Generated by [Claude Code](https://claude.ai/code/session_016FMBJLkpkpVpZdz6PWzeWe)_