### PR TITLE
build: add pkg-config and libffi to dependency lists

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
             cxx: g++
             build: Debug
             cmake_flags: -DPACKAGE_DWLIB=ON
-            packages: build-essential autoconf automake bison flex expect libmysqlclient-dev libpcre3-dev libpq-dev libsqlite3-dev libssl-dev libtool libz-dev telnet libgtest-dev libjemalloc-dev libffi-dev
+            packages: build-essential autoconf automake bison flex expect libmysqlclient-dev libpcre3-dev libpq-dev libsqlite3-dev libssl-dev libtool libz-dev telnet libgtest-dev libjemalloc-dev pkg-config libffi-dev
           - platform: Ubuntu
             os: ubuntu-24.04
             compiler: gcc
@@ -39,7 +39,7 @@ jobs:
             cxx: g++
             build: RelWithDebInfo
             cmake_flags: -DPACKAGE_DWLIB=ON
-            packages: build-essential autoconf automake bison flex expect libmysqlclient-dev libpcre3-dev libpq-dev libsqlite3-dev libssl-dev libtool libz-dev telnet libgtest-dev libjemalloc-dev libffi-dev
+            packages: build-essential autoconf automake bison flex expect libmysqlclient-dev libpcre3-dev libpq-dev libsqlite3-dev libssl-dev libtool libz-dev telnet libgtest-dev libjemalloc-dev pkg-config libffi-dev
 
           # Ubuntu - Clang
           - platform: Ubuntu
@@ -48,14 +48,14 @@ jobs:
             cc: clang
             cxx: clang++
             build: Debug
-            packages: build-essential autoconf automake bison flex expect libmysqlclient-dev libpcre3-dev libpq-dev libsqlite3-dev libssl-dev libtool libz-dev telnet libgtest-dev libjemalloc-dev libffi-dev
+            packages: build-essential autoconf automake bison flex expect libmysqlclient-dev libpcre3-dev libpq-dev libsqlite3-dev libssl-dev libtool libz-dev telnet libgtest-dev libjemalloc-dev pkg-config libffi-dev
           - platform: Ubuntu
             os: ubuntu-24.04
             compiler: clang
             cc: clang
             cxx: clang++
             build: RelWithDebInfo
-            packages: build-essential autoconf automake bison flex expect libmysqlclient-dev libpcre3-dev libpq-dev libsqlite3-dev libssl-dev libtool libz-dev telnet libgtest-dev libjemalloc-dev libffi-dev
+            packages: build-essential autoconf automake bison flex expect libmysqlclient-dev libpcre3-dev libpq-dev libsqlite3-dev libssl-dev libtool libz-dev telnet libgtest-dev libjemalloc-dev pkg-config libffi-dev
 
           # Ubuntu - Clang with Sanitizer
           - platform: Ubuntu
@@ -66,7 +66,7 @@ jobs:
             build: Debug
             sanitizer: true
             cmake_flags: -DENABLE_SANITIZER=ON
-            packages: build-essential autoconf automake bison flex expect libmysqlclient-dev libpcre3-dev libpq-dev libsqlite3-dev libssl-dev libtool libz-dev telnet libgtest-dev libjemalloc-dev libdw-dev libbz2-dev libffi-dev
+            packages: build-essential autoconf automake bison flex expect libmysqlclient-dev libpcre3-dev libpq-dev libsqlite3-dev libssl-dev libtool libz-dev telnet libgtest-dev libjemalloc-dev pkg-config libdw-dev libbz2-dev libffi-dev
           - platform: Ubuntu
             os: ubuntu-24.04
             compiler: clang
@@ -75,7 +75,7 @@ jobs:
             build: RelWithDebInfo
             sanitizer: true
             cmake_flags: -DENABLE_SANITIZER=ON
-            packages: build-essential autoconf automake bison flex expect libmysqlclient-dev libpcre3-dev libpq-dev libsqlite3-dev libssl-dev libtool libz-dev telnet libgtest-dev libjemalloc-dev libdw-dev libbz2-dev libffi-dev
+            packages: build-essential autoconf automake bison flex expect libmysqlclient-dev libpcre3-dev libpq-dev libsqlite3-dev libssl-dev libtool libz-dev telnet libgtest-dev libjemalloc-dev pkg-config libdw-dev libbz2-dev libffi-dev
 
           # macOS
           - platform: macOS
@@ -98,14 +98,14 @@ jobs:
             build: Debug
             cmake_generator: MSYS Makefiles
             cmake_flags: -DMARCH_NATIVE=OFF -DPACKAGE_CRYPTO=OFF -DPACKAGE_DB_MYSQL="" -DPACKAGE_DB_SQLITE=1
-            packages: mingw-w64-x86_64-toolchain mingw-w64-x86_64-cmake mingw-w64-x86_64-zlib mingw-w64-x86_64-pcre mingw-w64-x86_64-icu mingw-w64-x86_64-sqlite3 mingw-w64-x86_64-jemalloc mingw-w64-x86_64-gtest mingw-w64-x86_64-libffi bison flex make
+            packages: mingw-w64-x86_64-toolchain mingw-w64-x86_64-cmake mingw-w64-x86_64-zlib mingw-w64-x86_64-pcre mingw-w64-x86_64-icu mingw-w64-x86_64-sqlite3 mingw-w64-x86_64-jemalloc mingw-w64-x86_64-gtest mingw-w64-x86_64-pkgconf mingw-w64-x86_64-libffi bison flex make
           - platform: Windows
             os: windows-latest
             shell: msys2 {0}
             build: RelWithDebInfo
             cmake_generator: MSYS Makefiles
             cmake_flags: -DMARCH_NATIVE=OFF -DPACKAGE_CRYPTO=OFF -DPACKAGE_DB_MYSQL="" -DPACKAGE_DB_SQLITE=1
-            packages: mingw-w64-x86_64-toolchain mingw-w64-x86_64-cmake mingw-w64-x86_64-zlib mingw-w64-x86_64-pcre mingw-w64-x86_64-icu mingw-w64-x86_64-sqlite3 mingw-w64-x86_64-jemalloc mingw-w64-x86_64-gtest mingw-w64-x86_64-libffi bison flex make
+            packages: mingw-w64-x86_64-toolchain mingw-w64-x86_64-cmake mingw-w64-x86_64-zlib mingw-w64-x86_64-pcre mingw-w64-x86_64-icu mingw-w64-x86_64-sqlite3 mingw-w64-x86_64-jemalloc mingw-w64-x86_64-gtest mingw-w64-x86_64-pkgconf mingw-w64-x86_64-libffi bison flex make
 
     defaults:
       run:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -49,7 +49,7 @@ jobs:
 
     - run: |
         sudo apt update
-        sudo apt install -y build-essential autoconf automake bison expect libmysqlclient-dev libpcre3-dev libpq-dev libsqlite3-dev libssl-dev libtool libz-dev telnet libgtest-dev libjemalloc-dev
+        sudo apt install -y build-essential autoconf automake bison expect libmysqlclient-dev libpcre3-dev libpq-dev libsqlite3-dev libssl-dev libtool libz-dev telnet libgtest-dev libjemalloc-dev pkg-config libffi-dev
         mkdir build && cd build && cmake -DCMAKE_BUILD_TYPE=Debug -DPACKAGE_DB_SQLITE=2 .. && make -j 2 install && cd ..
 
     - name: Perform CodeQL Analysis

--- a/.github/workflows/coverity-scan.yml
+++ b/.github/workflows/coverity-scan.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Install packages
         run: |
           sudo apt update
-          sudo apt install -y build-essential autoconf automake bison expect libmysqlclient-dev libpcre3-dev libpq-dev libsqlite3-dev libssl-dev libtool libz-dev telnet libgtest-dev libjemalloc-dev
+          sudo apt install -y build-essential autoconf automake bison expect libmysqlclient-dev libpcre3-dev libpq-dev libsqlite3-dev libssl-dev libtool libz-dev telnet libgtest-dev libjemalloc-dev pkg-config libffi-dev
       - name: configure
         run: |
           mkdir build

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ RUN apk add --no-progress --no-cache \
     mariadb-dev mariadb-static postgresql-dev sqlite-dev sqlite-static\
     openssl-dev openssl-libs-static zlib-dev zlib-static icu-dev icu-static \
     pcre-dev bison git musl-dev libelf-static elfutils-dev zstd-static bzip2-static xz-static \
-    libffi-dev
+    pkgconf libffi-dev
 
 WORKDIR /build
 

--- a/QWEN.md
+++ b/QWEN.md
@@ -146,13 +146,14 @@ valgrind --leak-check=full ./build/bin/driver config.test
 ```bash
 # 安装依赖
 sudo apt install build-essential bison libmysqlclient-dev libpcre3-dev \
-  libpq-dev libsqlite3-dev libssl-dev libz-dev libjemalloc-dev libicu-dev
+  libpq-dev libsqlite3-dev libssl-dev libz-dev libjemalloc-dev libicu-dev \
+  pkg-config libffi-dev
 ```
 
 ### macOS
 ```bash
 # 安装依赖
-brew install cmake pkg-config mysql pcre libgcrypt libevent openssl jemalloc icu4c
+brew install cmake pkg-config mysql pcre libgcrypt libevent openssl jemalloc icu4c libffi
 
 # 使用环境变量构建
 OPENSSL_ROOT_DIR="/usr/local/opt/openssl" ICU_ROOT="/usr/local/opt/icu4c" cmake ..
@@ -163,7 +164,8 @@ OPENSSL_ROOT_DIR="/usr/local/opt/openssl" ICU_ROOT="/usr/local/opt/icu4c" cmake 
 # 安装 MSYS2 包
 pacman -S git mingw-w64-x86_64-toolchain mingw-w64-x86_64-cmake
 pacman -S mingw-w64-x86_64-zlib mingw-w64-x86_64-libevent \
-  mingw-w64-x86_64-pcre mingw-w64-x86_64-icu mingw-w64-x86_64-openssl
+  mingw-w64-x86_64-pcre mingw-w64-x86_64-icu mingw-w64-x86_64-openssl \
+  mingw-w64-x86_64-pkgconf mingw-w64-x86_64-libffi
 
 # 在 MINGW64 终端中构建
 cmake -G "MSYS Makefiles" ..

--- a/README.md
+++ b/README.md
@@ -135,8 +135,11 @@ sudo apt update
 sudo apt install -y build-essential autoconf automake bison expect \
   libmysqlclient-dev libpcre3-dev libpq-dev libsqlite3-dev \
   libssl-dev libtool libz-dev telnet libgtest-dev libjemalloc-dev \
-  libdw-dev libbz2-dev
+  pkg-config libffi-dev libdw-dev libbz2-dev
 ```
+
+> [!NOTE]
+> `flex` is only needed if you modify the LPC lexer (`src/compiler/internal/lexer.l`). Otherwise the build uses the pre-committed generated lexer.
 
 **2. Compile:**
 ```bash
@@ -152,7 +155,7 @@ make -j$(nproc) install
 **1. Install dependencies (Homebrew):**
 ```bash
 brew install cmake pkg-config pcre libgcrypt openssl jemalloc icu4c \
-  mysql sqlite3 googletest
+  mysql sqlite3 googletest libffi
 ```
 
 **2. Compile:**
@@ -175,6 +178,7 @@ pacman --noconfirm -S --needed \
   mingw-w64-x86_64-zlib mingw-w64-x86_64-pcre \
   mingw-w64-x86_64-icu mingw-w64-x86_64-sqlite3 \
   mingw-w64-x86_64-jemalloc mingw-w64-x86_64-gtest \
+  mingw-w64-x86_64-pkgconf mingw-w64-x86_64-libffi \
   bison make
 ```
 
@@ -218,7 +222,7 @@ apk add --no-cache linux-headers gcc g++ clang-dev make cmake bash \
   mariadb-dev mariadb-static postgresql-dev sqlite-dev sqlite-static \
   openssl-dev openssl-libs-static zlib-dev zlib-static icu-dev icu-static \
   pcre-dev bison git musl-dev libelf-static elfutils-dev \
-  zstd-static bzip2-static xz-static
+  pkgconf libffi-dev zstd-static bzip2-static xz-static
 ```
 
 **2. Compile (static build):**

--- a/README_CN.md
+++ b/README_CN.md
@@ -134,8 +134,11 @@ sudo apt update
 sudo apt install -y build-essential autoconf automake bison expect \
   libmysqlclient-dev libpcre3-dev libpq-dev libsqlite3-dev \
   libssl-dev libtool libz-dev telnet libgtest-dev libjemalloc-dev \
-  libdw-dev libbz2-dev
+  pkg-config libffi-dev libdw-dev libbz2-dev
 ```
+
+> [!NOTE]
+> 仅当你修改 LPC 词法分析器（`src/compiler/internal/lexer.l`）时才需要 `flex`；否则构建将使用预先提交的生成文件。
 
 **2. 编译：**
 ```bash
@@ -151,7 +154,7 @@ make -j$(nproc) install
 **1. 安装依赖（Homebrew）：**
 ```bash
 brew install cmake pkg-config pcre libgcrypt openssl jemalloc icu4c \
-  mysql sqlite3 googletest
+  mysql sqlite3 googletest libffi
 ```
 
 **2. 编译：**
@@ -174,6 +177,7 @@ pacman --noconfirm -S --needed \
   mingw-w64-x86_64-zlib mingw-w64-x86_64-pcre \
   mingw-w64-x86_64-icu mingw-w64-x86_64-sqlite3 \
   mingw-w64-x86_64-jemalloc mingw-w64-x86_64-gtest \
+  mingw-w64-x86_64-pkgconf mingw-w64-x86_64-libffi \
   bison make
 ```
 
@@ -217,7 +221,7 @@ apk add --no-cache linux-headers gcc g++ clang-dev make cmake bash \
   mariadb-dev mariadb-static postgresql-dev sqlite-dev sqlite-static \
   openssl-dev openssl-libs-static zlib-dev zlib-static icu-dev icu-static \
   pcre-dev bison git musl-dev libelf-static elfutils-dev \
-  zstd-static bzip2-static xz-static
+  pkgconf libffi-dev zstd-static bzip2-static xz-static
 ```
 
 **2. 编译（静态构建）：**

--- a/docs/build.md
+++ b/docs/build.md
@@ -50,8 +50,11 @@ $ sudo apt update
 $ sudo apt install -y build-essential autoconf automake bison expect \
   libmysqlclient-dev libpcre3-dev libpq-dev libsqlite3-dev \
   libssl-dev libtool libz-dev telnet libjemalloc-dev libicu-dev \
-  libgtest-dev
+  libgtest-dev pkg-config libffi-dev
 ```
+
+> [!NOTE]
+> `flex` is only needed if you modify the LPC lexer (`src/compiler/internal/lexer.l`). Otherwise the build uses the pre-committed generated lexer.
 
 For **sanitizer builds** (memory debugging), also install:
 ```shell
@@ -132,7 +135,7 @@ If not already installed, goto <https://brew.sh/> and follow instructions!
 
 ```shell
 $ brew install cmake pkg-config mysql pcre libgcrypt openssl jemalloc icu4c \
-  sqlite3 googletest
+  sqlite3 googletest libffi
 ```
 
 Set `HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK=1` to speed up brew installs if needed.
@@ -205,6 +208,7 @@ $ pacman --noconfirm -S --needed \
   mingw-w64-x86_64-zlib mingw-w64-x86_64-pcre \
   mingw-w64-x86_64-icu mingw-w64-x86_64-sqlite3 \
   mingw-w64-x86_64-jemalloc mingw-w64-x86_64-gtest \
+  mingw-w64-x86_64-pkgconf mingw-w64-x86_64-libffi \
   bison make
 ```
 
@@ -360,7 +364,7 @@ $ apk add --no-cache linux-headers gcc g++ clang-dev make cmake bash \
     mariadb-dev mariadb-static postgresql-dev sqlite-dev sqlite-static \
     openssl-dev openssl-libs-static zlib-dev zlib-static icu-dev icu-static \
     pcre-dev bison git musl-dev libelf-static elfutils-dev \
-    zstd-static bzip2-static xz-static
+    pkgconf libffi-dev zstd-static bzip2-static xz-static
 ```
 
 ### Installing jemalloc


### PR DESCRIPTION
Updates dependency lists to include `pkg-config` and `libffi`, now required by `package_ffi` (`pkg_check_modules(FFI REQUIRED libffi)`). `pkg-config` was previously an optional dependency with a manual search fallback.

Adds the correct package name per manager (`pkg-config`/`libffi-dev` for apt, `libffi` for brew, `pkgconf`/`libffi-dev` for apk, `-pkgconf`/ `-libffi` for pacman) across the READMEs, build docs, Dockerfile, and CI workflows. Also documents that `flex` dependency is only needed when editing the LPC lexer.