### PR TITLE
lexer: a directive-line block comment may span physical lines (#1236)

### DIFF
--- a/docs/lpc/preprocessor/define.md
+++ b/docs/lpc/preprocessor/define.md
@@ -60,6 +60,20 @@ End a line with `\` to continue the definition:
 } while (0)
 ```
 
+A block comment opened on a directive line may also span lines — it
+reads as whitespace and does not end the directive, so both of these
+define `WARNING_LEVEL` as `1`:
+
+```c
+#define WARNING_LEVEL 1 /* change to a higher value to
+                           show more warnings */
+
+#define WARNING_LEVEL 1 // single-line form
+```
+
+Text after the comment's close on its final line still belongs to the
+directive, matching C.
+
 ## Redefinition
 
 Redefining a macro with a **different** body is allowed: the compiler

--- a/src/compiler/internal/lexer.autogen.cc
+++ b/src/compiler/internal/lexer.autogen.cc
@@ -3762,9 +3762,21 @@ case 64:
 YY_RULE_SETUP
 #line 574 "$REPO_ROOT$/src/compiler/internal/lexer.l"
 {
-    lpc_lex_consume_directive_newline(yyscanner);
-    LpcDirectiveAction act =
-        lpc_lex_on_directive(yytext, yyleng, yyscanner, YY_START == SC_COND_SKIP);
+    /* The capture stops at a physical newline, which a block comment
+     * opened on the line may legally span (#1236) -- complete the
+     * logical line first (policy in lexer_rules_pp.cc, reading through
+     * lpc_lex_getc()). When it pulled the tail, the terminating newline
+     * has already been consumed and counted. */
+    ScratchString completed;
+    int pulled_lines = 0;
+    bool extended =
+        lpc_lex_complete_directive(yytext, yyleng, yyscanner, &completed, &pulled_lines);
+    if (!extended) {
+        lpc_lex_consume_directive_newline(yyscanner);
+    }
+    LpcDirectiveAction act = lpc_lex_on_directive(
+        extended ? completed.c_str() : yytext, extended ? (int)completed.size() : yyleng,
+        yyscanner, YY_START == SC_COND_SKIP, pulled_lines);
     if (act == LpcDirectiveAction::kEnterSkip) {
         BEGIN(SC_COND_SKIP);
     } else if (act == LpcDirectiveAction::kExitSkip) {
@@ -3774,13 +3786,13 @@ YY_RULE_SETUP
 	YY_BREAK
 case 65:
 YY_RULE_SETUP
-#line 585 "$REPO_ROOT$/src/compiler/internal/lexer.l"
+#line 597 "$REPO_ROOT$/src/compiler/internal/lexer.l"
 { /* dead-branch text: never tokenized */ }
 	YY_BREAK
 case 66:
 /* rule 66 can match eol */
 YY_RULE_SETUP
-#line 586 "$REPO_ROOT$/src/compiler/internal/lexer.l"
+#line 598 "$REPO_ROOT$/src/compiler/internal/lexer.l"
 { lpc_lex_newline(yyscanner); }
 	YY_BREAK
 /* Heredoc "@"/"@@" prefix and terminator identifier: fully native, no
@@ -3791,7 +3803,7 @@ YY_RULE_SETUP
      * still detected even though that rule then never fires. */
 case 67:
 YY_RULE_SETUP
-#line 594 "$REPO_ROOT$/src/compiler/internal/lexer.l"
+#line 606 "$REPO_ROOT$/src/compiler/internal/lexer.l"
 {
           yyextra->heredoc_terminator.clear();
           yyextra->heredoc_is_array = (yyleng == 2);
@@ -3800,13 +3812,13 @@ YY_RULE_SETUP
 	YY_BREAK
 case 68:
 YY_RULE_SETUP
-#line 599 "$REPO_ROOT$/src/compiler/internal/lexer.l"
+#line 611 "$REPO_ROOT$/src/compiler/internal/lexer.l"
 { yyextra->heredoc_terminator.assign(yytext, yyleng); }
 	YY_BREAK
 case 69:
 /* rule 69 can match eol */
 YY_RULE_SETUP
-#line 600 "$REPO_ROOT$/src/compiler/internal/lexer.l"
+#line 612 "$REPO_ROOT$/src/compiler/internal/lexer.l"
 {
           /* parseHeredoc() reads the body through lpc_lex_getc() (Flex's
            * own stream), so no rewind/flush choreography is needed here
@@ -3831,11 +3843,11 @@ YY_RULE_SETUP
      * original does. */
 case 70:
 YY_RULE_SETUP
-#line 621 "$REPO_ROOT$/src/compiler/internal/lexer.l"
+#line 633 "$REPO_ROOT$/src/compiler/internal/lexer.l"
 { /* consumed; next scan decides via <<EOF>> or "." below */ }
 	YY_BREAK
 case YY_STATE_EOF(SC_HEREDOC_TERM):
-#line 622 "$REPO_ROOT$/src/compiler/internal/lexer.l"
+#line 634 "$REPO_ROOT$/src/compiler/internal/lexer.l"
 {
           if (!lpc_lex_pop_splice_if_any(yyscanner)) {
             // Matches the original: EOF anywhere before the trailing
@@ -3849,7 +3861,7 @@ case YY_STATE_EOF(SC_HEREDOC_TERM):
 	YY_BREAK
 case 71:
 YY_RULE_SETUP
-#line 632 "$REPO_ROOT$/src/compiler/internal/lexer.l"
+#line 644 "$REPO_ROOT$/src/compiler/internal/lexer.l"
 {
           // Non-whitespace, non-newline byte right after the terminator
           // name (or immediately after "@"/"@@"): the original leaves it
@@ -3863,177 +3875,177 @@ YY_RULE_SETUP
 	YY_BREAK
 case 72:
 YY_RULE_SETUP
-#line 643 "$REPO_ROOT$/src/compiler/internal/lexer.l"
+#line 655 "$REPO_ROOT$/src/compiler/internal/lexer.l"
 { yylval_param->number = '+'; return L_INC_DEC; }
 	YY_BREAK
 case 73:
 YY_RULE_SETUP
-#line 644 "$REPO_ROOT$/src/compiler/internal/lexer.l"
+#line 656 "$REPO_ROOT$/src/compiler/internal/lexer.l"
 { yylval_param->number = F_ADD_EQ; return L_ASSIGN; }
 	YY_BREAK
 case 74:
 YY_RULE_SETUP
-#line 645 "$REPO_ROOT$/src/compiler/internal/lexer.l"
+#line 657 "$REPO_ROOT$/src/compiler/internal/lexer.l"
 { return '+'; }
 	YY_BREAK
 case 75:
 YY_RULE_SETUP
-#line 646 "$REPO_ROOT$/src/compiler/internal/lexer.l"
+#line 658 "$REPO_ROOT$/src/compiler/internal/lexer.l"
 { return L_ARROW; }
 	YY_BREAK
 case 76:
 YY_RULE_SETUP
-#line 647 "$REPO_ROOT$/src/compiler/internal/lexer.l"
+#line 659 "$REPO_ROOT$/src/compiler/internal/lexer.l"
 { yylval_param->number = '-'; return L_INC_DEC; }
 	YY_BREAK
 case 77:
 YY_RULE_SETUP
-#line 648 "$REPO_ROOT$/src/compiler/internal/lexer.l"
+#line 660 "$REPO_ROOT$/src/compiler/internal/lexer.l"
 { yylval_param->number = F_SUB_EQ; return L_ASSIGN; }
 	YY_BREAK
 case 78:
 YY_RULE_SETUP
-#line 649 "$REPO_ROOT$/src/compiler/internal/lexer.l"
+#line 661 "$REPO_ROOT$/src/compiler/internal/lexer.l"
 { return '-'; }
 	YY_BREAK
 case 79:
 YY_RULE_SETUP
-#line 651 "$REPO_ROOT$/src/compiler/internal/lexer.l"
+#line 663 "$REPO_ROOT$/src/compiler/internal/lexer.l"
 { yylval_param->number = F_LAND_EQ; return L_ASSIGN; }
 	YY_BREAK
 case 80:
 YY_RULE_SETUP
-#line 652 "$REPO_ROOT$/src/compiler/internal/lexer.l"
+#line 664 "$REPO_ROOT$/src/compiler/internal/lexer.l"
 { return L_LAND; }
 	YY_BREAK
 case 81:
 YY_RULE_SETUP
-#line 653 "$REPO_ROOT$/src/compiler/internal/lexer.l"
+#line 665 "$REPO_ROOT$/src/compiler/internal/lexer.l"
 { yylval_param->number = F_AND_EQ; return L_ASSIGN; }
 	YY_BREAK
 case 82:
 YY_RULE_SETUP
-#line 654 "$REPO_ROOT$/src/compiler/internal/lexer.l"
+#line 666 "$REPO_ROOT$/src/compiler/internal/lexer.l"
 { return '&'; }
 	YY_BREAK
 case 83:
 YY_RULE_SETUP
-#line 656 "$REPO_ROOT$/src/compiler/internal/lexer.l"
+#line 668 "$REPO_ROOT$/src/compiler/internal/lexer.l"
 { yylval_param->number = F_LOR_EQ; return L_ASSIGN; }
 	YY_BREAK
 case 84:
 YY_RULE_SETUP
-#line 657 "$REPO_ROOT$/src/compiler/internal/lexer.l"
+#line 669 "$REPO_ROOT$/src/compiler/internal/lexer.l"
 { return L_LOR; }
 	YY_BREAK
 case 85:
 YY_RULE_SETUP
-#line 658 "$REPO_ROOT$/src/compiler/internal/lexer.l"
+#line 670 "$REPO_ROOT$/src/compiler/internal/lexer.l"
 { yylval_param->number = F_OR_EQ; return L_ASSIGN; }
 	YY_BREAK
 case 86:
 YY_RULE_SETUP
-#line 659 "$REPO_ROOT$/src/compiler/internal/lexer.l"
+#line 671 "$REPO_ROOT$/src/compiler/internal/lexer.l"
 { return '|'; }
 	YY_BREAK
 case 87:
 YY_RULE_SETUP
-#line 661 "$REPO_ROOT$/src/compiler/internal/lexer.l"
+#line 673 "$REPO_ROOT$/src/compiler/internal/lexer.l"
 { yylval_param->number = F_XOR_EQ; return L_ASSIGN; }
 	YY_BREAK
 case 88:
 YY_RULE_SETUP
-#line 662 "$REPO_ROOT$/src/compiler/internal/lexer.l"
+#line 674 "$REPO_ROOT$/src/compiler/internal/lexer.l"
 { return '^'; }
 	YY_BREAK
 case 89:
 YY_RULE_SETUP
-#line 664 "$REPO_ROOT$/src/compiler/internal/lexer.l"
+#line 676 "$REPO_ROOT$/src/compiler/internal/lexer.l"
 { yylval_param->number = F_LSH_EQ; return L_ASSIGN; }
 	YY_BREAK
 case 90:
 YY_RULE_SETUP
-#line 665 "$REPO_ROOT$/src/compiler/internal/lexer.l"
+#line 677 "$REPO_ROOT$/src/compiler/internal/lexer.l"
 { yylval_param->number = F_LSH; return L_SHIFT; }
 	YY_BREAK
 case 91:
 YY_RULE_SETUP
-#line 666 "$REPO_ROOT$/src/compiler/internal/lexer.l"
+#line 678 "$REPO_ROOT$/src/compiler/internal/lexer.l"
 { yylval_param->number = F_LE; return L_ORDER; }
 	YY_BREAK
 case 92:
 YY_RULE_SETUP
-#line 667 "$REPO_ROOT$/src/compiler/internal/lexer.l"
+#line 679 "$REPO_ROOT$/src/compiler/internal/lexer.l"
 { return '<'; }
 	YY_BREAK
 case 93:
 YY_RULE_SETUP
-#line 669 "$REPO_ROOT$/src/compiler/internal/lexer.l"
+#line 681 "$REPO_ROOT$/src/compiler/internal/lexer.l"
 { yylval_param->number = F_RSH_EQ; return L_ASSIGN; }
 	YY_BREAK
 case 94:
 YY_RULE_SETUP
-#line 670 "$REPO_ROOT$/src/compiler/internal/lexer.l"
+#line 682 "$REPO_ROOT$/src/compiler/internal/lexer.l"
 { yylval_param->number = F_RSH; return L_SHIFT; }
 	YY_BREAK
 case 95:
 YY_RULE_SETUP
-#line 671 "$REPO_ROOT$/src/compiler/internal/lexer.l"
+#line 683 "$REPO_ROOT$/src/compiler/internal/lexer.l"
 { yylval_param->number = F_GE; return L_ORDER; }
 	YY_BREAK
 case 96:
 YY_RULE_SETUP
-#line 672 "$REPO_ROOT$/src/compiler/internal/lexer.l"
+#line 684 "$REPO_ROOT$/src/compiler/internal/lexer.l"
 { yylval_param->number = F_GT; return L_ORDER; }
 	YY_BREAK
 case 97:
 YY_RULE_SETUP
-#line 674 "$REPO_ROOT$/src/compiler/internal/lexer.l"
+#line 686 "$REPO_ROOT$/src/compiler/internal/lexer.l"
 { yylval_param->number = F_MULT_EQ; return L_ASSIGN; }
 	YY_BREAK
 case 98:
 YY_RULE_SETUP
-#line 675 "$REPO_ROOT$/src/compiler/internal/lexer.l"
+#line 687 "$REPO_ROOT$/src/compiler/internal/lexer.l"
 { return '*'; }
 	YY_BREAK
 case 99:
 YY_RULE_SETUP
-#line 677 "$REPO_ROOT$/src/compiler/internal/lexer.l"
+#line 689 "$REPO_ROOT$/src/compiler/internal/lexer.l"
 { yylval_param->number = F_MOD_EQ; return L_ASSIGN; }
 	YY_BREAK
 case 100:
 YY_RULE_SETUP
-#line 678 "$REPO_ROOT$/src/compiler/internal/lexer.l"
+#line 690 "$REPO_ROOT$/src/compiler/internal/lexer.l"
 { return '%'; }
 	YY_BREAK
 case 101:
 YY_RULE_SETUP
-#line 680 "$REPO_ROOT$/src/compiler/internal/lexer.l"
+#line 692 "$REPO_ROOT$/src/compiler/internal/lexer.l"
 { yylval_param->number = F_DIV_EQ; return L_ASSIGN; }
 	YY_BREAK
 case 102:
 YY_RULE_SETUP
-#line 681 "$REPO_ROOT$/src/compiler/internal/lexer.l"
+#line 693 "$REPO_ROOT$/src/compiler/internal/lexer.l"
 { return '/'; }
 	YY_BREAK
 case 103:
 YY_RULE_SETUP
-#line 683 "$REPO_ROOT$/src/compiler/internal/lexer.l"
+#line 695 "$REPO_ROOT$/src/compiler/internal/lexer.l"
 { yylval_param->number = F_EQ; return L_EQ_NE; }
 	YY_BREAK
 case 104:
 YY_RULE_SETUP
-#line 684 "$REPO_ROOT$/src/compiler/internal/lexer.l"
+#line 696 "$REPO_ROOT$/src/compiler/internal/lexer.l"
 { yylval_param->number = F_ASSIGN; return L_ASSIGN; }
 	YY_BREAK
 case 105:
 YY_RULE_SETUP
-#line 686 "$REPO_ROOT$/src/compiler/internal/lexer.l"
+#line 698 "$REPO_ROOT$/src/compiler/internal/lexer.l"
 { yylval_param->number = F_NULLISH_EQ; return L_ASSIGN; }
 	YY_BREAK
 case 106:
 YY_RULE_SETUP
-#line 687 "$REPO_ROOT$/src/compiler/internal/lexer.l"
+#line 699 "$REPO_ROOT$/src/compiler/internal/lexer.l"
 { return L_QUESTION_QUESTION; }
 	YY_BREAK
 /* Optional chaining "?." (mapping member/bracket access, e.g. m?.key,
@@ -4045,42 +4057,42 @@ case 107:
 yyg->yy_c_buf_p = yy_cp = yy_bp + 2;
 YY_DO_BEFORE_ACTION; /* set up yytext again */
 YY_RULE_SETUP
-#line 692 "$REPO_ROOT$/src/compiler/internal/lexer.l"
+#line 704 "$REPO_ROOT$/src/compiler/internal/lexer.l"
 { return L_OPTIONAL_DOT; }
 	YY_BREAK
 case 108:
 YY_RULE_SETUP
-#line 693 "$REPO_ROOT$/src/compiler/internal/lexer.l"
+#line 705 "$REPO_ROOT$/src/compiler/internal/lexer.l"
 { return '?'; }
 	YY_BREAK
 case 109:
 YY_RULE_SETUP
-#line 695 "$REPO_ROOT$/src/compiler/internal/lexer.l"
+#line 707 "$REPO_ROOT$/src/compiler/internal/lexer.l"
 { yylval_param->number = F_NE; return L_EQ_NE; }
 	YY_BREAK
 case 110:
 YY_RULE_SETUP
-#line 696 "$REPO_ROOT$/src/compiler/internal/lexer.l"
+#line 708 "$REPO_ROOT$/src/compiler/internal/lexer.l"
 { return '!'; }
 	YY_BREAK
 case 111:
 YY_RULE_SETUP
-#line 698 "$REPO_ROOT$/src/compiler/internal/lexer.l"
+#line 710 "$REPO_ROOT$/src/compiler/internal/lexer.l"
 { return L_COLON_COLON; }
 	YY_BREAK
 case 112:
 YY_RULE_SETUP
-#line 699 "$REPO_ROOT$/src/compiler/internal/lexer.l"
+#line 711 "$REPO_ROOT$/src/compiler/internal/lexer.l"
 { return ':'; }
 	YY_BREAK
 case 113:
 YY_RULE_SETUP
-#line 701 "$REPO_ROOT$/src/compiler/internal/lexer.l"
+#line 713 "$REPO_ROOT$/src/compiler/internal/lexer.l"
 { return L_DOT_DOT_DOT; }
 	YY_BREAK
 case 114:
 YY_RULE_SETUP
-#line 702 "$REPO_ROOT$/src/compiler/internal/lexer.l"
+#line 714 "$REPO_ROOT$/src/compiler/internal/lexer.l"
 { return L_RANGE; }
 	YY_BREAK
 /* Optional chaining bracket form "m.?[idx]" -- the only grammar
@@ -4089,17 +4101,17 @@ YY_RULE_SETUP
      * a literal '?' right after '.' was already a syntax error otherwise. */
 case 115:
 YY_RULE_SETUP
-#line 707 "$REPO_ROOT$/src/compiler/internal/lexer.l"
+#line 719 "$REPO_ROOT$/src/compiler/internal/lexer.l"
 { return L_DOT_OPTIONAL; }
 	YY_BREAK
 case 116:
 YY_RULE_SETUP
-#line 708 "$REPO_ROOT$/src/compiler/internal/lexer.l"
+#line 720 "$REPO_ROOT$/src/compiler/internal/lexer.l"
 { return '.'; }
 	YY_BREAK
 case 117:
 YY_RULE_SETUP
-#line 710 "$REPO_ROOT$/src/compiler/internal/lexer.l"
+#line 722 "$REPO_ROOT$/src/compiler/internal/lexer.l"
 { return ')'; }
 	YY_BREAK
 /* '{'/'}' inside a template literal's ${...} interpolation need brace-
@@ -4108,7 +4120,7 @@ YY_RULE_SETUP
      * expression itself. See SC_TEMPLATE_BODY above. */
 case 118:
 YY_RULE_SETUP
-#line 715 "$REPO_ROOT$/src/compiler/internal/lexer.l"
+#line 727 "$REPO_ROOT$/src/compiler/internal/lexer.l"
 {
           lpc_lex_brace_open(yyscanner);
           return '{';
@@ -4116,7 +4128,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 119:
 YY_RULE_SETUP
-#line 719 "$REPO_ROOT$/src/compiler/internal/lexer.l"
+#line 731 "$REPO_ROOT$/src/compiler/internal/lexer.l"
 {
           if (lpc_lex_brace_close(yyscanner)) {
             BEGIN(SC_TEMPLATE_BODY);
@@ -4127,32 +4139,32 @@ YY_RULE_SETUP
 	YY_BREAK
 case 120:
 YY_RULE_SETUP
-#line 726 "$REPO_ROOT$/src/compiler/internal/lexer.l"
+#line 738 "$REPO_ROOT$/src/compiler/internal/lexer.l"
 { return '['; }
 	YY_BREAK
 case 121:
 YY_RULE_SETUP
-#line 727 "$REPO_ROOT$/src/compiler/internal/lexer.l"
+#line 739 "$REPO_ROOT$/src/compiler/internal/lexer.l"
 { return ']'; }
 	YY_BREAK
 case 122:
 YY_RULE_SETUP
-#line 728 "$REPO_ROOT$/src/compiler/internal/lexer.l"
+#line 740 "$REPO_ROOT$/src/compiler/internal/lexer.l"
 { return ';'; }
 	YY_BREAK
 case 123:
 YY_RULE_SETUP
-#line 729 "$REPO_ROOT$/src/compiler/internal/lexer.l"
+#line 741 "$REPO_ROOT$/src/compiler/internal/lexer.l"
 { return ','; }
 	YY_BREAK
 case 124:
 YY_RULE_SETUP
-#line 730 "$REPO_ROOT$/src/compiler/internal/lexer.l"
+#line 742 "$REPO_ROOT$/src/compiler/internal/lexer.l"
 { return '~'; }
 	YY_BREAK
 case YY_STATE_EOF(INITIAL):
 case YY_STATE_EOF(SC_COND_SKIP):
-#line 732 "$REPO_ROOT$/src/compiler/internal/lexer.l"
+#line 744 "$REPO_ROOT$/src/compiler/internal/lexer.l"
 {
           if (lpc_lex_pushed_depth() > 0) {
             if (lpc_lex_top_buffer_kind() == LPC_BUF_IF_EXPR) {
@@ -4178,7 +4190,7 @@ case YY_STATE_EOF(SC_COND_SKIP):
 	YY_BREAK
 case 125:
 YY_RULE_SETUP
-#line 755 "$REPO_ROOT$/src/compiler/internal/lexer.l"
+#line 767 "$REPO_ROOT$/src/compiler/internal/lexer.l"
 {
           // Nothing above matched: genuinely invalid input. No outp
           // rewind/flush needed -- lpc_lex_badlex() only inspects the
@@ -4188,10 +4200,10 @@ YY_RULE_SETUP
 	YY_BREAK
 case 126:
 YY_RULE_SETUP
-#line 762 "$REPO_ROOT$/src/compiler/internal/lexer.l"
+#line 774 "$REPO_ROOT$/src/compiler/internal/lexer.l"
 YY_FATAL_ERROR( "flex scanner jammed" );
 	YY_BREAK
-#line 4195 "$BUILD_ROOT$/src/lexer.autogen.cc"
+#line 4207 "$BUILD_ROOT$/src/lexer.autogen.cc"
 
 	case YY_END_OF_BUFFER:
 		{
@@ -5365,7 +5377,7 @@ static int yy_flex_strlen (const char * s , yyscan_t yyscanner)
 
 #define YYTABLES_NAME "yytables"
 
-#line 762 "$REPO_ROOT$/src/compiler/internal/lexer.l"
+#line 774 "$REPO_ROOT$/src/compiler/internal/lexer.l"
 
 
 // Read ONE character from the scanner's input, through Flex itself (its

--- a/src/compiler/internal/lexer.l
+++ b/src/compiler/internal/lexer.l
@@ -572,9 +572,21 @@ WS_NO_NL    [ \t\r\v\f]
      * else fights.
      */
 <INITIAL,SC_COND_SKIP>^[ \t]*"#"[^\n]*(\\\r?\n[^\n]*)* {
-    lpc_lex_consume_directive_newline(yyscanner);
-    LpcDirectiveAction act =
-        lpc_lex_on_directive(yytext, yyleng, yyscanner, YY_START == SC_COND_SKIP);
+    /* The capture stops at a physical newline, which a block comment
+     * opened on the line may legally span (#1236) -- complete the
+     * logical line first (policy in lexer_rules_pp.cc, reading through
+     * lpc_lex_getc()). When it pulled the tail, the terminating newline
+     * has already been consumed and counted. */
+    ScratchString completed;
+    int pulled_lines = 0;
+    bool extended =
+        lpc_lex_complete_directive(yytext, yyleng, yyscanner, &completed, &pulled_lines);
+    if (!extended) {
+        lpc_lex_consume_directive_newline(yyscanner);
+    }
+    LpcDirectiveAction act = lpc_lex_on_directive(
+        extended ? completed.c_str() : yytext, extended ? (int)completed.size() : yyleng,
+        yyscanner, YY_START == SC_COND_SKIP, pulled_lines);
     if (act == LpcDirectiveAction::kEnterSkip) {
         BEGIN(SC_COND_SKIP);
     } else if (act == LpcDirectiveAction::kExitSkip) {

--- a/src/compiler/internal/lexer_rules_pp.cc
+++ b/src/compiler/internal/lexer_rules_pp.cc
@@ -56,6 +56,137 @@ ScratchString strip_directive_comments(std::string_view s) {
   return r;
 }
 
+// Index of the first '/*' that never closes within `s`, or npos when
+// every block comment in `s` is terminated. Quote/'//' handling mirrors
+// strip_directive_comments() above -- a '/*' inside a string literal or
+// after '//' does not open a comment.
+static size_t open_comment_start(std::string_view s) {
+  size_t i = 0;
+  while (i < s.size()) {
+    if (s[i] == '"' || s[i] == '\'' || s[i] == '`') {
+      char q = s[i++];
+      while (i < s.size() && s[i] != q) {
+        if (s[i] == '\\') i++;
+        if (i < s.size()) i++;
+      }
+      if (i < s.size()) i++;
+    } else if (i + 1 < s.size() && s[i] == '/' && s[i + 1] == '/') {
+      return std::string_view::npos;  // '//' runs to the newline that ends the capture
+    } else if (i + 1 < s.size() && s[i] == '/' && s[i + 1] == '*') {
+      size_t start = i;
+      i += 2;
+      while (i + 1 < s.size() && (s[i] != '*' || s[i + 1] != '/')) i++;
+      if (i + 1 >= s.size()) return start;  // ran off the capture: still open
+      i += 2;
+    } else {
+      i++;
+    }
+  }
+  return std::string_view::npos;
+}
+
+bool lpc_lex_complete_directive(const char* text, int len, void* yyscanner, ScratchString* out,
+                                int* pulled_lines) {
+  std::string_view sv(text, len);
+  size_t open = open_comment_start(sv);
+  if (open == std::string_view::npos) return false;
+
+  int kind = lpc_lex_top_buffer_kind();
+  if (kind == LPC_BUF_PLAIN || kind == LPC_BUF_EXPANSION || kind == LPC_BUF_IF_EXPR) return false;
+
+  out->assign(sv.substr(0, open));
+  *out += ' ';
+
+  // Newlines consumed here that do NOT end up in *out (comment-internal
+  // ones and the terminator) get the same bookkeeping the rule's own
+  // terminator consumption does (native yylineno advance inside
+  // lpc_lex_getc() + lpc_lex_newline() for total_lines); kept
+  // continuation newlines are counted from the text later, exactly like
+  // capture-embedded ones.
+  int consumed = 0;
+  bool in_comment = true;
+  bool in_line_comment = false;
+  char in_quote = 0;
+  bool quote_escape = false;
+  int prev = 0;
+  for (;;) {
+    int c = lpc_lex_getc(yyscanner);
+    if (c <= 0) {
+      // Same terminal case as SC_BLOCK_COMMENT's <<EOF>> rule (and
+      // lpc_lex_getc() already continued into parent buffers, matching
+      // its lpc_lex_pop_splice_if_any step).
+      lexerror("End of file in a comment (opened on a preprocessor directive)");
+      break;
+    }
+    if (in_comment) {
+      if (c == '\n') {
+        lpc_lex_newline(yyscanner);
+        consumed++;
+        prev = 0;
+      } else if (prev == '*' && c == '/') {
+        in_comment = false;
+        prev = 0;
+      } else if (prev == '/' && c == '*') {
+        yywarn("/* found in comment.");  // same warning as SC_BLOCK_COMMENT
+        prev = 0;
+      } else {
+        prev = c;
+      }
+      continue;
+    }
+    if (c == '\n') {
+      // A backslash before the newline splices the next physical line
+      // in, matching the capture pattern's (\\\r?\n[^\n]*)* tail (and C,
+      // where splicing precedes comment recognition -- so it applies
+      // inside '//' too).
+      size_t n = out->size();
+      bool spliced = (n >= 1 && (*out)[n - 1] == '\\') ||
+                     (n >= 2 && (*out)[n - 1] == '\r' && (*out)[n - 2] == '\\');
+      if (spliced) {
+        *out += '\n';
+        continue;
+      }
+      lpc_lex_newline(yyscanner);
+      consumed++;
+      break;  // the logical line's terminator
+    }
+    if (in_line_comment) {
+      *out += static_cast<char>(c);
+      continue;
+    }
+    if (in_quote) {
+      *out += static_cast<char>(c);
+      if (quote_escape) {
+        quote_escape = false;
+      } else if (c == '\\') {
+        quote_escape = true;
+      } else if (c == in_quote) {
+        in_quote = 0;
+      }
+      continue;
+    }
+    *out += static_cast<char>(c);
+    if (c == '"' || c == '\'' || c == '`') {
+      in_quote = static_cast<char>(c);
+      quote_escape = false;
+      continue;
+    }
+    size_t n = out->size();
+    if (n >= 2 && (*out)[n - 2] == '/' && (*out)[n - 1] == '*') {
+      out->resize(n - 2);
+      *out += ' ';
+      in_comment = true;
+      prev = 0;
+    } else if (n >= 2 && (*out)[n - 2] == '/' && (*out)[n - 1] == '/') {
+      in_line_comment = true;
+    }
+  }
+  // The formula in lpc_lex_on_directive() already subtracts the
+  // terminator; report only the newlines beyond it.
+  *pulled_lines = consumed > 0 ? consumed - 1 : 0;
+  return true;
+}
+
 ScratchString stringize(std::string_view s) {
   ScratchString r("\"");
   for (char c : s) {
@@ -1026,16 +1157,18 @@ static void dispatch_directive(std::string_view dir, std::string_view rest, void
 }
 
 LpcDirectiveAction lpc_lex_on_directive(const char* text, int len, void* yyscanner,
-                                        bool in_skip_mode) {
+                                        bool in_skip_mode, int pulled_lines) {
   // The directive's own first line, for error attribution: the lexer.l
   // rule consumed + counted the terminating newline before calling us,
   // so current_line is already one past the directive's LAST physical
   // line; its embedded continuations haven't been counted yet, so its
-  // FIRST line is exactly current_line - 1. Published around the
-  // dispatch calls below via compiler_directive_start_line (see its
-  // comment in compiler.h) so yyerror()/yywarn() attribute to the
-  // directive rather than the line after it.
-  int directive_line = current_line - 1;
+  // FIRST line is exactly current_line - 1 -- minus any extra physical
+  // lines lpc_lex_complete_directive() pulled for a spanning /* comment.
+  // Published around the dispatch calls below via
+  // compiler_directive_start_line (see its comment in compiler.h) so
+  // yyerror()/yywarn() attribute to the directive rather than the line
+  // after it.
+  int directive_line = current_line - 1 - pulled_lines;
 
   // Embedded continuation newlines are physical lines regardless of scan
   // mode or whether the directive dispatches -- counted exactly once,

--- a/src/compiler/internal/lexer_rules_pp.h
+++ b/src/compiler/internal/lexer_rules_pp.h
@@ -91,8 +91,32 @@ enum class LpcDirectiveAction {
   kEnterSkip,  // a condition turned false: BEGIN(SC_COND_SKIP)
   kExitSkip,   // the dead branch ended: BEGIN(INITIAL)
 };
+// pulled_lines: physical newlines lpc_lex_complete_directive() consumed
+// beyond the terminating one (0 when the rule's capture was already the
+// whole logical line) -- backed out of the first-line attribution below.
 LpcDirectiveAction lpc_lex_on_directive(const char* text, int len, void* yyscanner,
-                                        bool in_skip_mode);
+                                        bool in_skip_mode, int pulled_lines = 0);
+
+// The directive rule's capture stops at the first physical newline (plus
+// backslash continuations), which cannot span a /* comment that closes on
+// a LATER line -- the comment's remaining lines used to be tokenized as
+// code (#1236). Called by the rule action BEFORE
+// lpc_lex_consume_directive_newline(): scans the captured text
+// (quote-aware, same rules as strip_directive_comments()) and, when it
+// ends inside an open /* comment, keeps pulling raw bytes through
+// lpc_lex_getc() until the comment closes and the logical line really
+// ends. Each comment is folded to a single space (a comment is
+// whitespace, so text after the close still belongs to the directive, and
+// another /* there may open again). Returns false -- out/pulled_lines
+// untouched, nothing consumed -- when the capture has no open comment
+// (the common case costs one scan of the captured text) or the top buffer
+// is a splice/if-expr buffer (no newlines to pull; same guard as
+// lpc_lex_consume_directive_newline()). Returns true when it pulled the
+// tail: *out is the completed logical line, *pulled_lines the newline
+// count for lpc_lex_on_directive(), and the terminating newline has been
+// consumed AND counted -- the rule action must NOT consume it again.
+bool lpc_lex_complete_directive(const char* text, int len, void* yyscanner, ScratchString* out,
+                                int* pulled_lines);
 
 // #include implementation: resolves `rest` (macro-expanding it first when
 // unquoted), records the including file's identity on the include

--- a/src/tests/test_compiler.cc
+++ b/src/tests/test_compiler.cc
@@ -261,6 +261,12 @@ static std::vector<Token> TokenizeSession(bool keep_macros, const std::string& s
     toks.push_back(std::move(t));
   }
 
+  // Ownership discipline (see lpc_lex_scanner_destroyed): whoever
+  // destroys a scanner clears the active pointer, or the NEXT compile's
+  // very first current_line read dereferences the destroyed scanner's
+  // guts -- an order-dependent use-after-free that intermittently
+  // segfaulted CompileEntry tests running after any tokenizer test.
+  lpc_lex_scanner_destroyed(scanner);
   yylex_destroy(scanner);
   free_string(const_cast<char*>(current_file));
   current_file = nullptr;
@@ -719,6 +725,52 @@ TEST(Preprocessor, BlockCommentMultiline) {
 int y;
 )"),
             "int x;\n \n\nint y;\n");
+}
+
+// A block comment opened on a directive line may close on a LATER line
+// (#1236): the directive rule's capture stops at the physical newline, so
+// lpc_lex_complete_directive() must pull the comment's remaining lines --
+// they are whitespace, not code, and they don't end the directive.
+
+TEST(Preprocessor, DefineWithCommentSpanningLines) {
+  // The exact #1236 repro shape: continuation line must not be tokenized.
+  EXPECT_EQ(pp("#define WARNING_LEVEL 1 /* Change this to higher values to\n"
+               "                           show more warnings. */\n"
+               "int x = WARNING_LEVEL;\n"),
+            "int x = 1;");
+}
+
+TEST(Preprocessor, DefineCommentTailStillDirective) {
+  // Text after the close on the final line still belongs to the body (C
+  // semantics: the whole comment reads as one space) -- and the tail may
+  // open ANOTHER spanning comment.
+  EXPECT_EQ(pp("#define V 10 /* spans\none line */ + 5\nint x = V;\n"), "int x = 10 + 5;");
+  EXPECT_EQ(pp("#define W 1 /* one\n*/ + 2 /* two\n*/ + 3\nint y = W;\n"), "int y = 1 + 2 + 3;");
+}
+
+TEST(Preprocessor, DefineCommentSpanKeepsLineCount) {
+  // Physical lines consumed for the comment are counted exactly once.
+  EXPECT_EQ(pp("#define W 1 /* a\nb\nc */\nint l = __LINE__;\n"), "int l = 4;");
+}
+
+TEST(Preprocessor, IfWithCommentSpanningLines) {
+  // On a live #if the comment is whitespace in the expression; on a dead
+  // one the branch below the comment's close is still skipped.
+  EXPECT_EQ(pp("#if 1 /* live,\nstill comment */\nint x = 1;\n#endif\n"), "int x = 1;");
+  EXPECT_EQ(pp("#if 0 /* dead,\nstill comment */\nnot code at all\n#endif\nint y = 2;\n"),
+            "int y = 2;");
+}
+
+TEST(Preprocessor, DirectiveStringDoesNotOpenComment) {
+  // A '/*' inside a string literal on the directive line is body text.
+  EXPECT_EQ(pp("#define S \"a/*b\"\nstring s = S;\n"), "string s = \"a/*b\";");
+}
+
+TEST(Preprocessor, DirectiveCommentUnterminatedAtEofErrors) {
+  // The pull must stop at EOF with a diagnostic, not spin.
+  auto p = LpcPreprocessor::make_session();
+  p->preprocess_next("#define X 1 /* never closed\n", "test");
+  EXPECT_FALSE(p->errors().empty());
 }
 
 // ---------------------------------------------------------------------------

--- a/src/tests/test_lexer.cc
+++ b/src/tests/test_lexer.cc
@@ -111,6 +111,10 @@ static std::vector<Token> Tokenize(const std::string& source, const char* filena
   end_new_file();
 
   g_last_lex_ctx = *yyget_extra(scanner);
+  // Clear the active pointer before destroying (ownership discipline of
+  // lpc_lex_scanner_destroyed) so a later compile's current_line read
+  // can't dereference the destroyed scanner.
+  lpc_lex_scanner_destroyed(scanner);
   yylex_destroy(scanner);
 
   // --- minimal epilog ---

--- a/testsuite/single/tests/compiler/preprocessor.lpc
+++ b/testsuite/single/tests/compiler/preprocessor.lpc
@@ -38,6 +38,33 @@
 #define PRECEDENCE_OK 0
 #endif
 
+// #1236: a block comment opened on a directive line may close on a
+// LATER line -- the comment reads as whitespace, it neither ends the
+// directive nor leaves its continuation lines to be compiled as code.
+#define WARNING_LEVEL 1 /* Change this to higher values to
+                           show more warnings. */
+
+// Text after the close on the final line still belongs to the directive.
+#define CMT_TAIL 10 /* spans
+one line */ + 5
+
+// On a live #if...
+#if 1 /* comment on a live #if,
+closed here */
+#define CMT_IF_OK 1
+#else
+#define CMT_IF_OK 0
+#endif
+
+// ...and on a dead one: the branch below the comment is still skipped.
+#if 0 /* opened on the #if line,
+closed here */
+this is not code and must never be compiled
+#endif
+
+// A string literal on the directive line must not open a comment.
+#define CMT_STR "a/*b"
+
 void do_tests() {
     // ## token paste builds an identifier.
     int GLUE(fo, o) = 42;
@@ -68,6 +95,12 @@ void do_tests() {
     ASSERT_EQ(1, COND_OK);
     ASSERT_EQ(1, NOTDEF_OK);
     ASSERT_EQ(1, PRECEDENCE_OK);
+
+    // #1236 -- directive-line comments spanning physical lines.
+    ASSERT_EQ(1, WARNING_LEVEL);
+    ASSERT_EQ(15, CMT_TAIL);
+    ASSERT_EQ(1, CMT_IF_OK);
+    ASSERT_EQ("a/*b", CMT_STR);
 
     // Builtin macros: __FILE__ / __DIR__ / __LINE__.
     ASSERT_EQ("/single/tests/compiler/preprocessor.lpc", __FILE__);


### PR DESCRIPTION
Fixes the regression reported in #1236: a `/*` comment opened after a `#define` body and closed on a later line left the comment's continuation lines to be tokenized as code (`syntax error, unexpected L_IDENTIFIER` on the comment text). `//` was unaffected, matching the report.

**Root cause.** The single anchored directive rule captures one physical line (plus backslash continuations), and `strip_directive_comments()` silently swallowed the unterminated `/*` — the define parsed fine, but the scanner resumed at the comment's next line as ordinary code.

**Fix.** New `lpc_lex_complete_directive()` (lexer_rules_pp.cc) runs before the terminating-newline consumption. When the captured line ends inside an open block comment (quote-aware detection, same rules as `strip_directive_comments`), it pulls raw bytes through `lpc_lex_getc()` until the comment closes and the logical line really ends:

- Comments fold to a single space, so text after the close still belongs to the directive (C semantics): `#define V 10 /* spans\nlines */ + 5` defines `V` as `10 + 5`.
- The tail handles further spanning comments, string literals (`"a/*b"` never opens one), `//`, and backslash continuations.
- Works for all directives in both scan modes — a comment on a dead `#if 0` line is consumed too, so the skipped branch still ends at the right `#endif`.
- Pulled newlines get the same line bookkeeping as the rule's own terminator, and the count is backed out of the directive's first-line diagnostic attribution.
- EOF inside the comment reports the same error as `SC_BLOCK_COMMENT`'s `<<EOF>>` rule instead of spinning; nested `/*` gets the same warning.

The common no-comment case costs one scan of the already-captured text; nothing else changes.

**Also included** (separate commit): a pre-existing, order-dependent use-after-free in the two test harnesses — they called `yylex_destroy()` without `lpc_lex_scanner_destroyed()`, leaving the global `active_scanner` dangling for the next compile's `current_line` read. Any `Preprocessor` test followed by `CompileEntry.FatalInsideIfExpressionRecovers` segfaulted (reproduces on master); the new #1236 tests made it fire reliably in full runs.

**Tests.** Six new `Preprocessor` unit tests (repro shape, comment tail + repeated comments, `__LINE__` bookkeeping, live/dead `#if`, string-literal `/*`, EOF error) plus pins in `testsuite/single/tests/compiler/preprocessor.lpc`; documented in `docs/lpc/preprocessor/define.md`.

**Verification.** Scanner regenerated with flex 2.6.4; full LPC testsuite green on RelWithDebInfo and Debug (leak checker) builds; all GTest units pass; compiler_tests full-suite stress-run 5× clean (previously flaky).

Note: sibling PR #1241 fixes the other directive-comment regression (#1240, trailing comments captured into payloads); the two are independent but touch neighboring lines in `lexer_rules_pp.cc` and the same test files, so whichever merges second will need a trivial rebase.

Fixes #1236

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016FMBJLkpkpVpZdz6PWzeWe