### PR TITLE
lexer: strip comments from directive payloads before parsing (#1240)

### DIFF
--- a/docs/lpc/preprocessor/define.md
+++ b/docs/lpc/preprocessor/define.md
@@ -74,6 +74,15 @@ define `WARNING_LEVEL` as `1`:
 Text after the comment's close on its final line still belongs to the
 directive, matching C.
 
+Comments on a directive line are whitespace, never part of the macro:
+a trailing `//` or `/* */` after the body (or after the name on
+`#undef`/`#ifdef`) is stripped before the directive is parsed, and a
+block comment inside the body separates tokens like a space would:
+
+```c
+#define CREDITS "credits" // key into the economy mapping
+```
+
 ## Redefinition
 
 Redefining a macro with a **different** body is allowed: the compiler

--- a/src/compiler/internal/lexer_rules_pp.cc
+++ b/src/compiler/internal/lexer_rules_pp.cc
@@ -49,6 +49,10 @@ ScratchString strip_directive_comments(std::string_view s) {
       i += 2;
       while (i + 1 < s.size() && (s[i] != '*' || s[i + 1] != '/')) i++;
       if (i + 1 < s.size()) i += 2;
+      // A comment is ONE space (C translation phase 3), not nothing:
+      // eliding it entirely would paste the surrounding tokens together
+      // ("1/*x*/2" must stay two tokens, not become "12").
+      r += ' ';
     } else {
       r += s[i++];
     }
@@ -951,6 +955,13 @@ static ScratchString fold_backslash_newlines(std::string_view text) {
 static void dispatch_directive(std::string_view dir, std::string_view rest, void* yyscanner) {
   if (dir == "define") {
     if (lpc_lex_emitting()) {
+      // Comments are whitespace (C translation phase 3): strip them from
+      // the whole definition BEFORE parsing the name/params/body. A '//'
+      // tail otherwise lands in the stored body and -- expansion buffers
+      // carry no newline to end it -- comments out the rest of whatever
+      // spliced text the macro later expands into (#1240).
+      ScratchString rest_stripped = strip_directive_comments(rest);
+      rest = std::string_view(rest_stripped);
       size_t idx = 0;
       while (idx < rest.size() && (rest[idx] == ' ' || rest[idx] == '\t')) idx++;
       size_t ns = idx;
@@ -986,7 +997,10 @@ static void dispatch_directive(std::string_view dir, std::string_view rest, void
         if (idx < rest.size()) idx++;  // skip ')'
       }
       while (idx < rest.size() && (rest[idx] == ' ' || rest[idx] == '\t')) idx++;
-      ScratchString body = (idx < rest.size()) ? ScratchString(rest.substr(idx)) : ScratchString();
+      // trim(): a stripped trailing comment leaves trailing whitespace,
+      // which must not make "1" vs "1 " look like a redefinition.
+      ScratchString body =
+          (idx < rest.size()) ? ScratchString(trim(rest.substr(idx))) : ScratchString();
 
       std::string_view bv(body);
       auto bv_trim = trim(bv);
@@ -1028,7 +1042,9 @@ static void dispatch_directive(std::string_view dir, std::string_view rest, void
     }
   } else if (dir == "undef") {
     if (lpc_lex_emitting()) {
-      std::string name(trim(rest));
+      // Same phase-3 rule as #define: "#undef X // why" names X, not
+      // "X // why" (which silently erased nothing).
+      std::string name(trim(std::string_view(strip_directive_comments(rest))));
       if (pp_is_predefined(name)) {
         lexerror("Illegal to #undef a predefined value.");
       } else {
@@ -1036,11 +1052,13 @@ static void dispatch_directive(std::string_view dir, std::string_view rest, void
       }
     }
   } else if (dir == "ifdef") {
-    bool def = pp_find_macro(trim(rest)) != nullptr;
+    // Strip comments or "#ifdef X // why" looks up the wrong name and
+    // silently takes the false branch.
+    bool def = pp_find_macro(trim(std::string_view(strip_directive_comments(rest)))) != nullptr;
     bool emit = lpc_lex_emitting() && def;
     g_compile.conds.push_back({emit, emit});
   } else if (dir == "ifndef") {
-    bool def = pp_find_macro(trim(rest)) != nullptr;
+    bool def = pp_find_macro(trim(std::string_view(strip_directive_comments(rest)))) != nullptr;
     bool emit = lpc_lex_emitting() && !def;
     g_compile.conds.push_back({emit, emit});
   } else if (dir == "if") {
@@ -1115,7 +1133,9 @@ static void dispatch_directive(std::string_view dir, std::string_view rest, void
     }
   } else if (dir == "pragma") {
     if (lpc_lex_emitting()) {
-      ScratchString rest_str(trim(rest));
+      // Pragma payloads are word lists, so a trailing comment would read
+      // as an unknown pragma word -- strip like the other parsed forms.
+      ScratchString rest_str(trim(std::string_view(strip_directive_comments(rest))));
       handle_pragma(const_cast<char*>(rest_str.c_str()));
     }
   } else if (dir == "line" ||

--- a/src/tests/test_compiler.cc
+++ b/src/tests/test_compiler.cc
@@ -773,6 +773,45 @@ TEST(Preprocessor, DirectiveCommentUnterminatedAtEofErrors) {
   EXPECT_FALSE(p->errors().empty());
 }
 
+// Comments are whitespace (C translation phase 3) and must be stripped
+// from a directive's payload BEFORE it is parsed (#1240): a '//' tail
+// captured into a macro body comments out the rest of whatever spliced
+// text the macro later expands into, and a trailing comment on
+// #undef/#ifdef corrupts the looked-up name.
+
+TEST(Preprocessor, DefineLineCommentNotInBody) {
+  // The #1240 repro shape: CREDITS expanding inside MIN's spliced body
+  // must not swallow the rest of the expression.
+  EXPECT_EQ(pp("#define CREDITS \"credits\" // Current number of credits\n"
+               "#define MIN(x,y) ((x) < (y) ? (x) : (y))\n"
+               "int f() { return MIN(c, m[e][CREDITS]); }\n"),
+            "int f() { return ((c) < (m[e][\"credits\"]) ? (c) : (m[e][\"credits\"])); }");
+}
+
+TEST(Preprocessor, DefineBlockCommentInBodyIsOneSpace) {
+  // The comment folds to ONE space, so "-/*c*/-1" stays two '-' tokens;
+  // pasting them into '--' would fail the #if evaluation and flip the
+  // branch.
+  EXPECT_EQ(pp("#define TWO 1 -/*c*/-1\n#if TWO == 2\nint spaced;\n#else\nint pasted;\n#endif\n"),
+            "int spaced;");
+}
+
+TEST(Preprocessor, DefineParamListComment) {
+  // A comment inside a function-like parameter list is whitespace too.
+  EXPECT_EQ(pp("#define F(a, /* second */ b) a + b\nint x = F(1, 2);\n"), "int x = 1 + 2;");
+}
+
+TEST(Preprocessor, UndefWithTrailingComment) {
+  // "#undef GONE // bye" must erase GONE, not look up "GONE // bye".
+  EXPECT_EQ(pp("#define GONE 5\n#undef GONE // bye\nint GONE = 6;\nint x = GONE;\n"),
+            "int GONE = 6; int x = GONE;");
+}
+
+TEST(Preprocessor, IfdefWithTrailingComment) {
+  EXPECT_EQ(pp("#define FEAT 1\n#ifdef FEAT // enabled\nint on;\n#endif\n"), "int on;");
+  EXPECT_EQ(pp("#ifndef FEAT /* not defined */\nint off;\n#endif\n"), "int off;");
+}
+
 // ---------------------------------------------------------------------------
 // 5. Conditional compilation
 // ---------------------------------------------------------------------------

--- a/testsuite/single/tests/compiler/preprocessor.lpc
+++ b/testsuite/single/tests/compiler/preprocessor.lpc
@@ -65,6 +65,26 @@ this is not code and must never be compiled
 // A string literal on the directive line must not open a comment.
 #define CMT_STR "a/*b"
 
+// #1240: comments are whitespace in a directive's payload -- a '//'
+// tail must NOT be captured into the body (it would comment out the
+// rest of whatever spliced line the macro expands into), and trailing
+// comments on #ifdef/#undef must not corrupt the name.
+#define CREDITS_KEY "credits" // Current number of credits
+#define MIN2(x, y) ((x) < (y) ? (x) : (y))
+
+// A body-internal block comment is ONE space: the two '-' below must
+// not paste into '--'.
+#define DOUBLE_NEG 1 -/*minus*/-1
+
+#ifdef CREDITS_KEY // trailing comment here too
+#define IFDEF_CMT_OK 1
+#else
+#define IFDEF_CMT_OK 0
+#endif
+
+#define UNDEF_ME 5
+#undef UNDEF_ME // gone
+
 void do_tests() {
     // ## token paste builds an identifier.
     int GLUE(fo, o) = 42;
@@ -101,6 +121,14 @@ void do_tests() {
     ASSERT_EQ(15, CMT_TAIL);
     ASSERT_EQ(1, CMT_IF_OK);
     ASSERT_EQ("a/*b", CMT_STR);
+
+    // #1240 -- trailing comments on directives are whitespace.
+    mapping economies = ([ "e" : ([ "credits" : 100 ]) ]);
+    ASSERT_EQ(42, MIN2(42, economies["e"][CREDITS_KEY]));
+    ASSERT_EQ(2, DOUBLE_NEG);
+    ASSERT_EQ(1, IFDEF_CMT_OK);
+    int UNDEF_ME = 9;
+    ASSERT_EQ(9, UNDEF_ME);
 
     // Builtin macros: __FILE__ / __DIR__ / __LINE__.
     ASSERT_EQ("/single/tests/compiler/preprocessor.lpc", __FILE__);


### PR DESCRIPTION
Fixes #1240 (dev-lexer regression from mudlib stress-testing).

**Root cause.** A `//` comment after a `#define` body was captured INTO the stored macro body. Expansion buffers carry no newline to end a line comment, so when the macro expanded inside a spliced line — the report's `MIN(credits, economies[economy][CREDITS])`, where MIN's substituted body and pre-expanded arguments become one buffer — the `//` ate the rest of the splice, producing the baffling `unexpected ';'` attributed to the outer macro. (Top-level uses like `int i = ONE + 2;` worked by accident: the comment ran out at the expansion buffer's end and the parent's bytes survived.)

The same missed strip broke two silent variants confirmed while fixing: `#undef X // why` erased nothing (looked up `X // why`), and `#ifdef X // why` looked up the wrong name and took the false branch without a peep.

**Fix.** Comments are whitespace (C translation phase 3): `dispatch_directive` now strips them from the payload before parsing for `#define` (name/params/body — body also right-trimmed so a stripped comment can't turn `1` vs `1 ` into a spurious redefinition warning), `#undef`, `#ifdef`, `#ifndef`, and `#pragma` (word-list payload); `#if`/`#elif` already stripped. `strip_directive_comments()` now folds a block comment to ONE space instead of nothing, so `1 -/*c*/-1` keeps its token boundaries instead of pasting `--`. `#error`/`#warn`/`#echo` payloads stay raw.

**Tests.** Five new `Preprocessor` unit tests (the report's repro shape through MIN, paste-prevention pinned via `#if` branch selection, comment inside a function-like parameter list, `#undef`/`#ifdef` trailing comments) plus matching end-to-end pins in `testsuite/single/tests/compiler/preprocessor.lpc`; behavior documented in `docs/lpc/preprocessor/define.md`.

**Verification.** The issue's exact repro compiles clean. Debug build: all 303 GTest units pass and the full LPC testsuite is green.

Note: sibling PR #1239 fixes the other directive-comment regression (#1236, spanning block comments) from the same stress-testing; the two are independent but touch neighboring lines in `lexer_rules_pp.cc` and the same test files, so whichever merges second will need a trivial rebase.

Fixes #1240

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016FMBJLkpkpVpZdz6PWzeWe

---
_Generated by [Claude Code](https://claude.ai/code/session_016FMBJLkpkpVpZdz6PWzeWe)_