### PR TITLE
Add recompile_object() efun: in-place program update, state preserved

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,7 +17,7 @@ FluffOS is a high-performance LPMUD driver and game engine. Its codebase is stru
   - `wasm/`: WebAssembly target files (JS transport, exported entry points, crash-handler stub).
 * **`src/vm/`**: The execution VM and LPC bytecode interpreter.
   - `interpret.cc`: The core bytecode interpreter loop (`eval_instruction`).
-  - `simulate.cc`: Object loading, cloning, destruction, and simulation event loops.
+  - `simulate.cc`: Object loading, cloning, destruction, and simulation event loops; also `recompile_object()` (in-place program update: recompiles a source file and swaps the program into the live master copy and all clones, carrying variables over by name -- see docs/concepts/general/hot_reload.md).
   - `vm.cc`: VM startup and master object callbacks.
 * **`src/compiler/`**: The LPC parser, compiler, and code generator.
   - `grammar.y` / `grammar.autogen.cc`: Bison rules compiling LPC scripts to bytecode.
@@ -71,6 +71,11 @@ LPC variables are dynamically typed and managed via the `svalue_t` structure. Me
 * Compound types (`T_ARRAY`, `T_MAPPING`, `T_BUFFER`, `T_CLASS`, and ref-counted `T_STRING` strings) are reference-counted.
 * If you copy a pointer to one of these types into another structure, you must increment its ref count (e.g., `arr->ref++`).
 * If you overwrite or destroy a reference, you must decrement its ref count or use `free_svalue(sval, tag)` to clean it up safely.
+
+### Object Variable Block & Allocation Tags
+* An object's global variables are a SEPARATE allocation from the `object_t` itself (`ob->variables`, `TAG_OBJ_VARS`, always >= 1 svalue, sized to `prog->num_variables_total`) -- this is what lets `recompile_object()` swap a program with a different variable count onto a live object. Allocate via `allocate_object_variables()`; `tot_alloc_object_size` accounting uses `sizeof(object_t) + (max(n,1)-1)*sizeof(svalue_t)`.
+* When introducing a new DMALLOC tag, wire it into the debug-build walkers in `packages/develop/checkmemory.cc` (a `DO_MARK` at the owning object's mark site plus an orphan-report case), or every testsuite run on a Debug build will flag the blocks. Pick a free `TAG_PERMANENT + n` slot in `base/internal/debugmalloc.h`.
+* `destruct_object()` SWEEPS the VM stack (`remove_object_from_stack`): any efun that runs arbitrary LPC (applies, `__INIT`) before cleaning up an object argument must free it with `free_svalue(sp, ...)`, never `free_object(&sp->u.ob, ...)` -- the slot may have become a plain number 0.
 
 ### String Allocations
 * **Constant Strings (`STRING_CONSTANT`)**: Not ref-counted or freed (point directly to literal read-only memory).
@@ -126,6 +131,7 @@ FluffOS uses GitHub Actions for CI on pull requests and pushes to `master`.
 * **Testing Targets**:
   - `driver-testsuite`: Boots the local driver pointing to the test configuration.
   - `driver-fulltest` / `driver-autotest`: Runs the LPC test suite and reports results before exiting.
+* **Harness facts that bite:** LPC fixture files must live OUTSIDE `testsuite/single/tests/` (use `/clone/...` or write them at runtime under `/data/...`) -- the runner executes every `tests/**/*.lpc` in RANDOMIZED order. Tests that register global state (e.g. `master->set_compile_hooks()`) must tear it down UNCONDITIONALLY: ASSERT macros record-and-continue, so wrap the body in `catch(run_checks())`, clean up, then re-`error()`. `master::flag()` sits on the call stack for the entire run (so e.g. the master object can never be recompiled from inside a test; use a `call_out` that fires post-run and `shutdown(-1)`s on failure -- call_outs only fire after the suite in FULL runs, never in single-file runs, which shut down synchronously). A plain `-ftest:` filter needs the FULL test path; suite runs dirty `testsuite/aw_test.txt` and `testsuite/trace_test.json` (restore before committing). `file_name(ob)` returns a leading slash.
 * **The LPC suite is a real pass/fail gate, registered with ctest.** the ctest test is named `testsuite` — `ctest -R testsuite` (equivalently the `driver-autotest` CMake target) runs `driver etc/config.test -ftest`; CI runs `ctest -LE testsuite` (GTest) and `ctest -L testsuite` (this suite) as separate steps. The runner (`testsuite/command/tests.lpc`) prints gtest-style `[ RUN ]/[ OK ]/[ FAILED ]` blocks with per-file timing; **failed checks are recorded and the run continues** (one run reports every failure), then a recap lists the failed files and the driver exits nonzero. A clean run prints `Checks succeeded.` and exits 0 — that pair is the sound pass signal. Filter runs with `-ftest:single/tests/efuns/foo.lpc` (one file) or `-ftest:efuns/dual*` (glob). When touching the lexer/parser, run the suite 2–3× (it randomizes test file order) and prefer both a Debug ASan build and a `RelWithDebInfo` build (some issues are release-only).
 
 ---
@@ -155,6 +161,11 @@ When editing compiler, VM, or package features, keep these structural mechanics 
 ### Applies (Driver-to-LPC Callbacks)
 * "Applies" are standard callbacks that the driver VM invokes on LPC objects during specific runtime events (e.g., `create` during cloning, `init` when entering a room, `clean_up` during sweep collections).
 * Applies are mapped using the `applies_table.autogen.cc` lookup tables.
+* **Compile-time master applies** `inherit_program(from, path, priv)` and `include_file(compiled, from, path)` are consulted for every inherit statement / #include directive: string return redirects the path, array-of-strings return supplies the source text itself, any other return denies. They run MID-COMPILE (same precedent as `valid_override`/`get_include_path`): implementations must never trigger another compile. Reference pages in docs/apply/master/; the dependency graph they expose powers the hot-reload daemon (`testsuite/single/hot_reload.lpc`).
+
+### Hot Reload (`recompile_object()`)
+* `recompile_object(master_copy)` recompiles the source and swaps the program into the live master copy and every clone -- no destruct, identity preserved, variables carried by name (private included; new program's `__INIT` runs first, then surviving names get old values). Works for the master object, the simul_efun object (their cached dispatch tables `master_applies`/`simuls` are rebuilt against the new program BEFORE its `__INIT` runs; simul indices are name-stable by design) and virtual objects (the backing program is what recompiles).
+* Invariants when touching this machinery: refuse while any live frame executes the old program (bytecode/variable indices are layout-relative); void pending `replace_program()` entries at each target's swap point (`cancel_pending_replace_program` -- entries are computed against the program being replaced and old code can register one mid-update); function pointers that depend on the owner's layout (`FP_LOCAL`, `FP_FUNCTIONAL`) carry an `owner_gen` snapshot of `ob->prog_generation` and error cleanly when stale; `FP_LOCAL` funptrs store their creation program and account `func_ref` against IT (creation/destruction must stay symmetric -- decrementing `owner->prog` corrupts counts after a swap).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ An LPMUD system is built from three distinct layers, each with a clear responsib
 - **Clone-based objects** — an LPC source file is a blueprint. The driver clones it to create instances: one `/obj/sword.c` file → thousands of individual sword objects in the world.
 - **Inheritance** — objects inherit and override behavior: `/std/weapon.c` → `/obj/sword.c` → `/obj/cursed_sword.c`.
 - **Garbage collected** — the driver handles memory automatically via reference counting; LPC code never calls `free()`.
-- **Live hot-reload** — you can update and reload a running object without restarting the server or disconnecting players.
+- **Live hot-reload** — `recompile_object()` swaps a recompiled program into a running object *and all its clones* without restarting the server or disconnecting players; variables carry over by name, so state survives the update.
 - **Event-driven** — no threads, no blocking. Game logic runs in response to player commands, network events, and `call_out()` timers.
 - **Sandboxed** — the driver tracks evaluation cost and kills runaway code before it can crash the server.
 
@@ -349,6 +349,11 @@ cd testsuite
 - MySQL, PostgreSQL, SQLite integration.
 - Async IO operations.
 - External program integration.
+
+### Hot Reload
+- `recompile_object()` efun: recompile a source file and swap the new program into the live master copy and every clone — no destruct, object identity and variable state preserved (works for the master object, the simul_efun object, and virtual objects too).
+- Compile-time master applies `inherit_program()` and `include_file()` expose the full dependency graph (and can redirect, synthesize, or deny inherits/includes).
+- A reference auto-hot-reload daemon (watch files, reload on change, dependency-ordered) ships in the testsuite; see the [hot reload guide](https://www.fluffos.info/concepts/general/hot_reload).
 
 ### Networking
 - TLS support.

--- a/docs/concepts/general/hot_reload.md
+++ b/docs/concepts/general/hot_reload.md
@@ -316,8 +316,8 @@ is destructed.
 To summarize the reference daemon's modes: `watch(prog)` reloads
 through `recompile_object()` (state and clones carried in place),
 `watch(prog, 0)` opts out (destruct+load, fresh initializers, clones
-untouched), and the cooperative pair takes over when the object
-defines it. All three shapes are pinned by
+untouched), and the cooperative path takes over when the object
+defines `hot_reload_state()`. All three shapes are pinned by
 `/single/tests/applies/hot_reload.lpc`, and the `recompile_object()`
 semantics themselves by `/single/tests/efuns/recompile_object.lpc`.
 

--- a/docs/concepts/general/hot_reload.md
+++ b/docs/concepts/general/hot_reload.md
@@ -5,9 +5,11 @@ title: general / hot_reload
 
 FluffOS can tell the mudlib, at compile time, exactly which files every
 program is built from. That is the missing piece for **auto hot-reload**:
-a daemon that watches source files on disk and automatically destructs
-and reloads the affected master copies when anything changes, so developers
-see their edits take effect without manually running an `update` command.
+a daemon that watches source files on disk and automatically
+hot-updates the affected programs — master copies and live clones
+alike, variable state intact — the moment anything changes, so
+developers see their edits take effect without manually running an
+`update` command.
 
 This page explains the driver mechanism and walks through a complete
 mudlib implementation. A working reference lives in the testsuite:
@@ -213,17 +215,22 @@ still use its code: compiled programs are reference counted, so
 existing inheritors keep the old program until they are themselves
 reloaded.
 
+This destruct+load `reload()` is the simplest correct baseline — step
+5 upgrades it to the driver's `recompile_object()` efun, which performs the
+same recompile-and-swap on the *live* objects, keeping variable state
+and reaching every clone.
+
 ## Step 4: make it automatic
 
 Poll from a `call_out` loop; `watch()` is the registration point (it
 loads the target itself so the compile happens while the daemon is
-recording):
+recording — `keep_state` is explained in step 5):
 
 ```c
-public int watch(string prog) {
+public int watch(string prog, int keep_state: (: 1 :)) {
     prog = program_of(prog);
     if (!find_object(prog)) load_object(prog);
-    watched[prog] = 1;
+    watched[prog] = keep_state ? WATCH_KEEP_STATE : WATCH_PLAIN;
     snapshot_program(prog);
     return 1;
 }
@@ -241,6 +248,78 @@ public void enable(int interval) {
 }
 ```
 
+## Step 5: keep variable state across reloads — recompile_object()
+
+The destruct+load cycle resets global variables to their initializers
+and cannot touch clones. The driver's
+[`recompile_object()`](../../efun/objects/recompile_object.md) efun replaces that
+cycle entirely:
+
+```c
+int n = recompile_object(find_object("/obj/widget"));
+```
+
+recompiles the program from its source file and swaps it into the
+**live master copy and every clone sharing it** — no destruct, same
+object identity everywhere (pointers held by other objects, inventory,
+shadows, interactive state, call_outs and heart_beat all survive).
+Each object's global variables carry over **by name**, private ones
+included: the new program's initializers run first, then every
+surviving name gets its old value back; new variables keep their
+initializers, vanished names are dropped. It returns the number of
+objects updated.
+
+The reference daemon's default (state-keeping) reload path is exactly
+this: `recompile_object()` on each changed ancestor, then on the watched
+program, so the child's recompile picks up the freshly swapped parent.
+
+Two things to know:
+
+* An object **currently executing** (anywhere on the call stack)
+  cannot be hot-updated — the daemon's poller naturally runs from a
+  `call_out`, where watched objects are idle.
+* Function pointers made against the old program layout (pointers to
+  local functions, functionals) become stale and raise a clean error
+  when called; recreate them after the update.
+
+### Doing it by hand: value transfer
+
+Objects that define the cooperative pair
+`hot_reload_state()`/`hot_reload_restore()` opt out of `recompile_object()`
+in the reference daemon: they reload through destruct+load and get
+back exactly the state their pair chose to carry — the way to make
+some state deliberately *not* survive.
+
+The same destruct+load path can also carry state generically without
+driver support, using three efuns from the contrib package —
+[`variables()`](../../efun/contrib/variables.md),
+[`fetch_variable()`](../../efun/contrib/fetch_variable.md) and
+[`store_variable()`](../../efun/contrib/store_variable.md):
+
+```c
+// BEFORE destructing: capture every reachable global by name
+mapping state = ([]);
+foreach (string name in variables(ob))
+    catch (state[name] = fetch_variable(name, ob));
+
+// AFTER the fresh load: restore the names that still exist
+foreach (string name, mixed value in state)
+    catch (store_variable(name, value, fresh));
+```
+
+Unlike `recompile_object()`, this transfer runs outside the driver, so
+`private` variables are not reachable (the `catch` skips them) and a
+captured value that referenced the old master copy nulls out when it
+is destructed.
+
+To summarize the reference daemon's modes: `watch(prog)` reloads
+through `recompile_object()` (state and clones carried in place),
+`watch(prog, 0)` opts out (destruct+load, fresh initializers, clones
+untouched), and the cooperative pair takes over when the object
+defines it. All three shapes are pinned by
+`/single/tests/applies/hot_reload.lpc`, and the `recompile_object()`
+semantics themselves by `/single/tests/efuns/recompile_object.lpc`.
+
 ## Putting it together
 
 ```c
@@ -251,9 +330,9 @@ d->watch("/obj/widget");      // widget inherits /std/base, which includes color
 // ... edit /std/colors.h on disk ...
 
 // within a poll interval the daemon notices: colors.h is in widget's
-// dependency closure through /std/base -> destructs the stale master
-// copies of base and widget, reloads /obj/widget, and the next
-// "/obj/widget"->describe() runs the new code.
+// dependency closure through /std/base -> hot-updates the stale base,
+// then widget, in place. The next "/obj/widget"->describe() -- and
+// every live widget clone -- runs the new code, all state intact.
 ```
 
 This exact flow — including the deepest case, editing an include of an
@@ -262,13 +341,19 @@ This exact flow — including the deepest case, editing an include of an
 
 ## Semantics and caveats
 
-* **What reloads is the master copy** (the object loaded from the
-  file, as opposed to its clones). Existing clones keep the old
-  program until they are re-created; anything fetched via
-  `"/path/name"->func()` or fresh `find_object()`/`new()` after the
-  reload gets the new code. The master copy's global variables reset to their
-  initializers on reload — daemons that must keep state across reloads
-  need to save/restore it themselves.
+* **Clones follow the reload path.** The default `recompile_object()` path
+  swaps the program into the master copy *and every live clone*, each
+  keeping its own state. The destruct+load path (opt-out mode, or the
+  cooperative pair) replaces only the master copy: existing clones
+  keep the old program until re-created — enumerate them with
+  [`children()`](../../efun/objects/children.md) (filter with
+  `clonep()`) to destruct or migrate stragglers. Either way, anything
+  fetched via `"/path/name"->func()` or fresh `find_object()`/`new()`
+  after the reload gets the new code.
+* **Function pointers into a hot-updated object go stale** (pointers
+  to local functions, functionals): calling one afterwards raises a
+  clean error rather than running mis-indexed code. Recreate them
+  after the update; efun/simul_efun pointers are unaffected.
 * **Only programs compiled while the daemon was registered have
   complete records.** That is why `watch()` loads its target itself,
   and why the daemon rebuilds records during every reload.
@@ -288,6 +373,9 @@ This exact flow — including the deepest case, editing an include of an
   [`include_file`](../../apply/master/include_file.md) — the apply
   reference pages, including the redirect / inline-source / deny
   return forms
+* [`recompile_object`](../../efun/objects/recompile_object.md) — the efun
+  reference: swap a recompiled program into the live master copy and
+  its clones
 * [`inherit`](../../lpc/constructs/inherit.md),
   [`#include`](../../lpc/preprocessor/include.md) — the language
   constructs and their resolution rules

--- a/docs/concepts/general/hot_reload.md
+++ b/docs/concepts/general/hot_reload.md
@@ -22,8 +22,9 @@ mudlib implementation. A working reference lives in the testsuite:
 A compiled LPC program is built from more than its own source file:
 
 * every `#include`d header is spliced into the compile, and
-* every `inherit`ed program's code is copied into the child's program
-  at compile time.
+* every `inherit`ed program is bound into the child at compile time —
+  the child's program links against the exact parent program it was
+  compiled with.
 
 So when `/std/base.c` or a header it includes changes, reloading only
 the objects whose *own* file changed silently leaves every inheritor
@@ -284,8 +285,8 @@ Two things to know:
 
 ### Doing it by hand: value transfer
 
-Objects that define the cooperative pair
-`hot_reload_state()`/`hot_reload_restore()` opt out of `recompile_object()`
+Objects that define `hot_reload_state()` (optionally paired with
+`hot_reload_restore()`) opt out of `recompile_object()`
 in the reference daemon: they reload through destruct+load and get
 back exactly the state their pair chose to carry — the way to make
 some state deliberately *not* survive.
@@ -350,6 +351,10 @@ This exact flow — including the deepest case, editing an include of an
   `clonep()`) to destruct or migrate stragglers. Either way, anything
   fetched via `"/path/name"->func()` or fresh `find_object()`/`new()`
   after the reload gets the new code.
+* **Even the master and simul_efun objects can be recompiled** — the
+  driver rebuilds their dispatch tables (with name-stable simul_efun
+  indices) during the swap. Do it from a `call_out` or another idle
+  context: like any object, they cannot be recompiled while executing.
 * **Function pointers into a hot-updated object go stale** (pointers
   to local functions, functionals): calling one afterwards raises a
   clean error rather than running mis-indexed code. Recreate them

--- a/docs/concepts/general/hot_reload.md
+++ b/docs/concepts/general/hot_reload.md
@@ -351,6 +351,10 @@ This exact flow — including the deepest case, editing an include of an
   `clonep()`) to destruct or migrate stragglers. Either way, anything
   fetched via `"/path/name"->func()` or fresh `find_object()`/`new()`
   after the reload gets the new code.
+* **Virtual objects update through their backing program** — the
+  efun recompiles the real file the virtual object carries. The
+  daemon's dependency records are keyed by compiled program name, so
+  watch virtual objects via their backing file.
 * **Even the master and simul_efun objects can be recompiled** — the
   driver rebuilds their dispatch tables (with name-stable simul_efun
   indices) during the swap. Do it from a `call_out` or another idle

--- a/docs/efun/index.md
+++ b/docs/efun/index.md
@@ -346,6 +346,7 @@ title: EFUN
 * [present](objects/present)
 * [query_heart_beat](objects/query_heart_beat)
 * [query_notify_destruct](objects/query_notify_destruct)
+* [recompile_object](objects/recompile_object)
 * [reload_object](objects/reload_object)
 * [restore_object](objects/restore_object)
 * [save_object](objects/save_object)

--- a/docs/efun/objects/index.md
+++ b/docs/efun/objects/index.md
@@ -21,6 +21,7 @@ title: objects
 * [present](present)
 * [query_heart_beat](query_heart_beat)
 * [query_notify_destruct](query_notify_destruct)
+* [recompile_object](recompile_object)
 * [reload_object](reload_object)
 * [restore_object](restore_object)
 * [save_object](save_object)

--- a/docs/efun/objects/recompile_object.md
+++ b/docs/efun/objects/recompile_object.md
@@ -1,0 +1,87 @@
+---
+title: objects / recompile_object
+---
+# recompile_object
+
+### NAME
+
+    recompile_object() - recompile a program and swap it into the live
+    master copy and all its clones, keeping variable state
+
+### SYNOPSIS
+
+    int recompile_object( object master_copy );
+
+### DESCRIPTION
+
+    Recompiles the master copy's program from its source file and swaps
+    the fresh program into the master copy AND every clone sharing it.
+    Nothing is destructed: object identity is preserved everywhere, so
+    pointers held by other objects, the object's name, inventory,
+    shadows, interactive state, heart_beat and pending call_outs all
+    stay intact. This is an in-place "hot update", as opposed to the classic
+    destruct + load_object() cycle (which resets state and cannot touch
+    clones).
+
+    Each updated object's global variables carry over BY NAME: the new
+    program's variable initializers run first, then every variable
+    whose name also existed in the old program gets its old value back
+    (private variables included - the transfer happens inside the
+    driver). Variables new in this version keep their initializers;
+    vanished names are dropped. create() is NOT called again.
+
+    The recompile behaves like a normal load: unloaded inherited
+    programs are loaded on demand, and the master applies
+    inherit_program(4), include_file(4), get_include_path(4) and
+    valid_read(4) are all consulted.
+
+    Returns the number of objects updated (the master copy plus its
+    clones).
+
+### ERRORS
+
+    The call fails with an error if:
+
+    - a clone is passed (pass the master copy; its clones are updated
+      with it);
+    - any object sharing the program is currently executing, anywhere
+      on the call stack (bytecode positions and variable indices in
+      live frames are relative to the old program) - in particular an
+      object cannot recompile itself;
+    - the source fails to compile (the objects are left untouched on
+      the old program);
+    - the target is the simul_efun object, a replace_program() is
+      pending on the program, or recompile_object is already in progress.
+
+### CAVEATS
+
+    Function pointers made before the update whose behavior depends on
+    the owner's program layout (pointers to local functions, and
+    functionals / anonymous functions) become STALE: calling them after
+    a recompile_object of their owner raises a clean "Stale function pointer"
+    error instead of running mis-indexed code. Recreate them after the
+    update. Efun and simul_efun pointers are unaffected.
+
+    Programs that INHERIT the updated program are not recompiled - like
+    with the destruct/reload cycle, inheritance copies code at compile
+    time. Update inheritors separately (parents first). The testsuite's
+    /single/hot_reload.lpc daemon automates exactly that ordering from
+    the compile-time dependency graph.
+
+### EXAMPLE
+
+    ```c
+    object ob = find_object("/obj/sword");
+
+    // ... edit /obj/sword.c on disk ...
+
+    int n = recompile_object(ob);
+    // every live sword (master copy + clones) now runs the new code,
+    // each keeping its own enchantment, wielder, condition, ...
+    write(sprintf("updated %d objects\n", n));
+    ```
+
+### SEE ALSO
+
+    reload_object(3), children(3), clonep(3), destruct(3),
+    inherit_program(4), include_file(4)

--- a/docs/efun/objects/recompile_object.md
+++ b/docs/efun/objects/recompile_object.md
@@ -35,6 +35,13 @@ title: objects / recompile_object
     inherit_program(4), include_file(4), get_include_path(4) and
     valid_read(4) are all consulted.
 
+    Virtual objects (materialized through the master's
+    compile_object(4) hook) update like any other object: the recompile
+    targets the BACKING program - the real file whose program the
+    virtual object carries - and the virtual name, identity and flag
+    are untouched. A virtual object whose backing program has no
+    on-disk source fails cleanly.
+
     The master object and the simul_efun object can themselves be
     recompiled: their cached dispatch tables (apply-name and
     simul_efun-name to function) are rebuilt against the new program

--- a/docs/efun/objects/recompile_object.md
+++ b/docs/efun/objects/recompile_object.md
@@ -35,6 +35,17 @@ title: objects / recompile_object
     inherit_program(4), include_file(4), get_include_path(4) and
     valid_read(4) are all consulted.
 
+    The master object and the simul_efun object can themselves be
+    recompiled: their cached dispatch tables (apply-name and
+    simul_efun-name to function) are rebuilt against the new program
+    before its initializers run. Simul_efun indices are preserved by
+    NAME across the rebuild, so simul calls compiled into every other
+    program keep working; a simul_efun removed by the new source fails
+    with the usual "no longer a simul_efun" runtime error. Note that
+    the currently-executing rule below applies as usual - the master
+    cannot be recompiled from code the master itself is running (e.g.
+    from inside one of its applies).
+
     Returns the number of objects updated (the master copy plus its
     clones).
 
@@ -44,14 +55,15 @@ title: objects / recompile_object
 
     - a clone is passed (pass the master copy; its clones are updated
       with it);
-    - any object sharing the program is currently executing, anywhere
-      on the call stack (bytecode positions and variable indices in
-      live frames are relative to the old program) - in particular an
-      object cannot recompile itself;
+    - any live frame is executing the program's code, anywhere on the
+      call stack - including an inheritor running one of its inherited
+      functions (bytecode positions and variable indices in live frames
+      are relative to the old program). In particular an object cannot
+      recompile itself;
     - the source fails to compile (the objects are left untouched on
       the old program);
-    - the target is the simul_efun object, a replace_program() is
-      pending on the program, or recompile_object is already in progress.
+    - a replace_program() is pending on the program, or another
+      recompile_object() is already in progress.
 
 ### CAVEATS
 
@@ -63,8 +75,9 @@ title: objects / recompile_object
     update. Efun and simul_efun pointers are unaffected.
 
     Programs that INHERIT the updated program are not recompiled - like
-    with the destruct/reload cycle, inheritance copies code at compile
-    time. Update inheritors separately (parents first). The testsuite's
+    with the destruct/reload cycle, a child program stays bound to the
+    exact parent program it was compiled against. Update inheritors
+    separately (parents first). The testsuite's
     /single/hot_reload.lpc daemon automates exactly that ordering from
     the compile-time dependency graph.
 

--- a/docs/efun/objects/recompile_object.md
+++ b/docs/efun/objects/recompile_object.md
@@ -62,11 +62,12 @@ title: objects / recompile_object
 
     - a clone is passed (pass the master copy; its clones are updated
       with it);
-    - any live frame is executing the program's code, anywhere on the
-      call stack - including an inheritor running one of its inherited
-      functions (bytecode positions and variable indices in live frames
-      are relative to the old program). In particular an object cannot
-      recompile itself;
+    - any live frame is executing the program's code or belongs to an
+      object running it, anywhere on the call stack - including an
+      inheritor running one of its inherited functions, and an object
+      of this program running an inherited parent's code (bytecode
+      positions and variable indices in live frames are relative to the
+      old layout). In particular an object cannot recompile itself;
     - the source fails to compile (the objects are left untouched on
       the old program);
     - a replace_program() is pending on the program, or another

--- a/docs/efun/objects/reload_object.md
+++ b/docs/efun/objects/reload_object.md
@@ -21,5 +21,5 @@ title: objects / reload_object
 
 ### SEE ALSO
 
-    export_uid(3), new(3), clone_object(3), destruct(3)
+    recompile_object(3), export_uid(3), new(3), clone_object(3), destruct(3)
 

--- a/src/base/internal/debugmalloc.h
+++ b/src/base/internal/debugmalloc.h
@@ -71,6 +71,10 @@ static const int TAG_PARSER = (TAG_PERMANENT + 37);
 #endif
 static const int TAG_INPUT_TO = (TAG_PERMANENT + 38);
 static const int TAG_SOCKETS = (TAG_PERMANENT + 39);
+// An object's variable block (vm/internal/base/object.cc
+// allocate_object_variables) -- separate from the object_t allocation
+// so recompile_object() can swap programs with a different variable count.
+static const int TAG_OBJ_VARS = (TAG_PERMANENT + 40);
 // Compile-arena chunks (compiler/internal/scratchpad.cc): retained across
 // compiles by design -- whitelisted in check_all_blocks like the other
 // persistent driver infrastructure.

--- a/src/compiler/internal/disassembler.cc
+++ b/src/compiler/internal/disassembler.cc
@@ -562,7 +562,7 @@ static void disassemble(FILE* f, char* code, int start, int end, program_t* prog
         break;
       case F_SIMUL_EFUN:
         COPY_SHORT(&sarg, pc);
-        if (sarg >= num_simul_efun) {
+        if (sarg >= num_simul_efun || !simuls[sarg].func) {
           sprintf(buff, "<invalid %d> %d\n", sarg, pc[2]);
         } else {
           sprintf(buff, "\"%s\" args: %d", simuls[sarg].func->funcname, pc[2]);
@@ -574,7 +574,9 @@ static void disassemble(FILE* f, char* code, int start, int end, program_t* prog
         switch (EXTRACT_UCHAR(pc++)) {
           case FP_SIMUL:
             LOAD_SHORT(sarg, pc);
-            sprintf(buff, "<simul_efun> \"%s\"", simuls[sarg].func->funcname);
+            sprintf(buff, "<simul_efun> \"%s\"",
+                    (sarg < num_simul_efun && simuls[sarg].func) ? simuls[sarg].func->funcname
+                                                                 : "<removed>");
             break;
           case FP_EFUN:
             LOAD_SHORT(sarg, pc);

--- a/src/packages/core/core.spec
+++ b/src/packages/core/core.spec
@@ -276,6 +276,7 @@ int get_char(string | function, ...);
 object *children(string);
 
 void reload_object(object);
+int recompile_object(object);
 
 void error(string);
 int uptime();

--- a/src/packages/core/efuns_main.cc
+++ b/src/packages/core/efuns_main.cc
@@ -3217,9 +3217,11 @@ void f_reload_object() {
 
 #ifdef F_RECOMPILE_OBJECT
 void f_recompile_object() {
-  object_t* ob = sp->u.ob;
-  int count = recompile_object(ob);
-  free_object(&sp->u.ob, "f_recompile_object");
+  int count = recompile_object(sp->u.ob);
+  // The target (or one of its clones) may have destructed itself in its
+  // new program's __INIT: destruct sweeps the VM stack, so sp may hold
+  // a plain 0 instead of the object reference by now.
+  free_svalue(sp, "f_recompile_object");
   put_number(count);
 }
 #endif

--- a/src/packages/core/efuns_main.cc
+++ b/src/packages/core/efuns_main.cc
@@ -141,6 +141,7 @@ void f_bind() {
   *new_fp = *old_fp;
   new_fp->hdr.ref = 1;
   new_fp->hdr.owner = ob; /* one ref from being on stack */
+  new_fp->hdr.owner_gen = ob->prog_generation;
   if (new_fp->hdr.args) {
     new_fp->hdr.args->ref++;
   }
@@ -3211,6 +3212,15 @@ void f_memory_info() {
 void f_reload_object() {
   reload_object(sp->u.ob);
   free_object(&(sp--)->u.ob, "f_reload_object");
+}
+#endif
+
+#ifdef F_RECOMPILE_OBJECT
+void f_recompile_object() {
+  object_t* ob = sp->u.ob;
+  int count = recompile_object(ob);
+  free_object(&sp->u.ob, "f_recompile_object");
+  put_number(count);
 }
 #endif
 

--- a/src/packages/core/replace_program.cc
+++ b/src/packages/core/replace_program.cc
@@ -26,6 +26,29 @@ int replace_program_pending(object_t* ob) {
   return 0;
 }
 
+/*
+ * Void any pending replace_program() for ob. recompile_object() calls
+ * this at the moment it swaps ob's program: a pending entry's target
+ * program pointer and variable offset were computed against the
+ * program being replaced (old code may have registered it mid-update,
+ * e.g. from another target's __INIT), and letting the backend sweep
+ * apply it to the fresh program would corrupt the variable block. An
+ * entry registered AFTER the swap is computed against the new program
+ * and is left alone.
+ */
+void cancel_pending_replace_program(object_t* ob) {
+  replace_ob_t **prev = &obj_list_replace, *r;
+
+  while ((r = *prev)) {
+    if (r->ob == ob) {
+      *prev = r->next;
+      FREE((char*)r);
+    } else {
+      prev = &r->next;
+    }
+  }
+}
+
 void replace_programs() {
   replace_ob_t *r_ob, *r_next;
   int i, num_fewer, offset;

--- a/src/packages/core/replace_program.h
+++ b/src/packages/core/replace_program.h
@@ -2,6 +2,7 @@
 #define _REPLACE_PROGRAM_H_
 
 int replace_program_pending(object_t*);
+void cancel_pending_replace_program(object_t*);
 void replace_programs(void);
 
 typedef struct replace_ob_s {

--- a/src/packages/core/sprintf.cc
+++ b/src/packages/core/sprintf.cc
@@ -401,7 +401,7 @@ void svalue_to_string(svalue_t* obj, outbuffer_t* outbuf, int indent, int traili
             outbuf_add(outbuf, "0");
             break;
           }
-          outbuf_add(outbuf, function_name(ob->prog, obj->u.fp->f.local.index));
+          outbuf_add(outbuf, function_name(obj->u.fp->f.local.prog, obj->u.fp->f.local.index));
           break;
         case FP_SIMUL:
           outbuf_add(outbuf, simuls[obj->u.fp->f.simul.index].func->funcname);

--- a/src/packages/core/sprintf.cc
+++ b/src/packages/core/sprintf.cc
@@ -404,7 +404,13 @@ void svalue_to_string(svalue_t* obj, outbuffer_t* outbuf, int indent, int traili
           outbuf_add(outbuf, function_name(obj->u.fp->f.local.prog, obj->u.fp->f.local.index));
           break;
         case FP_SIMUL:
-          outbuf_add(outbuf, simuls[obj->u.fp->f.simul.index].func->funcname);
+          // The named simul_efun may have been removed by a simul_efun
+          // object update; the table entry stays with a null func.
+          if (simuls[obj->u.fp->f.simul.index].func) {
+            outbuf_add(outbuf, simuls[obj->u.fp->f.simul.index].func->funcname);
+          } else {
+            outbuf_add(outbuf, "<removed simul_efun>");
+          }
           break;
         case FP_FUNCTIONAL:
         case FP_FUNCTIONAL | FP_NOT_BINDABLE: {

--- a/src/packages/develop/checkmemory.cc
+++ b/src/packages/develop/checkmemory.cc
@@ -758,7 +758,7 @@ void check_all_blocks(int flag) {
               if (first) {
                 hptr = first;
                 do {
-                  if (hptr->token & (IHE_SIMUL | IHE_EFUN)) {
+                  if (hptr->token & (IHE_SIMUL | IHE_EFUN | IHE_ORPHAN)) {
                     DO_MARK(hptr, TAG_PERM_IDENT);
                   }
                   hptr = hptr->next;

--- a/src/packages/develop/checkmemory.cc
+++ b/src/packages/develop/checkmemory.cc
@@ -161,6 +161,10 @@ static void mark_object(object_t* ob) {
     DO_MARK(ob->obname, TAG_OBJ_NAME);
   }
 
+  if (ob->variables) {
+    DO_MARK(ob->variables, TAG_OBJ_VARS);
+  }
+
   if (ob->replaced_program) {
     EXTRA_REF(BLOCK(ob->replaced_program))++;
   }
@@ -253,9 +257,7 @@ static void mark_funp(funptr_t* fp) {
   }
   switch (fp->hdr.type) {
     case FP_LOCAL | FP_NOT_BINDABLE:
-      if (fp->hdr.owner) {
-        fp->hdr.owner->prog->extra_func_ref++;
-      }
+      fp->f.local.prog->extra_func_ref++;
       break;
     case FP_FUNCTIONAL:
     case FP_FUNCTIONAL | FP_NOT_BINDABLE:
@@ -953,6 +955,10 @@ void check_all_blocks(int flag) {
           case TAG_OBJ_NAME:
             outbuf_addv(&out, "WARNING: Found orphan object name: %s %04x\n", entry->desc,
                         entry->tag);
+            break;
+          case TAG_OBJ_VARS:
+            outbuf_addv(&out, "WARNING: Found orphan object variable block: %s %04x\n",
+                        entry->desc, entry->tag);
             break;
           case TAG_INTERACTIVE:
             outbuf_addv(&out, "WARNING: Found orphan interactive: %s %04x\n", entry->desc,

--- a/src/vm/internal/base/function.cc
+++ b/src/vm/internal/base/function.cc
@@ -12,9 +12,7 @@ void dealloc_funp(funptr_t* fp) {
 
   switch (fp->hdr.type) {
     case FP_LOCAL | FP_NOT_BINDABLE:
-      if (fp->hdr.owner) {
-        prog = fp->hdr.owner->prog;
-      }
+      prog = fp->f.local.prog;
       break;
     case FP_FUNCTIONAL:
     case FP_FUNCTIONAL | FP_NOT_BINDABLE:
@@ -99,6 +97,7 @@ funptr_t* make_efun_funp(int opcode, svalue_t* args) {
   fp = reinterpret_cast<funptr_t*>(DMALLOC(sizeof(funptr_t), TAG_FUNP, "make_efun_funp"));
   fp->hdr.owner = current_object;
   add_ref(current_object, "make_efun_funp");
+  fp->hdr.owner_gen = current_object->prog_generation;
   fp->hdr.type = FP_EFUN;
 
   fp->f.efun.index = opcode;
@@ -127,11 +126,13 @@ funptr_t* make_lfun_funp(int index, svalue_t* args) {
   fp = reinterpret_cast<funptr_t*>(DMALLOC(sizeof(funptr_t), TAG_FUNP, "make_lfun_funp"));
   fp->hdr.owner = current_object;
   add_ref(current_object, "make_lfun_funp");
+  fp->hdr.owner_gen = current_object->prog_generation;
   fp->hdr.type = FP_LOCAL | FP_NOT_BINDABLE;
 
-  fp->hdr.owner->prog->func_ref++;
-  debug(d_flag, "add func ref /%s: now %i\n", fp->hdr.owner->prog->filename,
-        fp->hdr.owner->prog->func_ref);
+  fp->f.local.prog = current_object->prog;
+  fp->f.local.prog->func_ref++;
+  debug(d_flag, "add func ref /%s: now %i\n", fp->f.local.prog->filename,
+        fp->f.local.prog->func_ref);
 
   newindex = index + function_index_offset;
   if (current_object->prog->function_flags[newindex] & FUNC_ALIAS) {
@@ -156,6 +157,7 @@ funptr_t* make_simul_funp(int index, svalue_t* args) {
   fp = reinterpret_cast<funptr_t*>(DMALLOC(sizeof(funptr_t), TAG_FUNP, "make_simul_funp"));
   fp->hdr.owner = current_object;
   add_ref(current_object, "make_simul_funp");
+  fp->hdr.owner_gen = current_object->prog_generation;
   fp->hdr.type = FP_SIMUL;
 
   fp->f.simul.index = index;
@@ -184,6 +186,7 @@ funptr_t* make_functional_funp(short num_arg, short num_local, short len, svalue
   fp = reinterpret_cast<funptr_t*>(DMALLOC(sizeof(funptr_t), TAG_FUNP, "make_functional_funp"));
   fp->hdr.owner = current_object;
   add_ref(current_object, "make_functional_funp");
+  fp->hdr.owner_gen = current_object->prog_generation;
   fp->hdr.type = FP_FUNCTIONAL + flag;
 
   current_prog->func_ref++;
@@ -219,6 +222,21 @@ svalue_t* call_function_pointer(funptr_t* funp, int num_arg) {
   if (!funp->hdr.owner || (funp->hdr.owner->flags & O_DESTRUCTED)) {
     error("Owner (/%s) of function pointer is destructed.\n",
           (funp->hdr.owner ? funp->hdr.owner->obname : "(null)"));
+  }
+  /* FP_LOCAL indices and FP_FUNCTIONAL variable offsets are relative to
+     the owner's program layout when the pointer was made; after a
+     recompile_object() they would run the wrong function or scribble over the
+     re-laid-out variables. Fail cleanly instead. */
+  switch (funp->hdr.type & FP_MASK) {
+    case FP_LOCAL:
+    case FP_FUNCTIONAL:
+      if (funp->hdr.owner_gen != funp->hdr.owner->prog_generation) {
+        error("Stale function pointer: owner /%s was recompiled since it was created.\n",
+              funp->hdr.owner->obname);
+      }
+      break;
+    default:
+      break;
   }
   setup_fake_frame(funp);
   if ((v = funp->hdr.args)) {

--- a/src/vm/internal/base/function.h
+++ b/src/vm/internal/base/function.h
@@ -4,16 +4,21 @@
 /* It is usually better to include "lpc_incl.h" instead of including this
    directly */
 
+/* FP_SIMUL / FP_EFUN */
+typedef struct {
+  short index;
+} simul_ptr_t;
+typedef simul_ptr_t efun_ptr_t;
+
 /* FP_LOCAL */
 typedef struct {
   short index;
+  /* The owner's program when the pointer was made: `index` is relative
+     to ITS function table, and it is the program whose func_ref this
+     pointer holds. The owner's live prog can move on (recompile_object),
+     so creation/destruction accounting must use this one. */
+  struct program_t* prog;
 } local_ptr_t;
-
-/* FP_SIMUL */
-typedef local_ptr_t simul_ptr_t;
-
-/* FP_EFUN */
-typedef local_ptr_t efun_ptr_t;
 
 /* FP_FUNCTIONAL */
 struct functional_t {
@@ -34,6 +39,13 @@ struct funptr_hdr_t {
 #ifdef DEBUGMALLOC_EXTENSIONS
   int extra_ref;
 #endif
+  /* owner->prog_generation at creation/bind time. FP_LOCAL indices and
+     FP_FUNCTIONAL variable offsets are relative to the owner's program
+     LAYOUT at that moment; if recompile_object() has swapped the program
+     since, calling through them would run the wrong function or corrupt
+     variables -- the call path compares generations and errors
+     cleanly instead. */
+  uint32_t owner_gen;
   struct object_t* owner;
   struct array_t* args;
 };

--- a/src/vm/internal/base/object.cc
+++ b/src/vm/internal/base/object.cc
@@ -1853,6 +1853,10 @@ void dealloc_object(object_t* ob, const char* from) {
     free_prog(&ob->prog);
     ob->prog = nullptr;
   }
+  if (ob->variables) {
+    FREE(ob->variables);
+    ob->variables = nullptr;
+  }
   if (ob->replaced_program) {
     FREE_MSTR(ob->replaced_program);
     ob->replaced_program = nullptr;
@@ -1914,33 +1918,34 @@ void free_object(object_t** ob, const char* const from) {
 }
 
 /*
- * Allocate an empty object, and set all variables to 0. Note that a
- * 'object_t' already has space for one variable. So, if no variables
- * are needed, we waste one svalue worth of memory (or we'd write too
- * much memory in copying the NULL_object over.
+ * Allocate the variable block for an object: a separate allocation (so
+ * recompile_object() can swap programs with a different variable count on the
+ * live object), always at least one svalue so ob->variables is never
+ * null, every slot nil.
+ */
+svalue_t* allocate_object_variables(int num_var) {
+  int n = num_var ? num_var : 1;
+  auto* vars =
+      reinterpret_cast<svalue_t*>(DMALLOC(n * sizeof(svalue_t), TAG_OBJ_VARS, "object variables"));
+  for (int i = 0; i < n; i++) {
+    vars[i] = const0u;
+  }
+  return vars;
+}
+
+/*
+ * Allocate an empty object, and set all variables to 0.
  */
 object_t* get_empty_object(int num_var) {
-  // static object_t NULL_object;
   object_t* ob;
   int size = sizeof(object_t) + (num_var - !!num_var) * sizeof(svalue_t);
-  int i;
 
   tot_alloc_object++;
   tot_alloc_object_size += size;
-  ob = reinterpret_cast<object_t*>(DMALLOC(size, TAG_OBJECT, "get_empty_object"));
-  /*
-   * marion Don't initialize via memset, this is incorrect. E.g. the bull
-   * machines have a (char *)0 which is not zero. We have structure
-   * assignment, so use it.
-   */
-  //*ob = NULL_object; gives a warning on const pointers
-  // memcpy(ob, &NULL_object, sizeof NULL_object);
-  // screw the "bull machines" we're in the 21st century now
+  ob = reinterpret_cast<object_t*>(DMALLOC(sizeof(object_t), TAG_OBJECT, "get_empty_object"));
   memset(ob, 0, sizeof(object_t));
   ob->ref = 1;
-  for (i = 0; i < num_var; i++) {
-    ob->variables[i] = const0u;
-  }
+  ob->variables = allocate_object_variables(num_var);
   return ob;
 }
 

--- a/src/vm/internal/base/object.h
+++ b/src/vm/internal/base/object.h
@@ -81,6 +81,9 @@ struct object_t {
 #endif
   uint64_t time_of_ref; /* Time when last referenced. Used by clean_uo */
   program_t* prog;
+  uint32_t prog_generation; /* bumped by recompile_object() when prog is swapped
+                               on the live object; funptrs snapshot it so
+                               stale index-based pointers fail cleanly */
   struct object_t* next_all;
   struct object_t* prev_all;
 #ifndef NO_ENVIRONMENT
@@ -115,8 +118,11 @@ struct object_t {
 #ifdef PACKAGE_PARSER
   struct parse_info_s* pinfo;
 #endif
-  svalue_t variables[1]; /* All variables to this program */
-                         /* The variables MUST come last in the struct */
+  svalue_t* variables; /* All variables to this program. A separate
+                          allocation (TAG_OBJ_VARS) sized to
+                          prog->num_variables_total (min 1), so
+                          recompile_object() can swap in a program with a
+                          different variable count on the live object. */
 };
 
 typedef int (*get_objectsfn_t)(object_t*, void*);
@@ -165,6 +171,7 @@ int object_visible(object_t*);
 #define object_visible(x) 1
 #endif
 int find_global_variable(program_t*, const char* const, unsigned short*, int);
+svalue_t* allocate_object_variables(int num_var);
 void dealloc_object(object_t*, const char*);
 void get_objects(object_t***, int*, get_objectsfn_t, void*);
 #ifdef DEBUGMALLOC_EXTENSIONS

--- a/src/vm/internal/master.cc
+++ b/src/vm/internal/master.cc
@@ -88,6 +88,20 @@ static void get_master_applies(object_t* ob) {
   }
 }
 
+/*
+ * Rebuild the cached apply-name -> function table after
+ * recompile_object() swapped a fresh program into the live master
+ * object. Must run before any LPC executes against the new program
+ * (its __INIT included): apply_master_ob() dispatches through this
+ * table by runtime index, and the old entries point into the old
+ * program's function table.
+ */
+void rebuild_master_applies() {
+  if (master_ob) {
+    get_master_applies(master_ob);
+  }
+}
+
 void set_master(object_t* ob) {
 #if defined(PACKAGE_UIDS) || defined(PACKAGE_MUDLIB_STATS)
   int first_load = (!master_ob);
@@ -95,10 +109,12 @@ void set_master(object_t* ob) {
   svalue_t* ret;
 
   get_master_applies(ob);
-  master_ob = ob;  // from here on apply_master_ob returns -1 only as return from the apply
+  if (master_ob != ob) {
+    master_ob = ob;  // from here on apply_master_ob returns -1 only as return from the apply
 
-  /* Make sure master_ob is never made a dangling pointer. */
-  add_ref(master_ob, "set_master");
+    /* Make sure master_ob is never made a dangling pointer. */
+    add_ref(master_ob, "set_master");
+  }
 #ifndef PACKAGE_UIDS
 #ifdef PACKAGE_MUDLIB_STATS
   if (first_load) {

--- a/src/vm/internal/master.h
+++ b/src/vm/internal/master.h
@@ -14,5 +14,6 @@ void init_master(const char*);
 struct svalue_t* apply_master_ob(int, int);
 struct svalue_t* safe_apply_master_ob(int, int);
 void set_master(struct object_t*);
+void rebuild_master_applies();
 
 #endif

--- a/src/vm/internal/simul_efun.cc
+++ b/src/vm/internal/simul_efun.cc
@@ -179,8 +179,27 @@ static void find_or_add_simul_efun(function_t* funp, int runtime_index) {
 void set_simul_efun(object_t* ob) {
   get_simul_efuns(ob->prog);
 
-  simul_efun_ob = ob;
-  add_ref(simul_efun_ob, "set_simul_efun");
+  if (simul_efun_ob != ob) {
+    simul_efun_ob = ob;
+    add_ref(simul_efun_ob, "set_simul_efun");
+  }
+}
+
+/*
+ * Rebuild the simul_efun dispatch table after recompile_object()
+ * swapped a fresh program into the live simul_efun object. Must run
+ * before any LPC executes against the new program (its __INIT
+ * included): call_simul_efun() dispatches by runtime index through
+ * this table, and the old entries point into the old program's
+ * function table. Indices are preserved by NAME across the rebuild
+ * (see get_simul_efuns), so calls compiled into other programs keep
+ * working; a simul_efun removed by the new source fails with the
+ * usual "no longer a simul_efun" error.
+ */
+void rebuild_simul_efuns() {
+  if (simul_efun_ob) {
+    get_simul_efuns(simul_efun_ob->prog);
+  }
 }
 
 void call_simul_efun(unsigned short index, int num_arg) {

--- a/src/vm/internal/simul_efun.cc
+++ b/src/vm/internal/simul_efun.cc
@@ -101,11 +101,15 @@ static void get_simul_efuns(program_t* prog) {
 
   if (num_simul_efun) {
     remove_simuls();
-    if (!num_new) {
-      FREE(simul_names);
-      FREE(simuls);
-      num_simul_efun = 0;
-    } else {
+    /* Do NOT free the tables when the new program defines no simuls:
+     * previously-compiled programs still carry F_SIMUL_EFUN opcodes and
+     * FP_SIMUL funptrs with baked indices into these arrays (live across
+     * a recompile of the simul_efun object). remove_simuls() has already
+     * tombstoned every entry (func = nullptr), which yields the clean
+     * "no longer a simul_efun" error; keeping the arrays preserves the
+     * name->index mapping so any re-added simul reuses its slot. Only
+     * grow the arrays when there are new candidate functions. */
+    if (num_new) {
       /* will be resized later */
       simul_names =
           RESIZE(simul_names, num_simul_efun + num_new, simul_entry, TAG_SIMULS, "get_simul_efuns");

--- a/src/vm/internal/simul_efun.h
+++ b/src/vm/internal/simul_efun.h
@@ -10,6 +10,7 @@ extern struct function_lookup_info_t* simuls;
 
 void init_simul_efun(const char*);
 void set_simul_efun(struct object_t*);
+void rebuild_simul_efuns();
 
 #ifdef DEBUGMALLOC_EXTENSIONS
 void mark_simuls(void);

--- a/src/vm/internal/simulate.cc
+++ b/src/vm/internal/simulate.cc
@@ -821,11 +821,6 @@ int recompile_object(object_t* target) {
   if (in_recompile_object) {
     error("recompile_object: already updating; nested recompile_object is not allowed.\n");
   }
-  if (simul_efun_ob && old_prog == simul_efun_ob->prog) {
-    // The simul_efun dispatch table points into this program's function
-    // table; swapping it would leave every simul call dangling.
-    error("recompile_object: cannot update the simul_efun object.\n");
-  }
   if (strrchr(target->obname, '#')) {
     // Normalize the request: updating "a clone" really means updating
     // the shared program; demand the master copy so the intent is clear.
@@ -986,6 +981,19 @@ int recompile_object(object_t* target) {
     ob->variables = allocate_object_variables(new_n);
     tot_alloc_object_size +=
         ((new_n ? new_n : 1) - (old_n ? old_n : 1)) * static_cast<int>(sizeof(svalue_t));
+
+    // The master and simul_efun objects dispatch through cached
+    // name->runtime-index tables; rebuild them against the new program
+    // BEFORE any LPC runs (the __INIT below included -- an error inside
+    // it would already route through these tables). Simul indices are
+    // preserved by name, so calls compiled into other programs keep
+    // working.
+    if (ob == master_ob) {
+      rebuild_master_applies();
+    }
+    if (ob == simul_efun_ob) {
+      rebuild_simul_efuns();
+    }
 
     // Fresh initializers first (this object's new code), then the
     // carried-over values overwrite every name that survived.

--- a/src/vm/internal/simulate.cc
+++ b/src/vm/internal/simulate.cc
@@ -60,7 +60,10 @@ void db_cleanup(void);  // FIXME
 
 #include "comm.h"  // FIXME
 
-#include "vm/internal/trace.h"  // for dump_trace && get_svalue_trace
+#include <vector>
+
+#include "packages/core/replace_program.h"  // for replace_program_pending
+#include "vm/internal/trace.h"              // for dump_trace && get_svalue_trace
 /*
  * This one is called from HUP.
  */
@@ -776,6 +779,255 @@ object_t* load_object_from_source(const std::string& source, const char* virtual
   ob->load_time = get_current_time();
 
   return ob;
+}
+
+// Depth-first over the inherit tree, own variables last: the exact
+// layout order of an object's variable block (mirrors fgv_recurse).
+static void recompile_variable_names(program_t* prog, std::vector<const char*>& out) {
+  for (int i = 0; i < prog->num_inherited; i++) {
+    recompile_variable_names(prog->inherit[i].prog, out);
+  }
+  for (int i = 0; i < prog->num_variables_defined; i++) {
+    out.push_back(prog->variable_table[i]);
+  }
+}
+
+/*
+ * recompile_object(ob): recompile the object's program from its source file
+ * and swap the fresh program into the LIVE master copy and every clone
+ * sharing it. No destruct: object identity (pointers held elsewhere,
+ * name, inventory, shadows, interactive state, call_outs, heart_beat)
+ * is untouched. Global variables carry over BY NAME -- the fresh
+ * program's __INIT runs first, then every variable whose name also
+ * existed in the old program gets its old value back; new variables
+ * keep their initializers, vanished names are dropped. This is only
+ * possible because the variable block is a separate allocation
+ * (allocate_object_variables), sized per program.
+ *
+ * Function pointers made against the old program layout (FP_LOCAL
+ * indices, FP_FUNCTIONAL variable offsets) become stale: each updated
+ * object's prog_generation is bumped and call_function_pointer()
+ * errors cleanly on the mismatch instead of running mis-indexed code.
+ */
+int recompile_object(object_t* target) {
+  // Nested recompile_object (from a parent load's create(), or from __INIT
+  // below) would mutate the target set under the outer call's feet.
+  static bool in_recompile_object = false;
+
+  program_t* old_prog = target->prog;
+  if (!old_prog) {
+    error("recompile_object: object has no program.\n");
+  }
+  if (in_recompile_object) {
+    error("recompile_object: already updating; nested recompile_object is not allowed.\n");
+  }
+  if (simul_efun_ob && old_prog == simul_efun_ob->prog) {
+    // The simul_efun dispatch table points into this program's function
+    // table; swapping it would leave every simul call dangling.
+    error("recompile_object: cannot update the simul_efun object.\n");
+  }
+  if (strrchr(target->obname, '#')) {
+    // Normalize the request: updating "a clone" really means updating
+    // the shared program; demand the master copy so the intent is clear.
+    error("recompile_object: pass the master copy, not a clone.\n");
+  }
+
+  /*
+   * Refuse while any frame still executes (or will return into) the old
+   * program: bytecode positions and variable indices in live frames are
+   * relative to the old layout.
+   */
+  if ((current_object && current_object->prog == old_prog) || current_prog == old_prog) {
+    error("recompile_object: '/%s' is currently executing.\n", target->obname);
+  }
+  for (control_stack_t* f = control_stack; f <= csp; f++) {
+    if ((f->ob && f->ob->prog == old_prog) || f->prog == old_prog) {
+      error("recompile_object: '/%s' is currently executing.\n", target->obname);
+    }
+  }
+  for (object_t* ob = obj_list; ob; ob = ob->next_all) {
+    if (ob->prog == old_prog && replace_program_pending(ob)) {
+      error("recompile_object: '/%s' has a pending replace_program().\n", ob->obname);
+    }
+  }
+
+  // The compiled name survives old_prog's release below.
+  std::string obname(old_prog->filename);
+  char obbase[MAX_OBJECT_NAME_SIZE];
+  if (!filename_to_obname(obname.c_str(), obbase, sizeof obbase)) {
+    strncpy(obbase, obname.c_str(), sizeof obbase - 1);
+    obbase[sizeof obbase - 1] = 0;
+  }
+
+  const char* pname = check_valid_path(obname.c_str(), target, "recompile_object", 0);
+  if (!pname) {
+    error("recompile_object: read access denied for '/%s'.\n", obname.c_str());
+  }
+  std::string source_path(pname);
+
+  in_recompile_object = true;
+  // error() throws, so the flag must reset on every path.
+  DEFER { in_recompile_object = false; };
+
+  /*
+   * Recompile, resolving unloaded parents with the same iterative dance
+   * as load_object() -- the recompile also re-consults the master's
+   * inherit_program/include_file applies.
+   */
+  auto inherit_chain_size = CONFIG_INT(__INHERIT_CHAIN_SIZE__);
+  program_t* new_prog = nullptr;
+  for (int rounds = 0;; rounds++) {
+    int f = open(source_path.c_str(), O_RDONLY);
+    if (f == -1) {
+      error("recompile_object: could not read the file '/%s'.\n", source_path.c_str());
+    }
+#ifdef _WIN32
+    _setmode(f, _O_BINARY);
+#endif
+    save_command_giver(command_giver);
+    new_prog = compile_file_fd(f, obname.c_str());
+    restore_command_giver();
+    close(f);
+    update_compile_av(total_lines);
+    total_lines = 0;
+
+    if (!inherit_file) {
+      break;
+    }
+
+    char inhbuf[MAX_OBJECT_NAME_SIZE];
+    char inhraw[MAX_OBJECT_NAME_SIZE];
+    std::string inh_source = std::move(inherit_file_source);
+    inherit_file_source.clear();
+
+    if (!filename_to_obname(inherit_file, inhbuf, sizeof inhbuf)) {
+      strcpy(inhbuf, inherit_file);
+    }
+    strncpy(inhraw, inherit_file, sizeof inhraw - 1);
+    inhraw[sizeof inhraw - 1] = 0;
+    FREE(inherit_file);
+    inherit_file = nullptr;
+
+    if (new_prog) {
+      free_prog(&new_prog);
+      new_prog = nullptr;
+    }
+    if (strcmp(inhbuf, obbase) == 0) {
+      error("Illegal to inherit self.\n");
+    }
+    if (rounds >= inherit_chain_size) {
+      error("Inherit chain too deep: > %d in recompile_object of '/%s'.\n", inherit_chain_size,
+            obbase);
+    }
+    if (!ObjectTable::instance().find(inhbuf)) {
+      object_t* inh_obj;
+      compiler_next_load_reason =
+          std::string("while loading '/") + inhbuf + "' inherited by '/" + obbase + "'";
+      if (!inh_source.empty()) {
+        inh_obj = load_object_from_source(inh_source, inhbuf, 1);
+      } else {
+        inh_obj = load_object(inhraw, 1);
+      }
+      if (!inh_obj) {
+        error("Inherited file '/%s' does not exist!\n", inhbuf);
+      }
+    }
+  }
+
+  if (num_parse_error > 0 || new_prog == nullptr) {
+    if (new_prog) {
+      free_prog(&new_prog);
+    }
+    error("recompile_object: error compiling '/%s'.\n", obname.c_str());
+  }
+
+  /*
+   * Variable transfer map: for every slot of the new layout, the old
+   * layout's slot with the same name (or -1). check_nosave=0: runtime
+   * state moves regardless of save-file semantics.
+   */
+  int old_n = old_prog->num_variables_total;
+  int new_n = new_prog->num_variables_total;
+  std::vector<const char*> names;
+  names.reserve(new_n);
+  recompile_variable_names(new_prog, names);
+  std::vector<int> old_index(new_n, -1);
+  for (int i = 0; i < new_n; i++) {
+    unsigned short vtype;
+    old_index[i] = find_global_variable(old_prog, names[i], &vtype, 0);
+  }
+
+  // Snapshot the update set first: __INIT below runs arbitrary LPC that
+  // may load/destruct objects and reshuffle obj_list.
+  std::vector<object_t*> targets;
+  for (object_t* ob = obj_list; ob; ob = ob->next_all) {
+    if (ob->prog == old_prog && !(ob->flags & O_DESTRUCTED)) {
+      add_ref(ob, "recompile_object");
+      targets.push_back(ob);
+    }
+  }
+
+  int count = 0;
+  for (object_t* ob : targets) {
+    if (ob->flags & O_DESTRUCTED) {
+      // Destructed by an earlier target's __INIT: it still carries the
+      // old program and dies with it.
+      object_t* tmp = ob;
+      free_object(&tmp, "recompile_object");
+      continue;
+    }
+
+    svalue_t* old_vars = ob->variables;
+    program_t* prev_prog = ob->prog;
+
+    reference_prog(new_prog, "recompile_object");
+    ob->prog = new_prog;
+    ob->prog_generation++;
+    ob->variables = allocate_object_variables(new_n);
+    tot_alloc_object_size +=
+        ((new_n ? new_n : 1) - (old_n ? old_n : 1)) * static_cast<int>(sizeof(svalue_t));
+
+    // Fresh initializers first (this object's new code), then the
+    // carried-over values overwrite every name that survived.
+    call___INIT(ob);
+    if (!(ob->flags & O_DESTRUCTED)) {
+      for (int i = 0; i < new_n; i++) {
+        if (old_index[i] >= 0) {
+          assign_svalue(&ob->variables[i], &old_vars[old_index[i]]);
+        }
+      }
+    }
+    for (int i = 0; i < old_n; i++) {
+      free_svalue(&old_vars[i], "recompile_object");
+    }
+    FREE(old_vars);
+    free_prog(&prev_prog);
+
+    if (!(ob->flags & O_DESTRUCTED)) {
+      // Recompute the function-presence flags load_object derives.
+      if (function_exists(APPLY_CLEAN_UP, ob, 1)) {
+        ob->flags |= O_WILL_CLEAN_UP;
+      } else {
+        ob->flags &= ~O_WILL_CLEAN_UP;
+      }
+#ifdef NO_ADD_ACTION
+      if (function_exists(APPLY_CATCH_TELL, ob, 1) ||
+          function_exists(APPLY_RECEIVE_MESSAGE, ob, 1)) {
+        ob->flags |= O_LISTENER;
+      } else {
+        ob->flags &= ~O_LISTENER;
+      }
+#endif
+      count++;
+    }
+    object_t* tmp = ob;
+    free_object(&tmp, "recompile_object");
+  }
+
+  // Drop the compile's own reference; the updated objects hold theirs.
+  free_prog(&new_prog);
+
+  return count;
 }
 
 static char* make_new_name(const char* str) {

--- a/src/vm/internal/simulate.cc
+++ b/src/vm/internal/simulate.cc
@@ -1002,22 +1002,41 @@ int recompile_object(object_t* target) {
     }
 
     // Fresh initializers first (this object's new code), then the
-    // carried-over values overwrite every name that survived.
-    call___INIT(ob);
-    if (!(ob->flags & O_DESTRUCTED)) {
+    // carried-over values overwrite every name that survived. __INIT
+    // runs arbitrary LPC and may error(); catch it so one target's bad
+    // initializer can't leak this loop's held refs (the snapshot ref,
+    // new_prog's compile ref, old_vars) or abort the other targets.
+    // On error the object is left committed to the new program with a
+    // fresh (partially initialized) variable block -- carried-over
+    // state is dropped, as with a create() that throws during load.
+    bool init_ok = true;
+    {
+      error_context_t econ;
+      save_context(&econ);
+      try {
+        call___INIT(ob);
+      } catch (const char*) {
+        restore_context(&econ);
+        init_ok = false;
+      }
+      pop_context(&econ);
+    }
+    if (init_ok && !(ob->flags & O_DESTRUCTED)) {
       for (int i = 0; i < new_n; i++) {
         if (old_index[i] >= 0) {
           assign_svalue(&ob->variables[i], &old_vars[old_index[i]]);
         }
       }
     }
+    // The old variable block and the old program reference are dropped
+    // regardless of how __INIT fared -- ob has already moved off them.
     for (int i = 0; i < old_n; i++) {
       free_svalue(&old_vars[i], "recompile_object");
     }
     FREE(old_vars);
     free_prog(&prev_prog);
 
-    if (!(ob->flags & O_DESTRUCTED)) {
+    if (init_ok && !(ob->flags & O_DESTRUCTED)) {
       // Recompute the function-presence flags load_object derives.
       if (function_exists(APPLY_CLEAN_UP, ob, 1)) {
         ob->flags |= O_WILL_CLEAN_UP;

--- a/src/vm/internal/simulate.cc
+++ b/src/vm/internal/simulate.cc
@@ -975,6 +975,12 @@ int recompile_object(object_t* target) {
     svalue_t* old_vars = ob->variables;
     program_t* prev_prog = ob->prog;
 
+    // Old code running on a not-yet-swapped target (driven from an
+    // earlier target's __INIT) may have registered a replace_program()
+    // since the pre-flight check: computed against the program we are
+    // replacing right now, so void it.
+    cancel_pending_replace_program(ob);
+
     reference_prog(new_prog, "recompile_object");
     ob->prog = new_prog;
     ob->prog_generation++;

--- a/src/vm/internal/simulate.h
+++ b/src/vm/internal/simulate.h
@@ -37,6 +37,7 @@ int filename_to_obname(const char*, char*, int);
 object_t* load_object(const char*, int);
 object_t* load_object_from_source(const std::string& source, const char* virtual_name,
                                   int callcreate);
+int recompile_object(object_t* target);
 object_t* clone_object(const char*, int);
 object_t* environment(svalue_t*);
 object_t* first_inventory(svalue_t*);

--- a/testsuite/single/hot_reload.lpc
+++ b/testsuite/single/hot_reload.lpc
@@ -20,12 +20,16 @@
 #define MASTER "/single/master"
 #define DEFAULT_INTERVAL 2
 
+// watched[prog] values: reload drops state / reload carries state over
+#define WATCH_PLAIN 1
+#define WATCH_KEEP_STATE 2
+
 // program name (no extension) -> ([ source path : 1 ]) - own source and
 // every file it #includes, recorded at compile time
 private mapping file_deps = ([]);
 // program name -> ([ inherited program name : 1 ])
 private mapping inherit_deps = ([]);
-// programs registered for auto reload
+// programs registered for auto reload (value: WATCH_* mode)
 private mapping watched = ([]);
 // source path -> ({ size, mtime }) at the last (re)load
 private mapping snapshot = ([]);
@@ -169,25 +173,68 @@ private void snapshot_program(string prog) {
   }
 }
 
-// --- reload ----------------------------------------------------------------
+// --- variable-state carry-over ----------------------------------------------
+//
+// The driver's recompile_object() efun swaps the fresh program into the live
+// master copy and every clone, carrying each object's global variables
+// over by name (private ones included) - that is the default reload
+// mechanism for state-keeping watches. An object that wants full
+// control - some state shouldn't survive a reload - defines the
+// cooperative pair
+//   mixed hot_reload_state();
+//   void hot_reload_restore(mixed state);
+// and is then reloaded through destruct+load with exactly the state
+// its pair chose to carry.
 
-private void forget(string prog) {
-  object ob = find_object(prog);
+private mixed capture_state(object ob) { return ob->hot_reload_state(); }
 
-  if (ob) destruct(ob);
-  map_delete(file_deps, prog);
-  map_delete(inherit_deps, prog);
+private void restore_state(object ob, mixed state) {
+  if (function_exists("hot_reload_restore", ob)) {
+    ob->hot_reload_restore(state);
+  }
 }
 
+// --- reload ----------------------------------------------------------------
+
 private void reload(string prog) {
-  // A changed ancestor's master copy must go away first: recompiling prog
-  // finds already-loaded parent programs by name, so a stale parent
-  // would be inherited as-is.
+  mixed state;
+  int have_state = 0;
+  object ob = find_object(prog);
+  // recompile_object() swaps the fresh program into the LIVE master copy and
+  // every clone (state rides along inside the driver, private variables
+  // included) -- the default for state-keeping watches. The
+  // destruct+load path remains for the opt-out mode and for objects
+  // that take control through the cooperative pair.
+  int cooperative = ob && function_exists("hot_reload_state", ob);
+  int use_recompile_object = ob && watched[prog] == WATCH_KEEP_STATE && !cooperative;
+
+  // Changed ancestors first: a recompile of prog finds already-loaded
+  // parent programs by name, so a stale parent would be inherited
+  // as-is. A loaded ancestor is hot-updated in place (its own clones
+  // and state ride along); an unloaded one just loses its records and
+  // reloads fresh during prog's recompile.
   foreach (string a in ancestors(prog, ([]))) {
-    if (self_changed(a)) forget(a);
+    if (self_changed(a)) {
+      object aob = find_object(a);
+      map_delete(file_deps, a);
+      map_delete(inherit_deps, a);
+      if (aob) recompile_object(aob);
+    }
   }
-  forget(prog);
-  load_object(prog);  // recompiles; the applies rebuild the dep records
+
+  map_delete(file_deps, prog);
+  map_delete(inherit_deps, prog);
+  if (use_recompile_object) {
+    recompile_object(ob);  // recompiles; the applies rebuild the dep records
+  } else {
+    if (cooperative && watched[prog] == WATCH_KEEP_STATE) {
+      state = capture_state(ob);
+      have_state = 1;
+    }
+    if (ob) destruct(ob);
+    ob = load_object(prog);
+    if (have_state) restore_state(ob, state);
+  }
   reload_count++;
   snapshot_program(prog);
 }
@@ -195,10 +242,12 @@ private void reload(string prog) {
 // --- public interface -------------------------------------------------------
 
 // Track a program (and everything its compile touches) for hot reload.
-public int watch(string prog) {
+// keep_state (default on) carries the master copy's global variables
+// across reloads; pass 0 to let each reload start from initializers.
+public int watch(string prog, int keep_state: (: 1 :)) {
   prog = program_of(prog);
   if (!find_object(prog)) load_object(prog);
-  watched[prog] = 1;
+  watched[prog] = keep_state ? WATCH_KEEP_STATE : WATCH_PLAIN;
   snapshot_program(prog);
   return 1;
 }

--- a/testsuite/single/hot_reload.lpc
+++ b/testsuite/single/hot_reload.lpc
@@ -113,7 +113,10 @@ private mapping closure_files(string prog, mapping seen) {
   return out;
 }
 
-// All programs in prog's inherit closure, excluding prog itself.
+// All programs in prog's inherit closure, excluding prog itself,
+// DEEPEST FIRST: a recompile snapshots the parent programs it links
+// against, so a changed grandparent must be fresh before a changed
+// parent recompiles, or the parent would bake the stale grandparent in.
 private string *ancestors(string prog, mapping seen) {
   string *out = ({ });
 
@@ -121,7 +124,7 @@ private string *ancestors(string prog, mapping seen) {
   foreach (string parent in keys(inherit_deps[prog])) {
     if (seen[parent]) continue;
     seen[parent] = 1;
-    out += ({ parent }) + ancestors(parent, seen);
+    out += ancestors(parent, seen) + ({ parent });
   }
   return out;
 }
@@ -196,6 +199,26 @@ private void restore_state(object ob, mixed state) {
 
 // --- reload ----------------------------------------------------------------
 
+// Drop a program's dep records ahead of a recompile (the applies
+// rebuild them during it) -- but restore them if the recompile throws
+// BEFORE compiling (currently-executing guard, unreadable file): the
+// object stays loaded on that path, so lost records would blind
+// closure_changed() to include-file changes forever.
+private void recompile_with_records(object ob, string prog) {
+  mapping fd = file_deps[prog];
+  mapping id = inherit_deps[prog];
+  string err;
+
+  map_delete(file_deps, prog);
+  map_delete(inherit_deps, prog);
+  err = catch(recompile_object(ob));
+  if (err) {
+    if (fd && !file_deps[prog]) file_deps[prog] = fd;
+    if (id && !inherit_deps[prog]) inherit_deps[prog] = id;
+    error(err);
+  }
+}
+
 private void reload(string prog) {
   mixed state;
   int have_state = 0;
@@ -216,17 +239,20 @@ private void reload(string prog) {
   foreach (string a in ancestors(prog, ([]))) {
     if (self_changed(a)) {
       object aob = find_object(a);
-      map_delete(file_deps, a);
-      map_delete(inherit_deps, a);
-      if (aob) recompile_object(aob);
+      if (aob) {
+        recompile_with_records(aob, a);
+      } else {
+        map_delete(file_deps, a);
+        map_delete(inherit_deps, a);
+      }
     }
   }
 
-  map_delete(file_deps, prog);
-  map_delete(inherit_deps, prog);
   if (use_recompile_object) {
-    recompile_object(ob);  // recompiles; the applies rebuild the dep records
+    recompile_with_records(ob, prog);  // the applies rebuild the dep records
   } else {
+    map_delete(file_deps, prog);
+    map_delete(inherit_deps, prog);
     if (cooperative && watched[prog] == WATCH_KEEP_STATE) {
       state = capture_state(ob);
       have_state = 1;

--- a/testsuite/single/master.lpc
+++ b/testsuite/single/master.lpc
@@ -130,6 +130,12 @@ mixed compile_object(string file)
     if (file=="/test/virtual") {
         return load_object("/single/void");
     }
+    // Virtual-object fixture for the recompile_object test: any
+    // /data/hu/virt* name materializes from the runtime-written
+    // /data/hu/vbase source.
+    if (file[0..12] == "/data/hu/virt" && file_size("/data/hu/vbase.lpc") > 0) {
+        return load_object("/data/hu/vbase");
+    }
     return 0;
 }
 

--- a/testsuite/single/tests/applies/hot_reload.lpc
+++ b/testsuite/single/tests/applies/hot_reload.lpc
@@ -22,7 +22,9 @@ private void write_src(string file, string body) {
 
 private void cleanup(object d) {
   foreach (string prog in ({ DIR + "/widget", DIR + "/base", DIR + "/counter",
-                             DIR + "/coop", DIR + "/plain", DIR + "/gadget" })) {
+                             DIR + "/coop", DIR + "/plain", DIR + "/gadget",
+                             DIR + "/kid", DIR + "/mid", DIR + "/grand",
+                             DIR + "/loop" })) {
     foreach (object o in children(prog)) {
       if (o) destruct(o);
     }
@@ -33,7 +35,8 @@ private void cleanup(object d) {
   }
   foreach (string f in ({ "/color.h", "/base.lpc", "/widget.lpc",
                           "/counter.lpc", "/coop.lpc", "/plain.lpc",
-                          "/gadget.lpc" })) {
+                          "/gadget.lpc", "/kid.lpc", "/mid.lpc",
+                          "/grand.lpc", "/loop.h", "/loop.lpc" })) {
     rm(DIR + f);
   }
   rmdir(DIR);
@@ -112,6 +115,41 @@ private void run_checks() {
   ASSERT_EQ(2, d->check_now());
   ASSERT_EQ("fixed blue", (DIR + "/base")->color());
   ASSERT_EQ("one very fixed blue widget", (DIR + "/widget")->describe());
+
+  // A chain with SEVERAL changed ancestors must refresh deepest-first:
+  // recompiling the middle parent bakes in whatever grandparent program
+  // is live at that moment, so the grandparent has to go first.
+  write_src(DIR + "/grand.lpc", "string g() { return \"g1\"; }\n");
+  write_src(DIR + "/mid.lpc",
+            "inherit \"" + DIR + "/grand\";\n" +
+            "string m() { return \"m1/\" + g(); }\n");
+  write_src(DIR + "/kid.lpc",
+            "inherit \"" + DIR + "/mid\";\n" +
+            "string k() { return m(); }\n");
+  ASSERT(d->watch(DIR + "/kid"));
+  ASSERT_EQ("m1/g1", (DIR + "/kid")->k());
+  write_src(DIR + "/grand.lpc", "string g() { return \"g2 new\"; }\n");
+  write_src(DIR + "/mid.lpc",
+            "inherit \"" + DIR + "/grand\";\n" +
+            "string m() { return \"m2 longer/\" + g(); }\n");
+  ASSERT_EQ(1, d->check_now());
+  ASSERT_EQ("m2 longer/g2 new", (DIR + "/kid")->k());
+
+  // Dependency records survive a reload that throws BEFORE compiling
+  // (here: the currently-executing guard, because the watched object
+  // itself drives the pass) -- the include edit must still be seen on
+  // the next idle pass.
+  write_src(DIR + "/loop.h", "#define LOOPV \"one\"\n");
+  write_src(DIR + "/loop.lpc",
+            "#include \"" + DIR + "/loop.h\"\n" +
+            "string v() { return LOOPV; }\n" +
+            "int poke(object dmn) { return dmn->check_now(); }\n");
+  ASSERT(d->watch(DIR + "/loop"));
+  ASSERT_EQ("one", (DIR + "/loop")->v());
+  write_src(DIR + "/loop.h", "#define LOOPV \"two three\"\n");
+  ASSERT_EQ(0, (DIR + "/loop")->poke(d));
+  ASSERT_EQ(1, d->check_now());
+  ASSERT_EQ("two three", (DIR + "/loop")->v());
 
   // --- variable state across reloads ---------------------------------------
 

--- a/testsuite/single/tests/applies/hot_reload.lpc
+++ b/testsuite/single/tests/applies/hot_reload.lpc
@@ -21,21 +21,26 @@ private void write_src(string file, string body) {
 }
 
 private void cleanup(object d) {
-  foreach (string prog in ({ DIR + "/widget", DIR + "/base" })) {
-    if (find_object(prog)) destruct(find_object(prog));
+  foreach (string prog in ({ DIR + "/widget", DIR + "/base", DIR + "/counter",
+                             DIR + "/coop", DIR + "/plain", DIR + "/gadget" })) {
+    foreach (object o in children(prog)) {
+      if (o) destruct(o);
+    }
   }
   if (d) {
     d->disable();
     destruct(d);
   }
-  foreach (string f in ({ "/color.h", "/base.lpc", "/widget.lpc" })) {
+  foreach (string f in ({ "/color.h", "/base.lpc", "/widget.lpc",
+                          "/counter.lpc", "/coop.lpc", "/plain.lpc",
+                          "/gadget.lpc" })) {
     rm(DIR + f);
   }
   rmdir(DIR);
 }
 
 private void run_checks() {
-  object d, widget;
+  object d, widget, ob, g1, g2, p1;
 
   ASSERT(mkdir(DIR) || file_size(DIR) == -2);
 
@@ -107,6 +112,133 @@ private void run_checks() {
   ASSERT_EQ(2, d->check_now());
   ASSERT_EQ("fixed blue", (DIR + "/base")->color());
   ASSERT_EQ("one very fixed blue widget", (DIR + "/widget")->describe());
+
+  // --- variable state across reloads ---------------------------------------
+
+  // The code is replaced, the variables are not: watch() carries the
+  // master copy's globals over by default. New variables ("extra")
+  // keep the fresh compile's initializers.
+  write_src(DIR + "/counter.lpc",
+            "int hits;\n" +
+            "int bump() { return ++hits; }\n" +
+            "string version() { return \"v1\"; }\n");
+  ASSERT(d->watch(DIR + "/counter"));
+  ob = find_object(DIR + "/counter");
+  ob->bump();
+  ob->bump();
+  ASSERT_EQ(3, ob->bump());
+  write_src(DIR + "/counter.lpc",
+            "int hits;\n" +
+            "int extra = 11;\n" +
+            "int bump() { return ++hits; }\n" +
+            "int query_extra() { return extra; }\n" +
+            "string version() { return \"v2\"; }\n");
+  ASSERT_EQ(1, d->check_now());
+  ob = find_object(DIR + "/counter");
+  ASSERT(objectp(ob));
+  ASSERT_EQ("v2", ob->version());
+  ASSERT_EQ(4, ob->bump());
+  ASSERT_EQ(11, ob->query_extra());
+
+  // --- clones ride along ------------------------------------------------
+
+  // A master copy change must reach every live clone. On the default
+  // (state-keeping) path the daemon reloads through the recompile_object()
+  // efun, which swaps the fresh program into the master copy AND every
+  // clone in place: same objects, new code, each clone's own state
+  // kept. children() is how a mudlib FINDS all live instances.
+  write_src(DIR + "/gadget.lpc",
+            "int uses;\n" +
+            "int use() { return ++uses; }\n" +
+            "string label() { return \"mk1\"; }\n");
+  ASSERT(d->watch(DIR + "/gadget"));
+  ob = find_object(DIR + "/gadget");
+  g1 = new(DIR + "/gadget");
+  g2 = new(DIR + "/gadget");
+  g1->use();
+  g2->use();
+  g2->use();
+
+  // Finding them: master copy + clones share the program name.
+  ASSERT_EQ(3, sizeof(children(DIR + "/gadget")));
+  ASSERT_EQ(2, sizeof(filter(children(DIR + "/gadget"), (: clonep($1) :))));
+
+  write_src(DIR + "/gadget.lpc",
+            "int uses;\n" +
+            "int use() { return ++uses; }\n" +
+            "string label() { return \"mk2 improved\"; }\n");
+  ASSERT_EQ(1, d->check_now());
+
+  // Same objects everywhere -- nothing was destructed...
+  ASSERT(find_object(DIR + "/gadget") == ob);
+  ASSERT(objectp(g1) && objectp(g2));
+  // ... running the new code ...
+  ASSERT_EQ("mk2 improved", ob->label());
+  ASSERT_EQ("mk2 improved", g1->label());
+  ASSERT_EQ("mk2 improved", g2->label());
+  // ... with each object's own state carried over.
+  ASSERT_EQ(1, ob->use());
+  ASSERT_EQ(2, g1->use());
+  ASSERT_EQ(3, g2->use());
+
+  // An object that defines the cooperative pair
+  // hot_reload_state()/hot_reload_restore() takes control of exactly
+  // what survives: it reloads through destruct+load and gets back only
+  // the state its pair chose to carry.
+  write_src(DIR + "/coop.lpc",
+            "private int secret = 5;\n" +
+            "int peek() { return secret; }\n" +
+            "void poke(int v) { secret = v; }\n" +
+            "string tag() { return \"first\"; }\n" +
+            "mixed hot_reload_state() { return secret; }\n" +
+            "void hot_reload_restore(mixed s) { secret = s; }\n");
+  ASSERT(d->watch(DIR + "/coop"));
+  ob = find_object(DIR + "/coop");
+  ob->poke(42);
+  write_src(DIR + "/coop.lpc",
+            "private int secret = 5;\n" +
+            "int peek() { return secret; }\n" +
+            "void poke(int v) { secret = v; }\n" +
+            "string tag() { return \"second one\"; }\n" +
+            "mixed hot_reload_state() { return secret; }\n" +
+            "void hot_reload_restore(mixed s) { secret = s; }\n");
+  ASSERT_EQ(1, d->check_now());
+  ob = find_object(DIR + "/coop");
+  ASSERT_EQ("second one", ob->tag());
+  ASSERT_EQ(42, ob->peek());
+
+  // Opt-out: watch(prog, 0) lets each reload start from initializers.
+  // This path destructs and reloads the master copy, so it CANNOT
+  // touch clones: they keep the old program until re-created.
+  write_src(DIR + "/plain.lpc",
+            "int n = 9;\n" +
+            "int get() { return n; }\n" +
+            "int set(int v) { return n = v; }\n" +
+            "string tag() { return \"aaa\"; }\n");
+  ASSERT(d->watch(DIR + "/plain", 0));
+  ob = find_object(DIR + "/plain");
+  ob->set(100);
+  p1 = new(DIR + "/plain");
+  p1->set(55);
+  write_src(DIR + "/plain.lpc",
+            "int n = 9;\n" +
+            "int get() { return n; }\n" +
+            "int set(int v) { return n = v; }\n" +
+            "string tag() { return \"b\"; }\n");
+  ASSERT_EQ(1, d->check_now());
+  ob = find_object(DIR + "/plain");
+  ASSERT_EQ("b", ob->tag());
+  ASSERT_EQ(9, ob->get());
+  // The pre-existing clone still runs the OLD program with its old
+  // state -- children() is how a mudlib finds such stragglers to
+  // destruct and re-create (or to pass to recompile_object-style handling).
+  ASSERT_EQ("aaa", p1->tag());
+  ASSERT_EQ(55, p1->get());
+  foreach (object straggler in filter(children(DIR + "/plain"), (: clonep($1) :))) {
+    destruct(straggler);
+  }
+  ASSERT(!objectp(p1));
+  ASSERT_EQ(1, sizeof(children(DIR + "/plain")));
 
   d->disable();
   ASSERT(!d->query_polling());

--- a/testsuite/single/tests/efuns/recompile_object.lpc
+++ b/testsuite/single/tests/efuns/recompile_object.lpc
@@ -1,0 +1,150 @@
+// recompile_object(object master_copy)
+//
+// Recompiles the master copy's program from its source file and swaps
+// the fresh program into the live master copy AND every clone sharing
+// it -- no destruct, same object identity everywhere. Global variables
+// carry over BY NAME per object (including private ones: the transfer
+// happens inside the driver): the new program's initializers run
+// first, then every surviving name gets its old value back. Returns
+// the number of objects updated.
+//
+// Function pointers created against the old program layout error
+// cleanly ("stale") instead of running mis-indexed code.
+
+#define DIR "/data/hu"
+#define THING DIR + "/thing"
+
+private void write_src(string body) {
+  ASSERT2(write_file(THING + ".lpc", body, 1), "write " + THING);
+}
+
+private void cleanup() {
+  foreach (object o in children(THING)) {
+    if (o) destruct(o);
+  }
+  rm(THING + ".lpc");
+  rmdir(DIR);
+}
+
+private void run_checks() {
+  object ob, c1, c2;
+  function fp;
+  string err;
+  int n;
+
+  ASSERT(mkdir(DIR) || file_size(DIR) == -2);
+
+  write_src(
+      "int count;\n" +
+      "private int secret = 3;\n" +
+      "int gone = 1;\n" +
+      "int bump() { return ++count; }\n" +
+      "int peek() { return secret; }\n" +
+      "void poke(int v) { secret = v; }\n" +
+      "string version() { return \"v1\"; }\n");
+
+  ob = load_object(THING);
+  c1 = new(THING);
+  c2 = new(THING);
+
+  // Distinct per-object state.
+  ob->bump();                          // master: count 1
+  c1->bump(); c1->bump();              // c1: count 2
+  c2->bump(); c2->bump(); c2->bump();  // c2: count 3
+  ob->poke(10); c1->poke(11); c2->poke(12);
+
+  // v2: new code, a new variable with an initializer, one variable
+  // removed, count/secret kept.
+  write_src(
+      "int count;\n" +
+      "private int secret = 3;\n" +
+      "int extra = 7;\n" +
+      "int bump() { return ++count; }\n" +
+      "int peek() { return secret; }\n" +
+      "void poke(int v) { secret = v; }\n" +
+      "int query_extra() { return extra; }\n" +
+      "function get_bump_fp() { return (: bump :); }\n" +
+      "void arm() { call_out(\"tick\", 100); }\n" +
+      "void disarm() { remove_call_out(\"tick\"); }\n" +
+      "int armed() { return find_call_out(\"tick\") != -1; }\n" +
+      "void tick() { }\n" +
+      "string version() { return \"v2\"; }\n");
+
+  // The master copy AND both clones update in one call.
+  n = recompile_object(ob);
+  ASSERT_EQ(3, n);
+
+  // Identity preserved: no destruct anywhere.
+  ASSERT(find_object(THING) == ob);
+  ASSERT(objectp(c1) && objectp(c2));
+
+  // Everyone runs the new code...
+  ASSERT_EQ("v2", ob->version());
+  ASSERT_EQ("v2", c1->version());
+  ASSERT_EQ("v2", c2->version());
+
+  // ... with each object's own state carried over (count continues),
+  ASSERT_EQ(2, ob->bump());
+  ASSERT_EQ(3, c1->bump());
+  ASSERT_EQ(4, c2->bump());
+
+  // ... private variables included (the transfer is driver-side),
+  ASSERT_EQ(10, ob->peek());
+  ASSERT_EQ(11, c1->peek());
+  ASSERT_EQ(12, c2->peek());
+
+  // ... new variables get their fresh initializers,
+  ASSERT_EQ(7, ob->query_extra());
+  ASSERT_EQ(7, c1->query_extra());
+
+  // ... and removed variables are gone.
+  ASSERT(stringp(catch(fetch_variable("gone", ob))));
+
+  // Only the master copy may be passed.
+  ASSERT(stringp(catch(recompile_object(c1))));
+
+  // A function pointer from v2, and an armed call_out.
+  fp = ob->get_bump_fp();
+  ASSERT_EQ(3, evaluate(fp));  // works before the next update
+  ob->arm();
+
+  // v3: another swap on top.
+  write_src(
+      "int count;\n" +
+      "private int secret = 3;\n" +
+      "int extra = 7;\n" +
+      "int bump() { return ++count; }\n" +
+      "int peek() { return secret; }\n" +
+      "int query_extra() { return extra; }\n" +
+      "void disarm() { remove_call_out(\"tick\"); }\n" +
+      "int armed() { return find_call_out(\"tick\") != -1; }\n" +
+      "void tick() { }\n" +
+      "int self_update() { return recompile_object(this_object()); }\n" +
+      "string version() { return \"v3\"; }\n");
+  ASSERT_EQ(3, recompile_object(ob));
+  ASSERT_EQ("v3", ob->version());
+  ASSERT_EQ(4, ob->bump());  // state still riding along
+
+  // The call_out survived the swap (call_outs reference functions by
+  // name); the v2 function pointer is now stale and fails cleanly.
+  ASSERT_EQ(1, ob->armed());
+  err = catch(evaluate(fp));
+  ASSERT2(stringp(err) && strsrch(err, "was recompiled") != -1, "stale fp: " + err);
+  ob->disarm();
+
+  // An object cannot recompile itself mid-execution.
+  err = catch(ob->self_update());
+  ASSERT2(stringp(err) && strsrch(err, "currently executing") != -1, "self: " + err);
+
+  // A vanished source file is a clean error; the object is untouched.
+  rm(THING + ".lpc");
+  ASSERT(stringp(catch(recompile_object(ob))));
+  ASSERT_EQ("v3", ob->version());
+}
+
+void do_tests() {
+  string err = catch(run_checks());
+
+  cleanup();
+  if (err) error(err);
+}

--- a/testsuite/single/tests/efuns/recompile_object.lpc
+++ b/testsuite/single/tests/efuns/recompile_object.lpc
@@ -18,11 +18,18 @@ private void write_src(string body) {
   ASSERT2(write_file(THING + ".lpc", body, 1), "write " + THING);
 }
 
+private void write_src2(string file, string body) {
+  ASSERT2(write_file(file, body, 1), "write " + file);
+}
+
 private void cleanup() {
-  foreach (object o in children(THING)) {
-    if (o) destruct(o);
+  foreach (string prog in ({ THING, DIR + "/seppuku" })) {
+    foreach (object o in children(prog)) {
+      if (o) destruct(o);
+    }
   }
   rm(THING + ".lpc");
+  rm(DIR + "/seppuku.lpc");
   rmdir(DIR);
 }
 
@@ -140,6 +147,65 @@ private void run_checks() {
   rm(THING + ".lpc");
   ASSERT(stringp(catch(recompile_object(ob))));
   ASSERT_EQ("v3", ob->version());
+
+  // An object may destruct itself from its new program's __INIT while
+  // being updated: the swap survives, the caller's stack reference is
+  // swept cleanly, and destructed objects drop out of the updated
+  // count.
+  write_src2(DIR + "/seppuku.lpc",
+             "int x = 1;\n" +
+             "string version() { return \"s1\"; }\n");
+  ob = load_object(DIR + "/seppuku");
+  c1 = new(DIR + "/seppuku");
+  write_src2(DIR + "/seppuku.lpc",
+             "int x = 2;\n" +
+             "int boom = go();\n" +
+             "int go() { destruct(this_object()); return 0; }\n" +
+             "string version() { return \"s2\"; }\n");
+  ASSERT_EQ(0, recompile_object(ob));
+  ASSERT(!objectp(ob));
+  ASSERT(!objectp(c1));
+  ASSERT(!find_object(DIR + "/seppuku"));
+
+  // The simul_efun object can be recompiled live: the dispatch table
+  // rebuilds against the new program with name-stable indices before
+  // its __INIT runs, so simul calls compiled into every other program
+  // keep working -- including this test's own ASSERT machinery, which
+  // dispatches through it on the very next line.
+  ASSERT_EQ(1, recompile_object(find_object("/single/simul_efun")));
+  ASSERT_EQ(1, same(({ 1, 2 }), ({ 1, 2 })));  // a simul from that very file
+
+  // The master object is recompilable too (see the post-run check
+  // below), but never while it is executing -- and in this harness
+  // master::flag() sits on the call stack for the entire run.
+  err = catch(recompile_object(find_object("/single/master")));
+  ASSERT2(stringp(err) && strsrch(err, "currently executing") != -1, "master: " + err);
+
+  // Once the run is over the master is idle, so recompile it then; the
+  // rebuilt apply table and carried-over master state are enforced by
+  // exiting nonzero on any failure.
+  call_out("master_recompile_check", 0);
+}
+
+protected void master_recompile_check() {
+  string err = catch(recompile_object(find_object("/single/master")));
+
+  if (err) {
+    debug_message("POST-RUN master recompile failed: " + err);
+    shutdown(-1);
+    return;
+  }
+  // State carried over (the check counter kept counting all run) and
+  // the rebuilt apply table dispatches (valid_write runs on the new
+  // program for this write_file).
+  if (!"/single/master"->query_num_checks() ||
+      !write_file("/data/master_recheck.tmp", "x", 1)) {
+    debug_message("POST-RUN master recompile: state or applies broken\n");
+    shutdown(-1);
+    return;
+  }
+  rm("/data/master_recheck.tmp");
+  debug_message("POST-RUN master recompile OK");
 }
 
 void do_tests() {

--- a/testsuite/single/tests/efuns/recompile_object.lpc
+++ b/testsuite/single/tests/efuns/recompile_object.lpc
@@ -25,7 +25,7 @@ private void write_src2(string file, string body) {
 private void cleanup() {
   foreach (string prog in ({ THING, DIR + "/seppuku", DIR + "/rp_thing",
                              DIR + "/rp_parent", DIR + "/virt",
-                             DIR + "/vbase" })) {
+                             DIR + "/vbase", DIR + "/initbad" })) {
     foreach (object o in children(prog)) {
       if (o) destruct(o);
     }
@@ -35,6 +35,7 @@ private void cleanup() {
   rm(DIR + "/rp_thing.lpc");
   rm(DIR + "/rp_parent.lpc");
   rm(DIR + "/vbase.lpc");
+  rm(DIR + "/initbad.lpc");
   rmdir(DIR);
 }
 
@@ -224,6 +225,31 @@ private void run_checks() {
   ASSERT(!objectp(ob));
   ASSERT(!objectp(c1));
   ASSERT(!find_object(DIR + "/seppuku"));
+
+  // An error thrown from the new program's __INIT during the update
+  // must not corrupt refs or abort sibling targets: the erroring object
+  // is left committed to the new program (state dropped, like a create()
+  // that throws during load), a sibling clone still updates, and no
+  // ref/variable-block leak (the debug-build memory checker after this
+  // file is the detector).
+  write_src2(DIR + "/initbad.lpc",
+             "int n = 1;\n" +
+             "int set_n(int v) { return n = v; }\n" +
+             "string version() { return \"ib1\"; }\n");
+  ob = load_object(DIR + "/initbad");
+  c1 = new(DIR + "/initbad");
+  c1->set_n(7);
+  write_src2(DIR + "/initbad.lpc",
+             "int n = 1;\n" +
+             "int boom = go();\n" +
+             "int go() { error(\"init boom\\n\"); return 0; }\n" +
+             "int set_n(int v) { return n = v; }\n" +
+             "string version() { return \"ib2\"; }\n");
+  // Both blueprint and clone update; each __INIT errors but is caught.
+  ASSERT_EQ(0, recompile_object(ob));
+  ASSERT(objectp(ob) && objectp(c1));      // neither leaked/immortalized
+  ASSERT_EQ("ib2", ob->version());         // committed to the new program
+  ASSERT_EQ(1, ob->set_n(1));              // usable; state reset to init
 
   // The simul_efun object can be recompiled live: the dispatch table
   // rebuilds against the new program with name-stable indices before

--- a/testsuite/single/tests/efuns/recompile_object.lpc
+++ b/testsuite/single/tests/efuns/recompile_object.lpc
@@ -23,13 +23,18 @@ private void write_src2(string file, string body) {
 }
 
 private void cleanup() {
-  foreach (string prog in ({ THING, DIR + "/seppuku" })) {
+  foreach (string prog in ({ THING, DIR + "/seppuku", DIR + "/rp_thing",
+                             DIR + "/rp_parent", DIR + "/virt",
+                             DIR + "/vbase" })) {
     foreach (object o in children(prog)) {
       if (o) destruct(o);
     }
   }
   rm(THING + ".lpc");
   rm(DIR + "/seppuku.lpc");
+  rm(DIR + "/rp_thing.lpc");
+  rm(DIR + "/rp_parent.lpc");
+  rm(DIR + "/vbase.lpc");
   rmdir(DIR);
 }
 
@@ -147,6 +152,59 @@ private void run_checks() {
   rm(THING + ".lpc");
   ASSERT(stringp(catch(recompile_object(ob))));
   ASSERT_EQ("v3", ob->version());
+
+  // Virtual objects update too: the object wears a virtual name
+  // (master::compile_object materialized it), but its program IS the
+  // backing file's program -- recompile_object() recompiles that
+  // backing source and swaps it in, keeping the virtual identity,
+  // name, flag and state.
+  write_src2(DIR + "/vbase.lpc",
+             "int n;\n" +
+             "int bump() { return ++n; }\n" +
+             "string vv() { return \"vb1\"; }\n");
+  ob = load_object(DIR + "/virt");  // via master::compile_object
+  ASSERT(objectp(ob));
+  ASSERT(virtualp(ob));
+  ASSERT_EQ(DIR + "/virt", file_name(ob));
+  ob->bump();
+  ASSERT_EQ(2, ob->bump());
+  write_src2(DIR + "/vbase.lpc",
+             "int n;\n" +
+             "int bump() { return ++n; }\n" +
+             "string vv() { return \"vb2 bigger\"; }\n");
+  ASSERT(recompile_object(ob) >= 1);
+  ASSERT(ob == find_object(DIR + "/virt"));
+  ASSERT(virtualp(ob));
+  ASSERT_EQ("vb2 bigger", ob->vv());
+  ASSERT_EQ(3, ob->bump());
+
+  // A replace_program() registered DURING the update -- old code on a
+  // not-yet-swapped clone, driven from the first target's __INIT -- was
+  // computed against the program being replaced; the swap voids it, or
+  // the backend sweep would later corrupt the fresh variable block.
+  // The rest of this suite run doubles as the sweep detector.
+  write_src2(DIR + "/rp_parent.lpc",
+             "int p1;\nint p2;\nint p3;\n" +
+             "int get_p3() { return p3; }\n");
+  write_src2(DIR + "/rp_thing.lpc",
+             "inherit \"" + DIR + "/rp_parent\";\n" +
+             "int a1;\n" +
+             "void do_rp() { replace_program(\"" + DIR + "/rp_parent\"); }\n" +
+             "string version() { return \"rp1\"; }\n");
+  ob = load_object(DIR + "/rp_thing");
+  c1 = new(DIR + "/rp_thing");
+  write_src2(DIR + "/rp_thing.lpc",
+             "int x = 1;\n" +
+             "int kicked = kick();\n" +
+             "int kick() {\n" +
+             "  foreach (object o in children(\"" + DIR + "/rp_thing\"))\n" +
+             "    if (o != this_object()) catch(o->do_rp());\n" +
+             "  return 1;\n" +
+             "}\n" +
+             "string version() { return \"rp2\"; }\n");
+  ASSERT_EQ(2, recompile_object(ob));
+  ASSERT_EQ("rp2", ob->version());
+  ASSERT_EQ("rp2", c1->version());
 
   // An object may destruct itself from its new program's __INIT while
   // being updated: the swap survives, the caller's stack reference is

--- a/testsuite/single/tests/efuns/recompile_object2.lpc
+++ b/testsuite/single/tests/efuns/recompile_object2.lpc
@@ -4,12 +4,15 @@
 // so they must survive the swap and route into the new code.
 
 #define DIR "/data/hu3"
+#define MARK "/data/hu3_mark"
 
 private void write_src(string file, string body) {
   ASSERT2(write_file(file, body, 1), "write " + file);
 }
 
 private void cleanup() {
+  // NOTE: the /data/hu3/co object deliberately survives -- its pending
+  // call_outs must fire after the run (see verify_callouts).
   foreach (string prog in ({ DIR + "/ct", DIR + "/sh_target", DIR + "/sh_shadow",
                              DIR + "/act" })) {
     foreach (object o in children(prog)) {
@@ -20,7 +23,9 @@ private void cleanup() {
                           "/act.lpc" })) {
     rm(DIR + f);
   }
-  rmdir(DIR);
+  // co.lpc and DIR are removed by verify_callouts, which fires after
+  // the co object's pending call_outs (the object is kept alive
+  // until then).
 }
 
 private void run_checks() {
@@ -73,6 +78,29 @@ private void run_checks() {
   destruct(sh);
   ASSERT_EQ("t2", ob->who());
 
+  // --- call_outs armed BEFORE the swap fire AFTER it: the name-based
+  // one must run the NEW program's code; the funptr-based one is stale
+  // and must fail with the clean staleness error, not corrupt anything.
+  // Both fire post-run (this suite executes synchronously), so a
+  // deferred verifier enforces the outcome by exiting nonzero.
+  rm(MARK);
+  rm(MARK + "_fp");
+  write_src(DIR + "/co.lpc",
+            "void fpmark() { write_file(\"" + MARK + "_fp\", \"x\", 1); }\n" +
+            "void late_tick() { write_file(\"" + MARK + "\", \"v1 ran\", 1); }\n" +
+            "void arm() { call_out(\"late_tick\", 0); call_out((: fpmark :), 0); }\n" +
+            "int pending() { return find_call_out(\"late_tick\"); }\n");
+  ob = load_object(DIR + "/co");
+  ob->arm();
+  write_src(DIR + "/co.lpc",
+            "void fpmark() { write_file(\"" + MARK + "_fp\", \"x\", 1); }\n" +
+            "void late_tick() { write_file(\"" + MARK + "\", \"v2 code ran\", 1); }\n" +
+            "void arm() { call_out(\"late_tick\", 0); call_out((: fpmark :), 0); }\n" +
+            "int pending() { return find_call_out(\"late_tick\"); }\n");
+  ASSERT_EQ(1, recompile_object(ob));
+  ASSERT(ob->pending() >= 0);  // still scheduled after the swap
+  call_out("verify_callouts", 1);
+
 #ifndef __NO_ADD_ACTION__
   // --- add_action sentences (registered by v1 code) and heart_beat
   // survive; the verb dispatches by name into the NEW program.
@@ -104,6 +132,36 @@ private void run_checks() {
   ASSERT(ob->try());                           // v1's sentence still fires...
   ASSERT_EQ(11, ob->q());                      // ... into v2 code, state kept
 #endif
+}
+
+// Fires one backend second after the run: the 0-delay call_outs armed
+// before the recompile have executed by now.
+protected void verify_callouts() {
+  string mark = read_file(MARK);
+
+  // The name-based call_out must have dispatched into the NEW program.
+  if (!mark || strsrch(mark, "v2 code ran") == -1) {
+    debug_message("POST-RUN callout check: name call_out did not run v2 code: " +
+                  sprintf("%O", mark));
+    shutdown(-1);
+    return;
+  }
+  // The funptr call_out was made against the OLD program layout, so it
+  // is stale: it must fail cleanly (safe_call_function_pointer catches
+  // it) and its target must NOT have run -- no crash, no mis-indexed
+  // execution.
+  if (file_size(MARK + "_fp") != -1) {
+    debug_message("POST-RUN callout check: stale funptr call_out RAN (should have been refused)");
+    shutdown(-1);
+    return;
+  }
+  rm(MARK);
+  // The co object was kept alive across the run so its call_outs could
+  // fire; clean it up now.
+  if (find_object(DIR + "/co")) destruct(find_object(DIR + "/co"));
+  rm(DIR + "/co.lpc");
+  rmdir(DIR);
+  debug_message("POST-RUN callout checks OK");
 }
 
 void do_tests() {

--- a/testsuite/single/tests/efuns/recompile_object2.lpc
+++ b/testsuite/single/tests/efuns/recompile_object2.lpc
@@ -1,0 +1,114 @@
+// recompile_object() interaction with object-attached runtime state:
+// shadow chains, catch_tell routing, add_action sentences and the
+// heart_beat registration all dispatch BY NAME against the live object,
+// so they must survive the swap and route into the new code.
+
+#define DIR "/data/hu3"
+
+private void write_src(string file, string body) {
+  ASSERT2(write_file(file, body, 1), "write " + file);
+}
+
+private void cleanup() {
+  foreach (string prog in ({ DIR + "/ct", DIR + "/sh_target", DIR + "/sh_shadow",
+                             DIR + "/act" })) {
+    foreach (object o in children(prog)) {
+      if (o) destruct(o);
+    }
+  }
+  foreach (string f in ({ "/ct.lpc", "/sh_target.lpc", "/sh_shadow.lpc",
+                          "/act.lpc" })) {
+    rm(DIR + f);
+  }
+  rmdir(DIR);
+}
+
+private void run_checks() {
+  object ob, sh, tp;
+
+  ASSERT(mkdir(DIR) || file_size(DIR) == -2);
+
+  // --- catch_tell: routed by name, state accumulates across the swap.
+  write_src(DIR + "/ct.lpc",
+            "string *msgs = ({ });\n" +
+            "void catch_tell(string s) { msgs += ({ \"v1:\" + s }); }\n" +
+            "string *q() { return msgs; }\n");
+  ob = load_object(DIR + "/ct");
+  tell_object(ob, "hello");
+  write_src(DIR + "/ct.lpc",
+            "string *msgs = ({ });\n" +
+            "void catch_tell(string s) { msgs += ({ \"v2:\" + s }); }\n" +
+            "string *q() { return msgs; }\n");
+  ASSERT_EQ(1, recompile_object(ob));
+  tell_object(ob, "again");
+  ASSERT_EQ(({ "v1:hello", "v2:again" }), ob->q());
+
+  // --- shadows: the chain survives updating the SHADOWED object...
+  write_src(DIR + "/sh_target.lpc",
+            "string who() { return \"t1\"; }\n" +
+            "string info() { return \"i1\"; }\n");
+  write_src(DIR + "/sh_shadow.lpc",
+            "string who() { return \"shadowed\"; }\n" +
+            "int attach(object t) { return shadow(t, 1) != 0; }\n");
+  ob = load_object(DIR + "/sh_target");
+  sh = load_object(DIR + "/sh_shadow");
+  ASSERT(sh->attach(ob));
+  ASSERT_EQ("shadowed", ob->who());
+  ASSERT_EQ("i1", ob->info());
+  write_src(DIR + "/sh_target.lpc",
+            "string who() { return \"t2\"; }\n" +
+            "string info() { return \"i2 bigger\"; }\n");
+  ASSERT_EQ(1, recompile_object(ob));
+  ASSERT(query_shadowing(sh) == ob);           // chain intact
+  ASSERT_EQ("shadowed", ob->who());            // still intercepted
+  ASSERT_EQ("i2 bigger", ob->info());          // new code underneath
+
+  // ... and updating the SHADOW itself while attached.
+  write_src(DIR + "/sh_shadow.lpc",
+            "string who() { return \"shadowed v2\"; }\n" +
+            "int attach(object t) { return shadow(t, 1) != 0; }\n");
+  ASSERT_EQ(1, recompile_object(sh));
+  ASSERT(query_shadowing(sh) == ob);
+  ASSERT_EQ("shadowed v2", ob->who());
+  destruct(sh);
+  ASSERT_EQ("t2", ob->who());
+
+#ifndef __NO_ADD_ACTION__
+  // --- add_action sentences (registered by v1 code) and heart_beat
+  // survive; the verb dispatches by name into the NEW program.
+  write_src(DIR + "/act.lpc",
+            "int hits;\n" +
+            "void arm() { enable_commands(); add_action(\"do_x\", \"xyzzy\");\n" +
+            "             set_heart_beat(1); }\n" +
+            "int do_x(string s) { hits += 1; return 1; }\n" +
+            "int try() { return command(\"xyzzy\"); }\n" +
+            "int q() { return hits; }\n" +
+            "void heart_beat() { }\n");
+  ob = load_object(DIR + "/act");
+  SAVETP;
+  ob->arm();
+  RESTORETP;
+  ASSERT(ob->try());
+  ASSERT_EQ(1, ob->q());
+  ASSERT_EQ(1, query_heart_beat(ob));
+  write_src(DIR + "/act.lpc",
+            "int hits;\n" +
+            "void arm() { enable_commands(); add_action(\"do_x\", \"xyzzy\");\n" +
+            "             set_heart_beat(1); }\n" +
+            "int do_x(string s) { hits += 10; return 1; }\n" +
+            "int try() { return command(\"xyzzy\"); }\n" +
+            "int q() { return hits; }\n" +
+            "void heart_beat() { }\n");
+  ASSERT_EQ(1, recompile_object(ob));
+  ASSERT_EQ(1, query_heart_beat(ob));          // registration survived
+  ASSERT(ob->try());                           // v1's sentence still fires...
+  ASSERT_EQ(11, ob->q());                      // ... into v2 code, state kept
+#endif
+}
+
+void do_tests() {
+  string err = catch(run_checks());
+
+  cleanup();
+  if (err) error(err);
+}


### PR DESCRIPTION
## Summary

Builds on the compile-time master applies and hot-reload groundwork merged in #1230. This PR adds the `recompile_object()` efun and the daemon/test/doc integration around it.

## `recompile_object(object master_copy)` — in-place program update ("hot update")

Recompiles the master copy's program from its source file and swaps the fresh program into the **live master copy and every clone sharing it** — the alternative to destruct+`load_object()`: nothing is destructed, object identity is preserved everywhere (pointers held by other objects, inventory, shadows, interactive state, call_outs, heart_beat), and each object's global variables carry over **by name** inside the driver, private ones included (the new program's `__INIT` runs first, then surviving names get their old values; new variables keep initializers, vanished names drop). The recompile behaves like a normal load: unloaded parents resolve through the retry dance and the compile-time master applies are consulted. Returns the number of objects updated.

**Enabled by an object-layout change:** the variable block moves out of the `object_t` allocation into its own (`TAG_OBJ_VARS`, wired into the debug-malloc walkers), so a program with a different variable count can be swapped onto a live object.

**Coverage of special objects:**
- **Master and simul_efun objects are recompilable** — their cached name→runtime-index dispatch tables (`master_applies` / `simuls`) rebuild against the new program before its `__INIT` runs; simul indices are preserved by name (that table is deliberately unsorted for exactly this reason), so simul calls compiled into other programs keep working and a removed simul fails with the usual runtime error.
- **Virtual objects** update through their backing program: the virtual name, identity, flag and state stay.

**Safety:** refused while any live frame executes the program's code (including inheritors running inherited functions), for clones, pending `replace_program()`, and nested calls. Function pointers whose behavior depends on the owner's program layout (`FP_LOCAL`, `FP_FUNCTIONAL`) go stale instead of corrupting: objects carry a `prog_generation` stamp, funptrs snapshot it at creation/bind, and calls error cleanly on mismatch.

**Bugs found and fixed by the multi-agent self-review rounds** (each reproduced, fixed, and pinned by tests):
- `FP_LOCAL` `func_ref` accounting asymmetry (increment on creation-time program, decrement on the owner's current one) — local funptrs now store their program and account against it symmetrically.
- The efun glue crashed when a target destructed itself from its new `__INIT` (destruct sweeps the VM stack, leaving the arg slot a plain 0).
- A `replace_program()` registered *during* the update (old code on a not-yet-swapped clone) was computed against the program being replaced; the backend sweep then corrupted the fresh variable block — pending entries are now voided at each target's swap point.
- Hot-reload daemon: ancestors now refresh deepest-first (a middle parent bakes in whatever grandparent program is live), and dependency records survive a reload that throws before compiling.

## Daemon integration & clone story

The hot-reload daemon's default (state-keeping) path reloads through `recompile_object()` — changed ancestors first, then the watched program — so clones ride along automatically. A cooperative `hot_reload_state()`/`hot_reload_restore()` pair takes the destruct+load path with exactly the state it chooses; `watch(prog, 0)` opts out. The daemon test demonstrates finding all live instances with `children()`/`clonep()` and both clone behaviors.

## Testsuite

- `single/tests/efuns/recompile_object.lpc` — master+clones in one call, per-object state incl. private variables, initializers/removed variables, stale funptr errors, executing/clone/missing-source guards, call_out survival, self-destructing `__INIT`, mid-update `replace_program`, virtual objects, live simul_efun recompile, master guard while executing plus an enforced post-run master recompile (exits nonzero on failure)
- `single/tests/applies/hot_reload.lpc` — clone scenarios, all three state modes, ≥3-level ancestor chains, record preservation across refused reloads

## Validation

- Full LPC suite (544 files) green on RelWithDebInfo and Debug+ASan/UBSan (debug runs the driver memory checker after every test); `POST-RUN master recompile OK` in both
- 298 GTest unit tests green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018DGhzJfPhDGJA94EPh1gEK