### PR TITLE
Char-mode input: deliver real keystrokes (BS/DEL, whole UTF-8, raw ESC); fix NAWS lost at logon

### DIFF
--- a/docs/concepts/general/tui.md
+++ b/docs/concepts/general/tui.md
@@ -1,0 +1,119 @@
+---
+title: general / tui
+---
+# The LPC TUI library (/std/tui)
+
+The testsuite mudlib ships a terminal-UI toolkit written in pure LPC, layered
+like `readline` + `ncurses`: line editing, history and incremental search for
+the prompt line, plus a screen buffer, diff renderer and widget set for
+full-screen applications.  It lives in `testsuite/std/tui/` and is portable to
+any FluffOS mudlib (copy the directory plus `include/tui.h`).
+
+The architecture document is
+[`testsuite/std/tui/DESIGN.md`](https://github.com/fluffos/fluffos/blob/master/testsuite/std/tui/DESIGN.md);
+this page is the user view.
+
+## Prompt-line editing (the readline replacement)
+
+Inherit `/std/tui/terminal` into your user object (it also provides the
+`window_size` / `terminal_type` applies), then replace `input_to()` calls
+with:
+
+```c
+void get_command() {
+    tui_readline((: got_command :), ([ "prompt": "> " ]));
+}
+
+void got_command(mixed line, int state) {
+    if (state != TUI_RL_DONE) return;      // TUI_RL_ABORT (^C) / TUI_RL_EOF (^D)
+    do_command(line);
+    get_command();
+}
+```
+
+Every prompt now has Emacs/readline editing: cursor motion (arrows,
+Ctrl-A/E/B/F, word motion Alt-B/F or Ctrl-arrows), kill/yank
+(Ctrl-K/U/W/Y, Alt-D), Ctrl-T transpose, ↑/↓ history, Ctrl-R/Ctrl-S
+incremental history search, Tab completion (pass a `"completer"` function in
+the options), bracketed paste, masked input (`"masked": 1` for passwords),
+wide-character (CJK) aware rendering with horizontal scrolling, and live
+terminal-resize handling via NAWS.  History persists per user object across
+calls.
+
+## Full-screen applications
+
+Inherit `/std/tui/app`, position widgets in `on_layout()`, and open the app
+with `tui_open()` from the user object:
+
+```c
+// my_app.lpc
+inherit TUI_APP;
+private object lst;
+
+void on_open(object term, int w, int h) {
+    if (!lst) {
+        lst = app_add(new("/std/tui/w/list"));
+        lst->set_items(({ "one", "two", "three" }));
+        lst->set_on_event((: on_event :));
+    }
+    ::on_open(term, w, h);
+}
+
+void on_layout(int w, int h) {
+    app_screen()->scr_clear();
+    app_screen()->scr_box(0, 0, w, h, TUI_BOX_ROUND, "36");
+    lst->set_geometry(2, 1, w - 4, h - 2);
+}
+
+// somewhere in the user object:  tui_open(new("/path/to/my_app"));
+```
+
+The terminal switches to the alternate screen with the cursor hidden; the app
+receives decoded key events (`on_key`), optional SGR mouse events
+(`on_mouse`, pass `(["mouse": 1])` to `tui_open`), and resize events
+(`on_resize`).  Tab/Shift-Tab cycle focus, Ctrl-C always quits, and
+`app_quit()` restores the terminal.  Shipped widgets: `label`, `list`
+(scrollable/selectable), `textfield` (a full readline engine per field);
+the widget base class (`/std/tui/widget`) makes new widgets ~30 lines.
+
+## The layers (use them à la carte)
+
+| Module | What it is |
+|---|---|
+| `/std/tui/ansi` | escape-sequence builders; `visible_width()` (ANSI-blind, wide-char-aware), `wslice()`, `wpad()` |
+| `/std/tui/keys` | keystroke decoder: `get_char()` byte stream → key events (CSI/SS3, modifiers, UTF-8, bracketed paste, SGR mouse) |
+| `/std/tui/readline` | the line-editor engine — a pure state machine, usable headless |
+| `/std/tui/screen` | virtual cell grid + minimal-diff frame renderer (the ncurses core) |
+| `/std/tui/widget`, `/std/tui/w/*`, `/std/tui/app` | widget protocol, shipped widgets, application container |
+| `/std/tui/terminal` | the only impure module: `get_char` loop, NAWS/TTYPE, ESC timeout, teardown |
+
+Everything below `terminal` is side-effect-free and covered by the LPC
+testsuite (`single/tests/std/tui/`).  Key-event constants and readline states
+are in `include/tui.h` (`TUI_KEY_*`, `TUI_MOD_*`, `TUI_CTRL(c)`,
+`TUI_RL_*`).
+
+## Try it
+
+Boot the testsuite mudlib and connect with any terminal:
+
+```bash
+./driver testsuite/etc/config.test &
+telnet localhost 4000
+> tuidemo        # readline demo: editing, history, ^R search, Tab completion
+> tuidemo app    # full-screen widget demo (Tab cycles focus, q quits)
+```
+
+## Requirements & caveats
+
+* Works over raw telnet, the websocket `telnet` subprotocol, and the WASM
+  bridge.  The websocket `ascii` subprotocol has no negotiation layer
+  (no char mode / echo control), so the library cannot run on it.
+* A client that never answers NAWS is assumed to be 80×24.
+* The driver must not be started with both `no ansi` and
+  `strip before process input` *acting on char mode* — since 2026 the driver
+  keeps ESC intact in char mode regardless of those options, so any current
+  build is fine.
+* Rendering emits the VT100/xterm common subset (CSI cursor addressing, SGR,
+  alternate screen, bracketed paste, SGR mouse) — understood by every modern
+  terminal, MUD client and xterm.js.  `tui_term()` exposes the negotiated
+  terminal type if an app wants to special-case.

--- a/docs/concepts/general/tui.md
+++ b/docs/concepts/general/tui.md
@@ -4,13 +4,15 @@ title: general / tui
 # The LPC TUI library (/std/tui)
 
 The testsuite mudlib ships a terminal-UI toolkit written in pure LPC, layered
-like `readline` + `ncurses`: line editing, history and incremental search for
-the prompt line, plus a screen buffer, diff renderer and widget set for
-full-screen applications.  It lives in `testsuite/std/tui/` and is portable to
-any FluffOS mudlib (copy the directory plus `include/tui.h`).
+like `readline` + `ncurses` + `pterm`: line editing, history and incremental
+search for the prompt line, inline select/multiselect/confirm prompts and
+pretty-printers for ordinary output, plus a screen buffer, diff renderer and
+widget set for full-screen applications.  It lives in `testsuite/std/tui/`
+and is portable to any FluffOS mudlib (copy the directory plus
+`include/tui.h`).
 
 The architecture document is
-[`testsuite/std/tui/DESIGN.md`](https://github.com/fluffos/fluffos/blob/master/testsuite/std/tui/DESIGN.md);
+[`testsuite/std/tui/README.md`](https://github.com/fluffos/fluffos/blob/master/testsuite/std/tui/README.md);
 this page is the user view.
 
 ## Prompt-line editing (the readline replacement)
@@ -39,6 +41,29 @@ the options), bracketed paste, masked input (`"masked": 1` for passwords),
 wide-character (CJK) aware rendering with horizontal scrolling, and live
 terminal-resize handling via NAWS.  History persists per user object across
 calls.
+
+## Inline prompts and printers (the pterm layer)
+
+Three prompt helpers run in the normal output flow — no full-screen mode:
+
+```c
+tui_select((: chose :), "Pick a class:", ({ "warrior", "mage", "thief" }));
+// -> chose(int index, string item, int state)
+tui_multiselect((: picked :), "Skills:", skills, ([ "height": 5 ]));
+// -> picked(int *indexes, string *items, int state)
+tui_confirm((: sure :), "Delete the character?", 0);
+// -> sure(int yes, int state)
+```
+
+Arrows navigate, Space toggles, Enter accepts, Esc/Ctrl-C aborts; on
+completion the list collapses to a one-line `? prompt: answer` record.
+
+`/std/tui/print` is a set of stateless printers that compose with `write()`:
+`p_table()` (boxed, width-aware), `p_tree()`, `p_bars()` (bar chart),
+`p_spark()` (sparkline), `p_panel()`, `p_bullets()`, `p_header()`,
+`p_progress()`, `p_info/p_success/p_warn/p_error()` and `p_bigtext()`
+(banner letters via `/std/bitmap_font`).  Run `tuidemo print` to see them
+all.
 
 ## Full-screen applications
 
@@ -72,19 +97,27 @@ The terminal switches to the alternate screen with the cursor hidden; the app
 receives decoded key events (`on_key`), optional SGR mouse events
 (`on_mouse`, pass `(["mouse": 1])` to `tui_open`), and resize events
 (`on_resize`).  Tab/Shift-Tab cycle focus, Ctrl-C always quits, and
-`app_quit()` restores the terminal.  Shipped widgets: `label`, `list`
-(scrollable/selectable), `textfield` (a full readline engine per field);
-the widget base class (`/std/tui/widget`) makes new widgets ~30 lines.
+`app_quit()` restores the terminal.
+
+Shipped widgets (`/std/tui/w/`, modeled on the pterm and blessed sets):
+`label`, `list`, `table` (columns + header + selection), `tree`
+(collapsible), `textfield` (a full readline engine per field), `checklist`,
+`radiolist`, `button`, `progress`, `spinner`, and `log` (bottom-anchored
+scrollback pane).  The widget base class (`/std/tui/widget`) makes new
+widgets ~30 lines; `tuidemo dashboard` and `tuidemo form` show most of the
+set in action.
 
 ## The layers (use them à la carte)
 
 | Module | What it is |
 |---|---|
 | `/std/tui/ansi` | escape-sequence builders; `visible_width()` (ANSI-blind, wide-char-aware), `wslice()`, `wpad()` |
+| `/std/tui/print` | pterm-style inline printers: tables, trees, charts, panels, banners |
 | `/std/tui/keys` | keystroke decoder: `get_char()` byte stream → key events (CSI/SS3, modifiers, UTF-8, bracketed paste, SGR mouse) |
 | `/std/tui/readline` | the line-editor engine — a pure state machine, usable headless |
+| `/std/tui/menu` | the inline select/multiselect engine behind `tui_select()` |
 | `/std/tui/screen` | virtual cell grid + minimal-diff frame renderer (the ncurses core) |
-| `/std/tui/widget`, `/std/tui/w/*`, `/std/tui/app` | widget protocol, shipped widgets, application container |
+| `/std/tui/widget`, `/std/tui/w/*`, `/std/tui/app` | widget protocol, the widget set, application container |
 | `/std/tui/terminal` | the only impure module: `get_char` loop, NAWS/TTYPE, ESC timeout, teardown |
 
 Everything below `terminal` is side-effect-free and covered by the LPC
@@ -99,8 +132,12 @@ Boot the testsuite mudlib and connect with any terminal:
 ```bash
 ./driver testsuite/etc/config.test &
 telnet localhost 4000
-> tuidemo        # readline demo: editing, history, ^R search, Tab completion
-> tuidemo app    # full-screen widget demo (Tab cycles focus, q quits)
+> tuidemo            # readline demo: editing, history, ^R search, Tab completion
+> tuidemo select     # inline select -> multiselect -> confirm chain
+> tuidemo print      # the inline printers
+> tuidemo app        # minimal full-screen demo
+> tuidemo dashboard  # animated spinner/progress/sparkline/table/log
+> tuidemo form       # textfield, radio group, checkboxes, buttons
 ```
 
 ## Requirements & caveats

--- a/docs/concepts/general/tui.md
+++ b/docs/concepts/general/tui.md
@@ -65,6 +65,14 @@ completion the list collapses to a one-line `? prompt: answer` record.
 (banner letters via `/std/bitmap_font`).  Run `tuidemo print` to see them
 all.
 
+Charts are built on `/std/tui/canvas`, a braille dot canvas (2×4 dots per
+cell, the blessed-contrib technique): `p_chart()` renders multi-series
+braille line charts with a y-axis and coloured legend, `p_vbars()` draws
+vertical bars with eighth-block partial tops, and `p_heatmap()` renders a
+2D matrix as 256-colour cells.  The same engine powers the `chart` widget
+(`add_point()` rolling history — see the dashboard's traffic graph).  Run
+`tuidemo charts` to see them.
+
 ## Full-screen applications
 
 Inherit `/std/tui/app`, position widgets in `on_layout()`, and open the app
@@ -102,17 +110,18 @@ receives decoded key events (`on_key`), optional SGR mouse events
 Shipped widgets (`/std/tui/w/`, modeled on the pterm and blessed sets):
 `label`, `list`, `table` (columns + header + selection), `tree`
 (collapsible), `textfield` (a full readline engine per field), `checklist`,
-`radiolist`, `button`, `progress`, `spinner`, and `log` (bottom-anchored
-scrollback pane).  The widget base class (`/std/tui/widget`) makes new
-widgets ~30 lines; `tuidemo dashboard` and `tuidemo form` show most of the
-set in action.
+`radiolist`, `button`, `progress`, `spinner`, `log` (bottom-anchored
+scrollback pane), and `chart` (braille line chart with rolling history).
+The widget base class (`/std/tui/widget`) makes new widgets ~30 lines;
+`tuidemo dashboard` and `tuidemo form` show most of the set in action.
 
 ## The layers (use them à la carte)
 
 | Module | What it is |
 |---|---|
 | `/std/tui/ansi` | escape-sequence builders; `visible_width()` (ANSI-blind, wide-char-aware), `wslice()`, `wpad()` |
-| `/std/tui/print` | pterm-style inline printers: tables, trees, charts, panels, banners |
+| `/std/tui/canvas` | braille dot canvas: sub-cell lines/plots for charts |
+| `/std/tui/print` | pterm-style inline printers: tables, trees, charts, heatmaps, panels, banners |
 | `/std/tui/keys` | keystroke decoder: `get_char()` byte stream → key events (CSI/SS3, modifiers, UTF-8, bracketed paste, SGR mouse) |
 | `/std/tui/readline` | the line-editor engine — a pure state machine, usable headless |
 | `/std/tui/menu` | the inline select/multiselect engine behind `tui_select()` |
@@ -135,6 +144,7 @@ telnet localhost 4000
 > tuidemo            # readline demo: editing, history, ^R search, Tab completion
 > tuidemo select     # inline select -> multiselect -> confirm chain
 > tuidemo print      # the inline printers
+> tuidemo charts     # vertical bars, braille line chart, heatmap
 > tuidemo app        # minimal full-screen demo
 > tuidemo dashboard  # animated spinner/progress/sparkline/table/log
 > tuidemo form       # textfield, radio group, checkboxes, buttons

--- a/docs/efun/interactive/get_char.md
+++ b/docs/efun/interactive/get_char.md
@@ -34,16 +34,25 @@ title: interactive / get_char
     argument (a string). Any additional arguments supplied to get_char will
     be passed on to 'fun' as arguments following the user input.
 
-### BUGS
+### DELIVERY
 
-    Please note that get_char has a significant bug in MudOS 0.9  and  ear‐
-    lier.  On many systems with poor telnet negotiation (read: almost every
-    major workstation on the market), get_char makes screen  output  behave
-    strangely.   It  is  not  recommended  for  common usage throughout the
-    mudlib until that bug is fixed.  (It is currently only  known  to  work
-    well for users connecting from NeXT computers.)
+    Exactly one keystroke is delivered per callback:
+
+    - A printable character arrives as itself.  A multi-byte UTF-8  charac‐
+      ter  is  delivered  whole,  as one valid one-character string (it is
+      never split into fragment bytes).
+    - Control bytes arrive verbatim, including Backspace (0x08) and Delete
+      (0x7f) -- char mode performs no line editing.
+    - Escape sequences (arrow keys, function keys)  arrive  byte-by-byte:
+      ESC, '[', 'A' are three separate callbacks.  Reassembling  them  is
+      the mudlib's job; see /std/tui/keys.lpc in the testsuite mudlib for
+      a full decoder, and the TUI library built on top of it.
+
+    Char mode is one-shot: after each callback the driver reverts to  line
+    mode  unless  the callback re-arms get_char() before returning.  Pass‐
+    ing the no-echo flag on every re-arm keeps client echo off across  the
+    whole exchange.
 
 ### SEE ALSO
 
     call_other(3), call_out(3), input_to(3)
-

--- a/docs/stdlib/index.md
+++ b/docs/stdlib/index.md
@@ -21,3 +21,5 @@ title: STDLIB
 * [base64encode](string/base64encode)
 * [bitmap_font](string/bitmap_font)
 * [break_string](string/break_string)
+## tui
+* [tui](tui) — terminal UI toolkit: readline prompts, inline printers & charts, full-screen widgets

--- a/docs/stdlib/tui.md
+++ b/docs/stdlib/tui.md
@@ -1,5 +1,5 @@
 ---
-title: general / tui
+title: stdlib / tui
 ---
 # The LPC TUI library (/std/tui)
 

--- a/src/base/internal/strutils.cc
+++ b/src/base/internal/strutils.cc
@@ -43,6 +43,28 @@ bool u8_validate(const uint8_t* s, size_t len) {
 
 std::string u8_sanitize(std::string_view src) { return utf8::replace_invalid(src); }
 
+size_t u8_incomplete_tail(std::string_view buf) {
+  const size_t n = buf.size();
+  const size_t scan = n < 3 ? n : 3;
+
+  for (size_t back = 1; back <= scan; back++) {
+    const auto c = static_cast<unsigned char>(buf[n - back]);
+    if ((c & 0xc0) == 0x80) continue;  // continuation byte: keep scanning for the lead
+    size_t len;
+    if (c >= 0xc2 && c < 0xe0) {
+      len = 2;
+    } else if (c >= 0xe0 && c < 0xf0) {
+      len = 3;
+    } else if (c >= 0xf0 && c <= 0xf4) {
+      len = 4;
+    } else {
+      return 0;  // ASCII or invalid lead: nothing worth waiting for
+    }
+    return len > back ? back : 0;  // incomplete -> hold `back` bytes
+  }
+  return 0;  // 3 continuations with no lead: malformed, deliver as-is
+}
+
 // Search "needle' in 'haystack', making sure it matches EGC boundary, returning byte offset.
 int32_t u8_egc_find_as_offset(EGCIterator& iter, const char* needle, size_t needle_len,
                               bool reverse) {

--- a/src/base/internal/strutils.h
+++ b/src/base/internal/strutils.h
@@ -195,6 +195,10 @@ size_t u8_width(const char* src, int len);
 void u8_truncate_below_width(const char* src, size_t len, size_t max_width, bool break_for_line,
                              bool always_break_before_newline, size_t* out_len, size_t* out_width);
 std::string u8_sanitize(std::string_view src);
+// Length (0-3) of the incomplete-but-valid UTF-8 sequence prefix at the end
+// of buf.  Streaming input should hold those bytes back until the rest of
+// the character arrives, instead of sanitizing them into U+FFFD.
+size_t u8_incomplete_tail(std::string_view buf);
 int32_t u8_egc_find_as_offset(EGCIterator& iter, const char* needle, size_t needle_len,
                               bool reverse);
 

--- a/src/comm.cc
+++ b/src/comm.cc
@@ -134,6 +134,15 @@ void on_user_logon(interactive_t* user) {
 
   set_prompt("> ");
 
+  // A fast client may have answered the initial DO NAWS while ip->ob was
+  // still the master object; replay the cached report on the real user.
+  if (ob->interactive->naws_w) {
+    push_number(ob->interactive->naws_w);
+    push_number(ob->interactive->naws_h);
+    set_eval(max_eval_cost);
+    safe_apply(APPLY_WINDOW_SIZE, ob, 2, ORIGIN_DRIVER);
+  }
+
   // Call logon() on the object.
   set_eval(max_eval_cost);
   ret = safe_apply(APPLY_LOGON, ob, 0, ORIGIN_DRIVER);
@@ -414,7 +423,11 @@ void on_user_input(interactive_t* ip, const char* data, size_t len) {
         }
         break;
       case 0x1b:
-        if (CONFIG_INT(__RC_NO_ANSI__) && CONFIG_INT(__RC_STRIP_BEFORE_PROCESS_INPUT__)) {
+        // The anti-ANSI-injection rewrite is a line-mode protection; in
+        // single-char mode the mudlib asked for raw keystrokes and needs
+        // ESC intact to decode arrow/function keys.
+        if (!(ip->iflags & SINGLE_CHAR) && CONFIG_INT(__RC_NO_ANSI__) &&
+            CONFIG_INT(__RC_STRIP_BEFORE_PROCESS_INPUT__)) {
           ip->text[ip->text_end++] = ANSI_SUBSTITUTE;
           break;
         }
@@ -426,6 +439,45 @@ void on_user_input(interactive_t* ip, const char* data, size_t len) {
   }
 }
 
+/*
+ * Single-char ("get_char") mode delivers one keystroke per callback.  A
+ * keystroke is one byte, except when the buffer starts with a complete,
+ * well-formed UTF-8 multi-byte sequence -- that is delivered whole, so LPC
+ * receives one valid character instead of 2-4 fragment bytes.  Waiting for
+ * the tail of a sequence is safe: the transports u8_sanitize() their input,
+ * so a valid prefix is always completed by subsequent bytes.  Malformed
+ * bytes are delivered one at a time, never stalled on.
+ *
+ * Returns the byte count to deliver, or 0 to wait for more input.
+ */
+static int single_char_bytes(const interactive_t* ip) {
+  const auto* p = reinterpret_cast<const unsigned char*>(ip->text) + ip->text_start;
+  const int avail = ip->text_end - ip->text_start;
+  if (avail <= 0) {
+    return 0;
+  }
+  int len;
+  if (p[0] < 0xc2 || p[0] > 0xf4) {
+    return 1; /* ASCII, or a byte that can't start a valid sequence */
+  } else if (p[0] < 0xe0) {
+    len = 2;
+  } else if (p[0] < 0xf0) {
+    len = 3;
+  } else {
+    len = 4;
+  }
+  if (avail < len) {
+    /* wait for the rest, unless the buffer can never grow */
+    return ip->text_end == sizeof(ip->text) - 1 ? 1 : 0;
+  }
+  for (int i = 1; i < len; i++) {
+    if ((p[i] & 0xc0) != 0x80) {
+      return 1; /* malformed: deliver the lead byte alone */
+    }
+  }
+  return len;
+}
+
 // Also used by ws_ascii.
 int cmd_in_buf(interactive_t* ip) {
   char* p;
@@ -435,9 +487,10 @@ int cmd_in_buf(interactive_t* ip) {
     return 0;
   }
 
-  /* if we're in single character mode, we've got input */
+  /* if we're in single character mode, we've got input once a whole
+     keystroke (possibly a multi-byte UTF-8 character) is buffered */
   if (ip->iflags & SINGLE_CHAR) {
-    return 1;
+    return single_char_bytes(ip) > 0;
   }
 
   for (p = ip->text + ip->text_start; p < ip->text + ip->text_end; p++) {
@@ -452,7 +505,7 @@ int cmd_in_buf(interactive_t* ip) {
 
 static char* first_cmd_in_buf(interactive_t* ip) {
   char* p;
-  static char tmp[2];
+  static char tmp[5];
 
   /* do standard input buffer cleanup */
   if (!clean_buf(ip)) {
@@ -461,13 +514,20 @@ static char* first_cmd_in_buf(interactive_t* ip) {
 
   p = ip->text + ip->text_start;
 
-  /* if we're in single character mode, we've got input */
+  /* if we're in single character mode, deliver one keystroke: control
+     bytes (including BS/DEL) verbatim, multi-byte UTF-8 characters whole */
   if (ip->iflags & SINGLE_CHAR) {
-    if (*p == 8 || *p == 127) {
-      *p = 0;
+    const int len = single_char_bytes(ip);
+    if (len == 0) {
+      /* incomplete UTF-8 sequence: wait for the rest */
+      ip->iflags &= ~CMD_IN_BUF;
+      return nullptr;
     }
-    tmp[0] = *p;
-    ip->text[ip->text_start++] = 0;
+    memcpy(tmp, p, len);
+    tmp[len] = '\0';
+    for (int i = 0; i < len; i++) {
+      ip->text[ip->text_start++] = 0;
+    }
     if (!clean_buf(ip)) {
       ip->iflags &= ~CMD_IN_BUF;
     }

--- a/src/interactive.h
+++ b/src/interactive.h
@@ -85,6 +85,18 @@ struct interactive_t {
   // libtelnet handle
   struct telnet_t* telnet;
 
+  // Incomplete trailing UTF-8 sequence held back from the last input chunk
+  // (a multi-byte character split across TCP segments), prepended to the
+  // next chunk before sanitizing.  See on_telnet_data().
+  char u8_carry[4];
+  int u8_carry_len;
+
+  // Last NAWS report (0 = none yet).  The window_size apply is replayed
+  // from this on logon, because fast clients answer the initial DO NAWS
+  // while ip->ob is still the master object.
+  int naws_w;
+  int naws_h;
+
   // --- native-transport private state (TRANSITIONAL) ---
   // Owned and touched only by the Transport implementations in
   // net/transport_libevent.cc (and net/websocket.cc); always null on

--- a/src/net/telnet.cc
+++ b/src/net/telnet.cc
@@ -85,7 +85,20 @@ static inline void on_telnet_data(const char* buffer, unsigned long size, intera
     }
   }
 
-  auto sanitized = u8_sanitize({transdata, translen});
+  // A multi-byte character split across TCP segments must not be sanitized
+  // into U+FFFD: hold the incomplete tail back until the rest arrives.
+  std::string data;
+  data.reserve(ip->u8_carry_len + translen);
+  data.append(ip->u8_carry, ip->u8_carry_len);
+  ip->u8_carry_len = 0;
+  data.append(transdata, translen);
+  if (const auto tail = u8_incomplete_tail(data)) {
+    memcpy(ip->u8_carry, data.data() + data.size() - tail, tail);
+    ip->u8_carry_len = static_cast<int>(tail);
+    data.resize(data.size() - tail);
+  }
+
+  auto sanitized = u8_sanitize(data);
   on_user_input(ip, sanitized.c_str(), sanitized.length());
 
   if (transdata != buffer) {
@@ -379,8 +392,15 @@ static inline void on_telnet_subnegotiation(unsigned char cmd, const char* buf, 
     }
     case TELNET_TELOPT_NAWS: {
       if (size >= 4) {
-        push_number((static_cast<unsigned char>(buf[0]) << 8) | static_cast<unsigned char>(buf[1]));
-        push_number((static_cast<unsigned char>(buf[2]) << 8) | static_cast<unsigned char>(buf[3]));
+        const int w = (static_cast<unsigned char>(buf[0]) << 8) | static_cast<unsigned char>(buf[1]);
+        const int h = (static_cast<unsigned char>(buf[2]) << 8) | static_cast<unsigned char>(buf[3]);
+        // Cache: fast clients answer the initial DO NAWS while ip->ob is
+        // still the master object; on_user_logon() replays the apply on
+        // the real user object (comm.cc).
+        ip->naws_w = w;
+        ip->naws_h = h;
+        push_number(w);
+        push_number(h);
         set_eval(max_eval_cost);
         safe_apply(APPLY_WINDOW_SIZE, ip->ob, 2, ORIGIN_DRIVER);
       }

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -21,6 +21,9 @@ if(${GTEST_FOUND})
   target_link_libraries(lexer_tests PRIVATE ${FLUFFOS_LINK} GTest::GTest GTest::Main)
   target_compile_definitions(lexer_tests PRIVATE -DTESTSUITE_DIR="${CMAKE_SOURCE_DIR}/testsuite")
 
+  add_executable(strutils_tests test_strutils.cc)
+  target_link_libraries(strutils_tests PRIVATE ${FLUFFOS_LINK} GTest::GTest GTest::Main)
+
   # Scratchpad-vs-malloc micro-benchmark: proves the compile arena beats
   # heap allocation for the compiler's allocation patterns. Timing-based,
   # so it is NOT registered with ctest -- run manually (RelWithDebInfo):
@@ -40,5 +43,6 @@ if(${GTEST_FOUND})
   gtest_discover_tests(ofile_tests DISCOVERY_TIMEOUT 60)
   gtest_discover_tests(compiler_tests DISCOVERY_TIMEOUT 60)
   gtest_discover_tests(lexer_tests DISCOVERY_TIMEOUT 60)
+  gtest_discover_tests(strutils_tests DISCOVERY_TIMEOUT 60)
 endif()
 

--- a/src/tests/test_strutils.cc
+++ b/src/tests/test_strutils.cc
@@ -1,0 +1,42 @@
+#include <gtest/gtest.h>
+#include "base/std.h"
+
+#include "base/internal/strutils.h"
+
+// u8_incomplete_tail: how many trailing bytes of a streaming chunk form the
+// prefix of a not-yet-complete UTF-8 character (and must be held back
+// instead of being sanitized into U+FFFD).
+
+TEST(U8IncompleteTail, CompleteInputHasNoTail) {
+  EXPECT_EQ(0u, u8_incomplete_tail(""));
+  EXPECT_EQ(0u, u8_incomplete_tail("ascii only"));
+  EXPECT_EQ(0u, u8_incomplete_tail("wide \xe4\xbd\xa0"));          // 你 complete
+  EXPECT_EQ(0u, u8_incomplete_tail("\xc3\xa9"));                   // é complete
+  EXPECT_EQ(0u, u8_incomplete_tail("\xf0\x9f\x98\x80"));           // 😀 complete
+}
+
+TEST(U8IncompleteTail, HoldsBackPartialSequences) {
+  EXPECT_EQ(1u, u8_incomplete_tail("abc\xc3"));                    // é lead only
+  EXPECT_EQ(1u, u8_incomplete_tail("abc\xe4"));                    // 你 lead only
+  EXPECT_EQ(2u, u8_incomplete_tail("abc\xe4\xbd"));                // 你 2 of 3
+  EXPECT_EQ(1u, u8_incomplete_tail("abc\xf0"));                    // 😀 1 of 4
+  EXPECT_EQ(2u, u8_incomplete_tail("abc\xf0\x9f"));                // 😀 2 of 4
+  EXPECT_EQ(3u, u8_incomplete_tail("abc\xf0\x9f\x98"));            // 😀 3 of 4
+  // partial sequence is the whole chunk
+  EXPECT_EQ(1u, u8_incomplete_tail("\xe4"));
+  EXPECT_EQ(2u, u8_incomplete_tail("\xe4\xbd"));
+}
+
+TEST(U8IncompleteTail, MalformedInputIsNotHeld) {
+  // invalid lead bytes: sanitize now, nothing will complete them
+  EXPECT_EQ(0u, u8_incomplete_tail("abc\xff"));
+  EXPECT_EQ(0u, u8_incomplete_tail("abc\xc0"));                    // overlong lead
+  EXPECT_EQ(0u, u8_incomplete_tail("abc\xf5"));                    // > U+10FFFF
+  // stray continuation bytes with no lead in reach
+  EXPECT_EQ(0u, u8_incomplete_tail("abc\x80"));
+  EXPECT_EQ(0u, u8_incomplete_tail("abc\x80\x80\x80"));
+  // complete-but-invalid pairs are left for the sanitizer
+  EXPECT_EQ(0u, u8_incomplete_tail("abc\xc3\xa9\xa9"));
+  // ASCII directly before the end
+  EXPECT_EQ(0u, u8_incomplete_tail("abc\x7f"));
+}

--- a/testsuite/clone/tuidemo_app.lpc
+++ b/testsuite/clone/tuidemo_app.lpc
@@ -1,0 +1,54 @@
+// Full-screen demo application for `tuidemo app` (see /command/tuidemo.lpc).
+// A list, a text field, and a status bar; Tab cycles focus, q quits.
+
+#include <tui.h>
+
+inherit TUI_APP;
+inherit TUI_ANSI;
+
+private object lst, fld, status, title;
+private string last_event = "welcome — Tab cycles focus, q quits";
+
+private void on_widget_event(object w, string what, mixed arg) {
+  if (w == lst && what == "select") {
+    last_event = "selected: " + lst->query_selected_item();
+  } else if (w == fld && what == "submit") {
+    last_event = "submitted: " + arg;
+    lst->set_items(lst->query_items() + ({ arg }));
+  } else if (what == "change") {
+    last_event = "highlight: " + lst->query_selected_item();
+  }
+}
+
+void on_layout(int w, int h) {
+  object scr = app_screen();
+
+  scr->scr_clear();
+  scr->scr_box(0, 0, w, h - 1, TUI_BOX_ROUND, ansi_fg(6));
+  title->set_geometry(2, 0, w - 4, 1);
+  lst->set_geometry(2, 2, w / 2 - 3, h - 6);
+  fld->set_geometry(w / 2 + 1, 2, w - w / 2 - 3, 1);
+  status->set_geometry(0, h - 1, w, 1);
+}
+
+void on_open(object t, int w, int h) {
+  if (!lst) {
+    title = app_add(new("/std/tui/w/label"));
+    title->set_text(" /std/tui demo ");
+    title->set_attr("1;36");
+    lst = app_add(new("/std/tui/w/list"));
+    lst->set_items(({ "alpha", "bravo", "charlie", "delta", "echo", "foxtrot" }));
+    lst->set_on_event((: on_widget_event :));
+    fld = app_add(new("/std/tui/w/textfield"));
+    fld->set_on_event((: on_widget_event :));
+    status = app_add(new("/std/tui/w/label"));
+    status->set_attr("7");
+  }
+  ::on_open(t, w, h);
+}
+
+string render() {
+  status->set_text(sprintf(" %dx%d  %s ", app_screen()->scr_width(),
+                           app_screen()->scr_height(), last_event));
+  return ::render();
+}

--- a/testsuite/clone/tuidemo_dash.lpc
+++ b/testsuite/clone/tuidemo_dash.lpc
@@ -1,0 +1,109 @@
+// `tuidemo dashboard` — an animated full-screen dashboard showing the
+// pterm/blessed-inspired widgets: spinner, progress bars, sparkline,
+// live table and a streaming log.  q (or Ctrl-C) quits.
+
+#include <tui.h>
+
+inherit TUI_APP;
+inherit TUI_PRINT;
+
+private object title, spin, cpu, mem, net, spark, tbl, logw, status;
+private int *history = ({});
+private int tick_no = 0;
+private int co = -1;
+
+private string *names = ({ "azalea", "borin", "celdor", "dagny", "ezra" });
+
+private void tick();  // forward: referenced by the call_out functionals
+
+void on_layout(int w, int h) {
+  object scr = app_screen();
+  int half = w / 2;
+
+  scr->scr_clear();
+  scr->scr_box(0, 1, w, h - 2, TUI_BOX_ROUND, "36");
+  title->set_geometry(0, 0, w, 1);
+  spin->set_geometry(2, 2, half - 3, 1);
+  cpu->set_geometry(2, 4, half - 3, 1);
+  mem->set_geometry(2, 5, half - 3, 1);
+  net->set_geometry(2, 6, half - 3, 1);
+  spark->set_geometry(2, 8, half - 3, 2);
+  tbl->set_geometry(half + 1, 2, w - half - 3, 8);
+  logw->set_geometry(2, 11, w - 4, h - 13);
+  status->set_geometry(0, h - 1, w, 1);
+}
+
+void on_open(object t, int w, int h) {
+  if (!title) {
+    title = app_add(new("/std/tui/w/label"));
+    title->set_attr("1;36");
+    title->set_text(" ⚡ /std/tui dashboard — Tab cycles focus, PgUp/PgDn scroll the log, q quits ");
+
+    spin = app_add(new("/std/tui/w/spinner"));
+    spin->set_label("crunching game ticks…");
+
+    cpu = app_add(new("/std/tui/w/progress"));
+    cpu->set_label("cpu");
+    cpu->set_attr("32");
+    mem = app_add(new("/std/tui/w/progress"));
+    mem->set_label("mem");
+    mem->set_attr("33");
+    net = app_add(new("/std/tui/w/progress"));
+    net->set_label("net");
+    net->set_attr("35");
+
+    spark = app_add(new("/std/tui/w/label"));
+    spark->set_attr("36");
+
+    tbl = app_add(new("/std/tui/w/table"));
+    tbl->set_columns(({ "player", "room", "hp" }));
+
+    logw = app_add(new("/std/tui/w/log"));
+    logw->set_attr("2");
+
+    status = app_add(new("/std/tui/w/label"));
+    status->set_attr("7");
+  }
+  ::on_open(t, w, h);
+  if (co == -1) co = call_out_walltime((: tick :), 0.25);
+}
+
+void on_closed() {
+  if (co != -1) {
+    remove_call_out(co);
+    co = -1;
+  }
+}
+
+private void tick() {
+  mixed *rows = ({});
+  int i;
+
+  co = -1;
+  if (!app_terminal()) return;
+
+  tick_no++;
+  spin->tick();
+  cpu->set_percent((tick_no * 7) % 101);
+  mem->set_percent(40 + (tick_no * 3) % 55);
+  net->set_percent(random(101));
+
+  history += ({ random(9) + 1 });
+  if (sizeof(history) > 40) history = history[<40..];
+  spark->set_text("traffic\n" + p_spark(history));
+
+  for (i = 0; i < sizeof(names); i++) {
+    rows += ({ ({ names[i], "room" + (1 + (tick_no + i) % 7), "" + (50 + random(50)) }) });
+  }
+  tbl->set_rows(rows);
+
+  if (tick_no % 4 == 1) {
+    logw->add_line(sprintf("[%d] %s enters room%d", tick_no,
+                           names[random(sizeof(names))], 1 + random(7)));
+  }
+  status->set_text(sprintf(" %dx%d  tick %d ", app_screen()->scr_width(),
+                           app_screen()->scr_height(), tick_no));
+
+  app_terminal()->tui_send(render());
+  co = call_out_walltime((: tick :), 0.25);
+}

--- a/testsuite/clone/tuidemo_dash.lpc
+++ b/testsuite/clone/tuidemo_dash.lpc
@@ -1,14 +1,12 @@
 // `tuidemo dashboard` — an animated full-screen dashboard showing the
-// pterm/blessed-inspired widgets: spinner, progress bars, sparkline,
-// live table and a streaming log.  q (or Ctrl-C) quits.
+// pterm/blessed-inspired widgets: spinner, progress bars, a braille line
+// chart, live table and a streaming log.  q (or Ctrl-C) quits.
 
 #include <tui.h>
 
 inherit TUI_APP;
-inherit TUI_PRINT;
 
-private object title, spin, cpu, mem, net, spark, tbl, logw, status;
-private int *history = ({});
+private object title, spin, cpu, mem, net, spark_lbl, chart, tbl, logw, status;
 private int tick_no = 0;
 private int co = -1;
 
@@ -27,9 +25,10 @@ void on_layout(int w, int h) {
   cpu->set_geometry(2, 4, half - 3, 1);
   mem->set_geometry(2, 5, half - 3, 1);
   net->set_geometry(2, 6, half - 3, 1);
-  spark->set_geometry(2, 8, half - 3, 2);
+  spark_lbl->set_geometry(2, 8, half - 3, 1);
+  chart->set_geometry(2, 9, half - 3, 2);
   tbl->set_geometry(half + 1, 2, w - half - 3, 8);
-  logw->set_geometry(2, 11, w - 4, h - 13);
+  logw->set_geometry(2, 12, w - 4, h - 14);
   status->set_geometry(0, h - 1, w, 1);
 }
 
@@ -52,8 +51,12 @@ void on_open(object t, int w, int h) {
     net->set_label("net");
     net->set_attr("35");
 
-    spark = app_add(new("/std/tui/w/label"));
-    spark->set_attr("36");
+    spark_lbl = app_add(new("/std/tui/w/label"));
+    spark_lbl->set_attr("36");
+    spark_lbl->set_text("traffic");
+    chart = app_add(new("/std/tui/w/chart"));
+    chart->add_series("traffic", "36");
+    chart->set_range(0, 10);
 
     tbl = app_add(new("/std/tui/w/table"));
     tbl->set_columns(({ "player", "room", "hp" }));
@@ -88,9 +91,7 @@ private void tick() {
   mem->set_percent(40 + (tick_no * 3) % 55);
   net->set_percent(random(101));
 
-  history += ({ random(9) + 1 });
-  if (sizeof(history) > 40) history = history[<40..];
-  spark->set_text("traffic\n" + p_spark(history));
+  chart->add_point(0, random(9) + 1);
 
   for (i = 0; i < sizeof(names); i++) {
     rows += ({ ({ names[i], "room" + (1 + (tick_no + i) % 7), "" + (50 + random(50)) }) });

--- a/testsuite/clone/tuidemo_form.lpc
+++ b/testsuite/clone/tuidemo_form.lpc
@@ -1,0 +1,75 @@
+// `tuidemo form` — a blessed-style form: textfield, radio group,
+// checkbox list and buttons.  Tab/Shift-Tab move between fields,
+// Space toggles, Enter presses; Ctrl-C quits.
+
+#include <tui.h>
+
+inherit TUI_APP;
+
+private object title, name_lbl, name_fld, class_lbl, class_rad;
+private object skills_lbl, skills_chk, ok_btn, cancel_btn, result;
+
+private void on_widget_event(object w, string what, mixed arg) {
+  if (w == ok_btn && what == "press") {
+    result->set_text(sprintf("→ %s the %s (%s)",
+                             name_fld->query_text() == "" ? "nameless" : name_fld->query_text(),
+                             class_rad->query_picked_item(),
+                             sizeof(skills_chk->query_checked_items())
+                                 ? implode(skills_chk->query_checked_items(), ", ")
+                                 : "no skills"));
+  } else if (w == cancel_btn && what == "press") {
+    app_quit();
+  }
+}
+
+void on_layout(int w, int h) {
+  object scr = app_screen();
+  int col = 16, fw = w - col - 4;
+
+  scr->scr_clear();
+  scr->scr_box(0, 1, w, h - 1, TUI_BOX_SINGLE, "34");
+  title->set_geometry(0, 0, w, 1);
+  name_lbl->set_geometry(3, 3, col - 3, 1);
+  name_fld->set_geometry(col, 3, fw > 30 ? 30 : fw, 1);
+  class_lbl->set_geometry(3, 5, col - 3, 1);
+  class_rad->set_geometry(col, 5, fw, 4);
+  skills_lbl->set_geometry(3, 10, col - 3, 1);
+  skills_chk->set_geometry(col, 10, fw, 5);
+  ok_btn->set_geometry(col, 16, 8, 1);
+  cancel_btn->set_geometry(col + 10, 16, 12, 1);
+  result->set_geometry(3, 18, w - 6, 2);
+}
+
+void on_open(object t, int w, int h) {
+  if (!title) {
+    title = app_add(new("/std/tui/w/label"));
+    title->set_attr("1;34");
+    title->set_text(" character sheet — Tab moves, Space toggles, Enter presses ");
+
+    name_lbl = app_add(new("/std/tui/w/label"));
+    name_lbl->set_text("name:");
+    name_fld = app_add(new("/std/tui/w/textfield"));
+
+    class_lbl = app_add(new("/std/tui/w/label"));
+    class_lbl->set_text("class:");
+    class_rad = app_add(new("/std/tui/w/radiolist"));
+    class_rad->set_items(({ "warrior", "mage", "thief", "cleric" }));
+
+    skills_lbl = app_add(new("/std/tui/w/label"));
+    skills_lbl->set_text("skills:");
+    skills_chk = app_add(new("/std/tui/w/checklist"));
+    skills_chk->set_items(({ "swords", "archery", "alchemy", "lockpicking", "diplomacy" }));
+
+    ok_btn = app_add(new("/std/tui/w/button"));
+    ok_btn->set_label("OK");
+    ok_btn->set_on_event((: on_widget_event :));
+
+    cancel_btn = app_add(new("/std/tui/w/button"));
+    cancel_btn->set_label("Cancel");
+    cancel_btn->set_on_event((: on_widget_event :));
+
+    result = app_add(new("/std/tui/w/label"));
+    result->set_attr("1;32");
+  }
+  ::on_open(t, w, h);
+}

--- a/testsuite/clone/user.lpc
+++ b/testsuite/clone/user.lpc
@@ -7,7 +7,7 @@
 
 inherit BASE;
 // TUI support: tui_readline() prompts, tui_open() full-screen apps, and the
-// window_size/terminal_type applies (see /std/tui/DESIGN.md).
+// window_size/terminal_type applies (see /std/tui/README.md).
 inherit TUI_TERMINAL;
 
 private string name;

--- a/testsuite/clone/user.lpc
+++ b/testsuite/clone/user.lpc
@@ -3,8 +3,12 @@
 // purpose:  is the representation of an interactive (user) in the MUD
 
 #include <globals.h>
+#include <tui.h>
 
 inherit BASE;
+// TUI support: tui_readline() prompts, tui_open() full-screen apps, and the
+// window_size/terminal_type applies (see /std/tui/DESIGN.md).
+inherit TUI_TERMINAL;
 
 private string name;
 
@@ -213,6 +217,7 @@ void tell_room(object ob, string msg) {
 void
 net_dead()
 {
+    tui_destroy();
     set_heart_beat(0);
 #ifndef __NO_ENVIRONMENT__
     tell_room(environment(), query_name() + " is link-dead.\n");
@@ -232,8 +237,8 @@ reconnect()
 }
 
 void window_size(int width, int height) {
-  string msg = sprintf("TELNET NAWS: %dx%d\n", width, height);
-  receive(msg);
+  if (!tui_active()) receive(sprintf("TELNET NAWS: %dx%d\n", width, height));
+  ::window_size(width, height);  // let /std/tui/terminal cache it
 }
 
 // receive_environ

--- a/testsuite/command/tuidemo.lpc
+++ b/testsuite/command/tuidemo.lpc
@@ -1,0 +1,47 @@
+// tuidemo — interactive demo of /std/tui (see /std/tui/DESIGN.md).
+//
+//   tuidemo        readline prompt: editing, ↑/↓ history, Ctrl-R search,
+//                  Tab completion over a few verbs; "quit" (or Ctrl-D) exits
+//   tuidemo app    full-screen widget demo: Tab cycles focus, arrows drive
+//                  the list, the field submits on Enter, q quits
+
+#include <tui.h>
+
+private string *verbs = ({ "look", "listen", "inventory", "invite", "quit", "quaff" });
+
+private string *complete_verb(string buf, int pos) {
+  // complete only the first word
+  if (strsrch(buf[0..pos - 1], " ") != -1) return ({});
+  return verbs;
+}
+
+private void got_line(mixed line, int st) {
+  object me = this_player();
+
+  if (st != TUI_RL_DONE) {
+    write(st == TUI_RL_ABORT ? "[aborted]\n" : "[eof]\n");
+    return;
+  }
+  if (line == "quit") {
+    write("bye.\n");
+    return;
+  }
+  if (line != "") write("you typed: " + line + "\n");
+  me->tui_readline((: got_line :),
+                   ([ "prompt": "tui> ", "completer": (: complete_verb :) ]));
+}
+
+int main(string arg) {
+  object me = this_player();
+
+  if (!me) return 0;
+  if (arg == "app") {
+    me->tui_open(new("/clone/tuidemo_app"));
+    return 1;
+  }
+  write("TUI readline demo: editing keys, Up/Down history, Ctrl-R search,\n"
+        "Tab completion.  'quit' or Ctrl-D exits.\n");
+  me->tui_readline((: got_line :),
+                   ([ "prompt": "tui> ", "completer": (: complete_verb :) ]));
+  return 1;
+}

--- a/testsuite/command/tuidemo.lpc
+++ b/testsuite/command/tuidemo.lpc
@@ -1,17 +1,26 @@
-// tuidemo — interactive demo of /std/tui (see /std/tui/DESIGN.md).
+// tuidemo — showcases for /std/tui (see /std/tui/README.md).
 //
-//   tuidemo        readline prompt: editing, ↑/↓ history, Ctrl-R search,
-//                  Tab completion over a few verbs; "quit" (or Ctrl-D) exits
-//   tuidemo app    full-screen widget demo: Tab cycles focus, arrows drive
-//                  the list, the field submits on Enter, q quits
+//   tuidemo            readline prompt: editing, ↑/↓ history, Ctrl-R search,
+//                      Tab completion; "quit" or Ctrl-D exits
+//   tuidemo select     inline select / multiselect / confirm prompts
+//   tuidemo print      the pterm-style inline printers, in plain line mode
+//   tuidemo app        basic full-screen demo (list + textfield)
+//   tuidemo dashboard  animated dashboard: spinner, progress, sparkline,
+//                      live table and log (q quits)
+//   tuidemo form       form demo: textfield, radio, checkboxes, buttons
 
 #include <tui.h>
 
+inherit TUI_PRINT;
+
 private string *verbs = ({ "look", "listen", "inventory", "invite", "quit", "quaff" });
 
+// --- readline showcase -------------------------------------------------
+
 private string *complete_verb(string buf, int pos) {
-  // complete only the first word
-  if (strsrch(buf[0..pos - 1], " ") != -1) return ({});
+  string head = pos > 0 ? buf[0..pos - 1] : "";
+
+  if (strsrch(head, " ") != -1) return ({});  // complete only the first word
   return verbs;
 }
 
@@ -31,16 +40,87 @@ private void got_line(mixed line, int st) {
                    ([ "prompt": "tui> ", "completer": (: complete_verb :) ]));
 }
 
+// --- select / multiselect / confirm showcase -----------------------------
+
+private void confirmed(int yes, int st) {
+  write(yes ? p_success("Character created.") : p_warn("Discarded."));
+}
+
+private void chose_skills(int *idx, string *items, int st) {
+  if (st != TUI_RL_DONE) {
+    write("[cancelled]\n");
+    return;
+  }
+  this_player()->tui_confirm((: confirmed :),
+                             "Create with " + implode(items, ", ") + "?", 1);
+}
+
+private void chose_class(int idx, string item, int st) {
+  if (st != TUI_RL_DONE) {
+    write("[cancelled]\n");
+    return;
+  }
+  this_player()->tui_multiselect((: chose_skills :), "Pick skills for the " + item + ":",
+                                 ({ "swords", "archery", "alchemy", "lockpicking",
+                                    "diplomacy", "cartography" }),
+                                 ([ "height": 4 ]));
+}
+
+// --- inline printers showcase ---------------------------------------------
+
+private void show_print() {
+  write(p_bigtext("TUI", "36"));
+  write(p_header("the /std/tui inline printers", 62));
+  write("\n");
+  write(p_info("printers compose with write() — no full-screen mode needed"));
+  write(p_success("this line came from p_success()"));
+  write(p_warn("p_warn() looks like this"));
+  write(p_error("and p_error() like this"));
+  write("\n");
+  write(p_panel("panel", "Boxed content, width-aware —\nwide chars work: 你好世界",
+                ([ "style": TUI_BOX_ROUND ])));
+  write(p_table(({ ({ "efun", "package", "notes" }),
+                   ({ "strwidth", "core", "display columns" }),
+                   ({ "terminal_colour", "contrib", "%^TOKEN%^ + wrapping" }),
+                   ({ "你好", "unicode", "double width" }) }),
+                ([ "header": 1 ])));
+  write(p_tree(({ ({ "std", ({ ({ "tui", ({ "ansi.lpc", "keys.lpc", "readline.lpc",
+                                            ({ "w", ({ "list.lpc", "table.lpc", "tree.lpc" }) }) }) }) }) }) })));
+  write("\n");
+  write(p_bars(({ ({ "orcs", 24 }), ({ "elves", 13 }), ({ "dwarves", 31 }) }),
+               ([ "width": 30, "attr": "36" ])));
+  write("\nsparkline  " + p_spark(({ 1, 3, 2, 8, 4, 6, 7, 2, 5, 8, 3, 1 })) + "\n");
+  write("progress   " + p_progress(64, 30) + "\n\n");
+  write(p_bullets(({ "bullet lists", ({ 1, "nest by depth" }), ({ 2, "three markers" }) })));
+}
+
+// ---------------------------------------------------------------------------
+
 int main(string arg) {
   object me = this_player();
 
   if (!me) return 0;
-  if (arg == "app") {
-    me->tui_open(new("/clone/tuidemo_app"));
-    return 1;
+  switch (arg) {
+    case "app":
+      me->tui_open(new("/clone/tuidemo_app"));
+      return 1;
+    case "dashboard":
+      me->tui_open(new("/clone/tuidemo_dash"));
+      return 1;
+    case "form":
+      me->tui_open(new("/clone/tuidemo_form"));
+      return 1;
+    case "print":
+      show_print();
+      return 1;
+    case "select":
+      me->tui_select((: chose_class :), "Pick a class:",
+                     ({ "warrior", "mage", "thief", "cleric", "ranger" }));
+      return 1;
   }
   write("TUI readline demo: editing keys, Up/Down history, Ctrl-R search,\n"
-        "Tab completion.  'quit' or Ctrl-D exits.\n");
+        "Tab completion.  'quit' or Ctrl-D exits.\n"
+        "Also try: tuidemo select | print | app | dashboard | form\n");
   me->tui_readline((: got_line :),
                    ([ "prompt": "tui> ", "completer": (: complete_verb :) ]));
   return 1;

--- a/testsuite/command/tuidemo.lpc
+++ b/testsuite/command/tuidemo.lpc
@@ -4,6 +4,7 @@
 //                      Tab completion; "quit" or Ctrl-D exits
 //   tuidemo select     inline select / multiselect / confirm prompts
 //   tuidemo print      the pterm-style inline printers, in plain line mode
+//   tuidemo charts     vertical bars, braille line chart, heatmap, sparkline
 //   tuidemo app        basic full-screen demo (list + textfield)
 //   tuidemo dashboard  animated dashboard: spinner, progress, sparkline,
 //                      live table and log (q quits)
@@ -94,6 +95,26 @@ private void show_print() {
   write(p_bullets(({ "bullet lists", ({ 1, "nest by depth" }), ({ 2, "three markers" }) })));
 }
 
+// --- charts showcase ---------------------------------------------------------
+
+private void show_charts() {
+  write(p_header("charts", 62));
+  write("\np_vbars — vertical bars with eighth-block tops:\n\n");
+  write(p_vbars(({ ({ "mon", 3 }), ({ "tue", 8 }), ({ "wed", 5 }),
+                   ({ "thu", 9 }), ({ "fri", 6 }) }),
+                ([ "height": 5, "values": 1, "attr": "33" ])));
+  write("\np_chart — braille line chart, two series:\n\n");
+  write(p_chart(({ ({ "hp", ({ 50, 52, 60, 55, 70, 65, 80, 90, 85, 95 }), "32" }),
+                   ({ "mana", ({ 90, 80, 82, 70, 65, 60, 50, 55, 40, 35 }), "36" }) }),
+                ([ "width": 50, "height": 8 ])));
+  write("\np_heatmap — logins per weekday/hour:\n\n");
+  write(p_heatmap(({ ({ 1, 3, 7, 4 }), ({ 2, 8, 9, 5 }), ({ 0, 4, 6, 2 }) }),
+                  ([ "ylabels": ({ "mon", "tue", "wed" }),
+                     "xlabels": ({ "00", "06", "12", "18" }), "cellw": 4 ])));
+  write("\np_spark — inline sparkline: " +
+        p_spark(({ 1, 3, 2, 8, 4, 6, 7, 2, 5, 8, 3, 1 })) + "\n");
+}
+
 // ---------------------------------------------------------------------------
 
 int main(string arg) {
@@ -113,6 +134,9 @@ int main(string arg) {
     case "print":
       show_print();
       return 1;
+    case "charts":
+      show_charts();
+      return 1;
     case "select":
       me->tui_select((: chose_class :), "Pick a class:",
                      ({ "warrior", "mage", "thief", "cleric", "ranger" }));
@@ -120,7 +144,7 @@ int main(string arg) {
   }
   write("TUI readline demo: editing keys, Up/Down history, Ctrl-R search,\n"
         "Tab completion.  'quit' or Ctrl-D exits.\n"
-        "Also try: tuidemo select | print | app | dashboard | form\n");
+        "Also try: tuidemo select | print | charts | app | dashboard | form\n");
   me->tui_readline((: got_line :),
                    ([ "prompt": "tui> ", "completer": (: complete_verb :) ]));
   return 1;

--- a/testsuite/include/tui.h
+++ b/testsuite/include/tui.h
@@ -20,6 +20,7 @@
 #define TUI_TERMINAL   "/std/tui/terminal"
 #define TUI_PRINT      "/std/tui/print"
 #define TUI_MENU       "/std/tui/menu"
+#define TUI_CANVAS     "/std/tui/canvas"
 
 // Special keys sit just above the Unicode range (max codepoint 0x10FFFF),
 // so they can never collide with a real character.

--- a/testsuite/include/tui.h
+++ b/testsuite/include/tui.h
@@ -18,6 +18,8 @@
 #define TUI_WIDGET     "/std/tui/widget"
 #define TUI_APP        "/std/tui/app"
 #define TUI_TERMINAL   "/std/tui/terminal"
+#define TUI_PRINT      "/std/tui/print"
+#define TUI_MENU       "/std/tui/menu"
 
 // Special keys sit just above the Unicode range (max codepoint 0x10FFFF),
 // so they can never collide with a real character.

--- a/testsuite/include/tui.h
+++ b/testsuite/include/tui.h
@@ -1,0 +1,79 @@
+#ifndef TUI_H
+#define TUI_H
+
+// ---------------------------------------------------------------------------
+// /std/tui — public contract.  See /std/tui/DESIGN.md.
+//
+// Key events are ints (special keys / modified keys) or strings (printable
+// text; a whole bracketed paste arrives as one string).  Mouse reports are
+// arrays: ({ TUI_EV_MOUSE, button, x, y, pressed }).
+// ---------------------------------------------------------------------------
+
+// Object paths (extension-less: the driver resolves .lpc/.c)
+#define TUI_DIR        "/std/tui"
+#define TUI_ANSI       "/std/tui/ansi"
+#define TUI_KEYS       "/std/tui/keys"
+#define TUI_READLINE   "/std/tui/readline"
+#define TUI_SCREEN     "/std/tui/screen"
+#define TUI_WIDGET     "/std/tui/widget"
+#define TUI_APP        "/std/tui/app"
+#define TUI_TERMINAL   "/std/tui/terminal"
+
+// Special keys sit just above the Unicode range (max codepoint 0x10FFFF),
+// so they can never collide with a real character.
+#define TUI_KEY_SPECIAL   0x110000
+#define TUI_KEY_UP        (TUI_KEY_SPECIAL + 1)
+#define TUI_KEY_DOWN      (TUI_KEY_SPECIAL + 2)
+#define TUI_KEY_RIGHT     (TUI_KEY_SPECIAL + 3)
+#define TUI_KEY_LEFT      (TUI_KEY_SPECIAL + 4)
+#define TUI_KEY_HOME      (TUI_KEY_SPECIAL + 5)
+#define TUI_KEY_END       (TUI_KEY_SPECIAL + 6)
+#define TUI_KEY_PGUP      (TUI_KEY_SPECIAL + 7)
+#define TUI_KEY_PGDN      (TUI_KEY_SPECIAL + 8)
+#define TUI_KEY_INSERT    (TUI_KEY_SPECIAL + 9)
+#define TUI_KEY_DELETE    (TUI_KEY_SPECIAL + 10)
+#define TUI_KEY_ENTER     (TUI_KEY_SPECIAL + 11)
+#define TUI_KEY_TAB       (TUI_KEY_SPECIAL + 12)
+#define TUI_KEY_BACKSPACE (TUI_KEY_SPECIAL + 13)
+#define TUI_KEY_ESC       (TUI_KEY_SPECIAL + 14)
+#define TUI_KEY_F1        (TUI_KEY_SPECIAL + 21)
+#define TUI_KEY_F2        (TUI_KEY_SPECIAL + 22)
+#define TUI_KEY_F3        (TUI_KEY_SPECIAL + 23)
+#define TUI_KEY_F4        (TUI_KEY_SPECIAL + 24)
+#define TUI_KEY_F5        (TUI_KEY_SPECIAL + 25)
+#define TUI_KEY_F6        (TUI_KEY_SPECIAL + 26)
+#define TUI_KEY_F7        (TUI_KEY_SPECIAL + 27)
+#define TUI_KEY_F8        (TUI_KEY_SPECIAL + 28)
+#define TUI_KEY_F9        (TUI_KEY_SPECIAL + 29)
+#define TUI_KEY_F10       (TUI_KEY_SPECIAL + 30)
+#define TUI_KEY_F11       (TUI_KEY_SPECIAL + 31)
+#define TUI_KEY_F12       (TUI_KEY_SPECIAL + 32)
+#define TUI_KEY_UNKNOWN   (TUI_KEY_SPECIAL + 63)
+
+// Modifier bits, above the special-key range.
+#define TUI_MOD_SHIFT     0x200000
+#define TUI_MOD_ALT       0x400000
+#define TUI_MOD_CTRL      0x800000
+#define TUI_MODS          (TUI_MOD_SHIFT | TUI_MOD_ALT | TUI_MOD_CTRL)
+
+// Convenience: TUI_CTRL('a') is what Ctrl-A decodes to.
+#define TUI_CTRL(c)       (TUI_MOD_CTRL | (c))
+#define TUI_ALT(c)        (TUI_MOD_ALT | (c))
+
+// Array-event kinds (first element of an array event)
+#define TUI_EV_MOUSE      1
+#define TUI_EV_CPR        2   /* cursor position report: ({ kind, row, col }) */
+
+// readline engine states (rl_feed() return / rl_state())
+#define TUI_RL_MORE       0   /* still editing */
+#define TUI_RL_DONE       1   /* line accepted (Enter) */
+#define TUI_RL_ABORT      2   /* Ctrl-C */
+#define TUI_RL_EOF        3   /* Ctrl-D on an empty line */
+
+// Box styles for scr_box()
+#define TUI_BOX_SINGLE    0
+#define TUI_BOX_DOUBLE    1
+#define TUI_BOX_ROUND     2
+#define TUI_BOX_ASCII     3
+
+#endif

--- a/testsuite/single/tests/std/tui/ansi.lpc
+++ b/testsuite/single/tests/std/tui/ansi.lpc
@@ -1,0 +1,54 @@
+// /std/tui/ansi: escape builders and the visible-width toolkit.
+
+#include <tui.h>
+
+void do_tests() {
+  object a = clone_object(TUI_ANSI);
+
+  // cursor addressing is 0-based x,y -> 1-based row;col
+  ASSERT_EQ("\e[3;6H", a->ansi_cup(5, 2));
+  ASSERT_EQ("\e[1;1H", a->ansi_cup(0, 0));
+  ASSERT_EQ("\e[2C", a->ansi_fwd(2));
+  ASSERT_EQ("", a->ansi_fwd(0));
+  ASSERT_EQ("", a->ansi_back(-1));
+  ASSERT_EQ("\e[0K", a->ansi_el(0));
+  ASSERT_EQ("\e[2J", a->ansi_ed(2));
+  ASSERT_EQ("\e[1;36m", a->ansi_sgr("1;36"));
+
+  // colours are SGR parameter strings
+  ASSERT_EQ("36", a->ansi_fg(6));
+  ASSERT_EQ("97", a->ansi_fg(15));
+  ASSERT_EQ("38;5;208", a->ansi_fg(208));
+  ASSERT_EQ("41", a->ansi_bg(1));
+  ASSERT_EQ("100", a->ansi_bg(8));
+  ASSERT_EQ("38;2;1;2;3", a->ansi_rgb_fg(1, 2, 3));
+
+  // strip_ansi: CSI, OSC (BEL and ST terminated), two-char escapes
+  ASSERT_EQ("hello", a->strip_ansi("\e[1;36mhello\e[0m"));
+  ASSERT_EQ("ab", a->strip_ansi("a\e]0;title\ab"));
+  ASSERT_EQ("ab", a->strip_ansi("a\e]0;title\e\\b"));
+  ASSERT_EQ("abc", a->strip_ansi("\e7abc"));
+  ASSERT_EQ("", a->strip_ansi("\e[2J\e[?25l"));
+  ASSERT_EQ("x", a->strip_ansi("x\e["));  // truncated sequence at end
+  ASSERT_EQ("plain", a->strip_ansi("plain"));
+
+  // visible width: escapes are free, wide chars count 2
+  ASSERT_EQ(5, a->visible_width("\e[31mhello\e[0m"));
+  ASSERT_EQ(4, a->visible_width("\e[1m你好\e[0m"));
+  ASSERT_EQ(0, a->visible_width(""));
+
+  // wslice: column-addressed slicing of plain text
+  ASSERT_EQ("bc", a->wslice("abcd", 1, 2));
+  ASSERT_EQ("abcd", a->wslice("abcd", 0, 10));
+  ASSERT_EQ("", a->wslice("abcd", 0, 0));
+  ASSERT_EQ("你", a->wslice("你好", 0, 3));   // 好 would straddle the edge
+  ASSERT_EQ("你", a->wslice("a你b", 1, 2));
+  ASSERT_EQ("b", a->wslice("a你b", 3, 2));    // leading half of 你 excluded
+
+  // wpad pads, never truncates
+  ASSERT_EQ("ab  ", a->wpad("ab", 4));
+  ASSERT_EQ("你好", a->wpad("你好", 3));
+  ASSERT_EQ("你好 ", a->wpad("你好", 5));
+
+  destruct(a);
+}

--- a/testsuite/single/tests/std/tui/charts.lpc
+++ b/testsuite/single/tests/std/tui/charts.lpc
@@ -1,0 +1,103 @@
+// The chart layer: braille canvas, p_vbars, p_chart, p_heatmap, w/chart.
+
+#include <tui.h>
+
+void do_tests() {
+  object cv = clone_object(TUI_CANVAS);
+  object p = clone_object(TUI_PRINT);
+  object w, scr;
+  string o;
+
+  // --- canvas dot math ---------------------------------------------------
+  cv->c_resize(4, 1);
+  ASSERT_EQ(8, cv->c_width_dots());
+  ASSERT_EQ(4, cv->c_height_dots());
+
+  cv->c_set(0, 0);
+  ASSERT_EQ(1, cv->c_get(0, 0));
+  ASSERT_EQ(({ "⠁", "" }), cv->c_cell(0, 0));      // U+2801, dot 1
+  cv->c_set(1, 0, "36");
+  ASSERT_EQ(({ "⠉", "36" }), cv->c_cell(0, 0));    // dots 1+4 (0x2809)
+  cv->c_set(0, 3);
+  ASSERT_EQ(({ "⡉", "36" }), cv->c_cell(0, 0));    // + dot 7 (0x2849)
+  cv->c_unset(0, 3);
+  ASSERT_EQ(({ "⠉", "36" }), cv->c_cell(0, 0));
+  ASSERT_EQ(({ " ", "" }), cv->c_cell(3, 0));       // untouched cell
+  ASSERT_EQ(0, cv->c_get(99, 99));                  // out of range is safe
+  cv->c_set(-1, 0);
+  cv->c_set(99, 99);
+
+  // a horizontal line through the top dot row of every cell
+  cv->c_clear();
+  cv->c_line(0, 0, 7, 0);
+  ASSERT_EQ("⠉⠉⠉⠉", cv->c_row(0));
+
+  // c_plot puts endpoints where they belong (bottom-left, top-right)
+  cv->c_resize(1, 1);
+  cv->c_plot(({ 0, 3 }), 0, 3);
+  ASSERT_EQ(1, cv->c_get(0, 3));
+  ASSERT_EQ(1, cv->c_get(1, 0));
+
+  // c_row emits SGR only when the attr changes
+  cv->c_resize(2, 1);
+  cv->c_set(0, 0, "36");
+  cv->c_set(2, 0, "36");
+  o = cv->c_row(0);
+  ASSERT_EQ("\e[0;36m⠁⠁\e[0m", o);
+  destruct(cv);
+
+  // --- p_vbars --------------------------------------------------------------
+  o = p->p_vbars(({ ({ "ab", 8 }), ({ "cd", 4 }) }), ([ "height": 2 ]));
+  ASSERT_EQ("███     \n███ ███ \nab  cd  \n", o);
+  // partial top cell in eighths
+  o = p->p_vbars(({ ({ "x", 4 }), ({ "y", 8 }) }), ([ "height": 1 ]));
+  ASSERT_EQ("▄▄▄ ███ \nx   y   \n", o);
+  // value row + a 7/8ths partial
+  o = p->p_vbars(({ ({ "x", 7 }), ({ "y", 8 }) }), ([ "height": 1, "values": 1 ]));
+  ASSERT_EQ("7   8   \n▇▇▇ ███ \nx   y   \n", o);
+  ASSERT_EQ("", p->p_vbars(({}), 0));
+
+  // --- p_chart ----------------------------------------------------------------
+  o = p->p_chart(({ 0, 3, 0 }), ([ "width": 3, "height": 1 ]));
+  ASSERT(strsrch(o, "3┤") != -1);                   // y-axis gutter, max label
+  ASSERT_EQ(1, sizeof(explode(o, "\n")));           // height rows, no legend
+  o = p->p_chart(({ ({ "hp", ({ 1, 5, 3 }), "32" }) }),
+                 ([ "width": 6, "height": 2 ]));
+  ASSERT(strsrch(o, "5┤") != -1);
+  ASSERT(strsrch(o, "1┤") != -1);
+  ASSERT(strsrch(o, "\e[32m●") != -1);              // coloured legend bullet
+  ASSERT(strsrch(o, " hp") != -1);                  // legend label
+  o = p->p_chart(({ 1, 2 }), ([ "width": 2, "height": 1, "axis": 0 ]));
+  ASSERT(strsrch(o, "┤") == -1);                    // gutter suppressed
+  ASSERT_EQ("", p->p_chart(({}), 0));
+
+  // --- p_heatmap ----------------------------------------------------------------
+  o = p->p_heatmap(({ ({ 0, 5 }), ({ 10, 10 }) }));
+  ASSERT(strsrch(o, "48;5;17") != -1);              // coolest ramp colour
+  ASSERT(strsrch(o, "48;5;196") != -1);             // hottest ramp colour
+  o = p->p_heatmap(({ ({ 0, 1 }) }),
+                   ([ "ylabels": ({ "row" }), "xlabels": ({ "aa", "bb" }), "cellw": 2 ]));
+  ASSERT(strsrch(o, "row ") != -1);
+  ASSERT(strsrch(o, "aabb") != -1);
+  ASSERT_EQ("", p->p_heatmap(({}), 0));
+  destruct(p);
+
+  // --- w/chart ---------------------------------------------------------------------
+  scr = clone_object(TUI_SCREEN);
+  scr->scr_resize(4, 2);
+  scr->scr_frame();
+  w = new("/std/tui/w/chart");
+  w->set_geometry(0, 0, 2, 1);
+  ASSERT_EQ(0, w->add_series("traffic", "36"));
+  foreach (int v in ({ 1, 2, 3, 4, 5, 6 })) w->add_point(0, v);
+  ASSERT_EQ(({ 3, 4, 5, 6 }), w->query_data(0));    // rolled to 2*ww points
+  w->set_range(0, 10);
+  w->draw(scr);
+  o = scr->scr_frame();
+  ASSERT(strsrch(o, "\e[0;36m") != -1);             // series colour
+  ASSERT(strsrch(o, "⠀") == -1);                    // no blank braille cells
+  ASSERT(strlen(o) > 8);                             // something was painted
+  w->remove();
+  destruct(w);
+  destruct(scr);
+}

--- a/testsuite/single/tests/std/tui/keys.lpc
+++ b/testsuite/single/tests/std/tui/keys.lpc
@@ -1,0 +1,88 @@
+// /std/tui/keys: the keystroke decoder, fed exactly as get_char() delivers
+// (one keystroke per call), and also in batches.
+
+#include <tui.h>
+
+void do_tests() {
+  object k = clone_object(TUI_KEYS);
+
+  // plain text and controls
+  ASSERT_EQ(({ "a" }), k->feed("a"));
+  ASSERT_EQ(({ "你" }), k->feed("你"));
+  ASSERT_EQ(({ TUI_KEY_ENTER }), k->feed("\r"));
+  ASSERT_EQ(({}), k->feed("\n"));                    // CR LF collapses
+  ASSERT_EQ(({ TUI_KEY_ENTER }), k->feed("\n"));     // lone LF
+  ASSERT_EQ(({ TUI_KEY_TAB }), k->feed("\t"));
+  ASSERT_EQ(({ TUI_KEY_BACKSPACE }), k->feed("\b"));
+  ASSERT_EQ(({ TUI_KEY_BACKSPACE }), k->feed(sprintf("%c", 127)));
+  ASSERT_EQ(({ TUI_KEY_BACKSPACE }), k->feed(""));   // pre-2026 driver quirk
+  ASSERT_EQ(({ TUI_CTRL('a') }), k->feed(sprintf("%c", 1)));
+  ASSERT_EQ(({ TUI_CTRL('z') }), k->feed(sprintf("%c", 26)));
+
+  // an arrow key split across callbacks, byte by byte
+  ASSERT_EQ(({}), k->feed("\e"));
+  ASSERT_EQ(1, k->has_pending());
+  ASSERT_EQ(({}), k->feed("["));
+  ASSERT_EQ(0, k->has_pending());                    // no longer a lone ESC
+  ASSERT_EQ(({ TUI_KEY_UP }), k->feed("A"));
+
+  // batched sequences
+  ASSERT_EQ(({ TUI_KEY_DOWN }), k->feed("\e[B"));
+  ASSERT_EQ(({ TUI_KEY_LEFT, TUI_KEY_RIGHT }), k->feed("\e[D\e[C"));
+  ASSERT_EQ(({ TUI_KEY_HOME }), k->feed("\e[H"));
+  ASSERT_EQ(({ TUI_KEY_END }), k->feed("\e[4~"));
+  ASSERT_EQ(({ TUI_KEY_HOME }), k->feed("\e[1~"));
+  ASSERT_EQ(({ TUI_KEY_PGUP }), k->feed("\e[5~"));
+  ASSERT_EQ(({ TUI_KEY_DELETE }), k->feed("\e[3~"));
+  ASSERT_EQ(({ TUI_KEY_END }), k->feed("\eOF"));
+  ASSERT_EQ(({ TUI_KEY_F1 }), k->feed("\eOP"));
+  ASSERT_EQ(({ TUI_KEY_F5 }), k->feed("\e[15~"));
+  ASSERT_EQ(({ TUI_KEY_F12 }), k->feed("\e[24~"));
+  ASSERT_EQ(({ TUI_MOD_SHIFT | TUI_KEY_TAB }), k->feed("\e[Z"));
+
+  // xterm modifiers: 1;5 = ctrl, 1;3 = alt, 1;2 = shift
+  ASSERT_EQ(({ TUI_MOD_CTRL | TUI_KEY_RIGHT }), k->feed("\e[1;5C"));
+  ASSERT_EQ(({ TUI_MOD_ALT | TUI_KEY_UP }), k->feed("\e[1;3A"));
+  ASSERT_EQ(({ TUI_MOD_SHIFT | TUI_KEY_LEFT }), k->feed("\e[1;2D"));
+  ASSERT_EQ(({ (TUI_MOD_CTRL | TUI_MOD_SHIFT) | TUI_KEY_DELETE }), k->feed("\e[3;6~"));
+
+  // alt-prefixed keys
+  ASSERT_EQ(({ TUI_MOD_ALT | 'b' }), k->feed("\eb"));
+  ASSERT_EQ(({ TUI_MOD_ALT | TUI_KEY_BACKSPACE }), k->feed("\e\b"));
+
+  // lone ESC resolves only via flush() (the glue's timeout)
+  ASSERT_EQ(({}), k->feed("\e"));
+  ASSERT_EQ(1, k->has_pending());
+  ASSERT_EQ(({ TUI_KEY_ESC }), k->flush());
+  ASSERT_EQ(({}), k->flush());
+  ASSERT_EQ(0, k->has_pending());
+
+  // a partially received CSI is never flushed (mid-sequence lag)
+  ASSERT_EQ(({}), k->feed("\e["));
+  ASSERT_EQ(({}), k->flush());
+  ASSERT_EQ(({ TUI_KEY_UP }), k->feed("A"));
+
+  // bracketed paste arrives as one text event, however it is chunked
+  ASSERT_EQ(({ "hello" }), k->feed("\e[200~hello\e[201~"));
+  ASSERT_EQ(({}), k->feed("\e[200~he"));
+  ASSERT_EQ(({}), k->feed("llo wo"));
+  ASSERT_EQ(({ "hello world" }), k->feed("rld\e[201~"));
+  // paste content may contain escape-sequence bytes verbatim
+  ASSERT_EQ(({ "a\rb" }), k->feed("\e[200~a\rb\e[201~"));
+
+  // SGR mouse: press and release, coordinates 0-based
+  ASSERT_EQ(({ ({ TUI_EV_MOUSE, 0, 9, 4, 1 }) }), k->feed("\e[<0;10;5M"));
+  ASSERT_EQ(({ ({ TUI_EV_MOUSE, 0, 9, 4, 0 }) }), k->feed("\e[<0;10;5m"));
+
+  // cursor position report
+  ASSERT_EQ(({ ({ TUI_EV_CPR, 12, 40 }) }), k->feed("\e[12;40R"));
+
+  // OSC responses are swallowed
+  ASSERT_EQ(({}), k->feed("\e]11;rgb:1/2/3\a"));
+  ASSERT_EQ(({ "x" }), k->feed("x"));
+
+  // unknown finals surface as TUI_KEY_UNKNOWN, not stray text
+  ASSERT_EQ(({ TUI_KEY_UNKNOWN }), k->feed("\e[99x"));
+
+  destruct(k);
+}

--- a/testsuite/single/tests/std/tui/menu.lpc
+++ b/testsuite/single/tests/std/tui/menu.lpc
@@ -1,0 +1,74 @@
+// /std/tui/menu: the inline select / multiselect engine.
+
+#include <tui.h>
+
+void do_tests() {
+  object m = clone_object(TUI_MENU);
+  string o;
+
+  // single select
+  o = m->m_begin("Pick a class:", ({ "warrior", "mage", "thief" }));
+  ASSERT(strsrch(o, "? Pick a class:") != -1);
+  ASSERT(strsrch(o, "❯") != -1);
+  ASSERT(strsrch(o, "warrior") != -1);
+  ASSERT_EQ(TUI_RL_MORE, m->m_state());
+
+  ASSERT_EQ(TUI_RL_MORE, m->m_feed(TUI_KEY_DOWN));
+  ASSERT_EQ(TUI_RL_DONE, m->m_feed(TUI_KEY_ENTER));
+  ASSERT_EQ(1, m->m_result());
+  ASSERT_EQ("mage", m->m_item(m->m_result()));
+  o = m->m_take_output();
+  ASSERT(strsrch(o, "mage") != -1);       // collapsed answer line
+  ASSERT(strsrch(o, "\e[0J") != -1);      // list cleared below
+
+  // keys after completion are ignored
+  ASSERT_EQ(TUI_RL_DONE, m->m_feed(TUI_KEY_DOWN));
+  ASSERT_EQ(1, m->m_result());
+
+  // abort restores nothing but reports the state
+  m->m_begin("Q:", ({ "x", "y" }));
+  ASSERT_EQ(TUI_RL_ABORT, m->m_feed(TUI_KEY_ESC));
+  m->m_begin("Q:", ({ "x", "y" }));
+  ASSERT_EQ(TUI_RL_ABORT, m->m_feed(TUI_CTRL('c')));
+
+  // multiselect: space toggles, enter accepts
+  o = m->m_begin("Skills:", ({ "a", "b", "c" }), ([ "multi": 1 ]));
+  ASSERT(strsrch(o, "[ ]") != -1);
+  m->m_feed(" ");                          // check a
+  m->m_feed(TUI_KEY_DOWN);
+  m->m_feed(" ");                          // check b
+  m->m_feed(" ");                          // uncheck b
+  m->m_feed(TUI_KEY_DOWN);
+  m->m_feed(" ");                          // check c
+  ASSERT_EQ(({ 0, 2 }), m->m_result());
+  o = m->m_take_output();
+  ASSERT(strsrch(o, "[x]") != -1);
+  ASSERT_EQ(TUI_RL_DONE, m->m_feed(TUI_KEY_ENTER));
+  ASSERT_EQ(({ 0, 2 }), m->m_result());
+
+  // enter with nothing checked picks the item under the cursor
+  m->m_begin("M2:", ({ "a", "b" }), ([ "multi": 1 ]));
+  m->m_feed(TUI_KEY_DOWN);
+  ASSERT_EQ(TUI_RL_DONE, m->m_feed(TUI_KEY_ENTER));
+  ASSERT_EQ(({ 1 }), m->m_result());
+
+  // preselection
+  m->m_begin("M3:", ({ "a", "b", "c" }), ([ "multi": 1, "checked": ({ 2 }) ]));
+  ASSERT_EQ(({ 2 }), m->m_result());
+
+  // height windowing: only `height` choices visible, overflow marked
+  o = m->m_begin("H:", ({ "one", "two", "three", "four", "five" }), ([ "height": 2 ]));
+  ASSERT(strsrch(o, "one") != -1);
+  ASSERT(strsrch(o, "three") == -1);
+  ASSERT(strsrch(o, "…") != -1);
+  m->m_feed(TUI_KEY_END);
+  o = m->m_take_output();
+  ASSERT(strsrch(o, "five") != -1);
+  ASSERT(strsrch(o, "one") == -1);
+
+  // an empty choice list aborts immediately
+  m->m_begin("E:", ({}));
+  ASSERT_EQ(TUI_RL_ABORT, m->m_state());
+
+  destruct(m);
+}

--- a/testsuite/single/tests/std/tui/print.lpc
+++ b/testsuite/single/tests/std/tui/print.lpc
@@ -1,0 +1,63 @@
+// /std/tui/print: the pterm-style inline printers.
+
+#include <tui.h>
+
+void do_tests() {
+  object p = clone_object(TUI_PRINT);
+  string o;
+
+  // table: width-aware cells (你 is 2 columns wide), header rule
+  o = p->p_table(({ ({ "a", "bb" }), ({ "你", "c" }) }), ([ "header": 1 ]));
+  ASSERT_EQ("┌────┬────┐\n"
+            "│ a  │ bb │\n"
+            "├────┼────┤\n"
+            "│ 你 │ c  │\n"
+            "└────┴────┘\n", o);
+  o = p->p_table(({ ({ "x" }) }), ([ "style": TUI_BOX_ASCII ]));
+  ASSERT_EQ("+---+\n| x |\n+---+\n", o);
+  ASSERT_EQ("", p->p_table(({}), 0));
+
+  // tree: both shapes — a rooted tree and a node list
+  o = p->p_tree(({ "root", ({ "a", ({ "b", ({ "c" }) }) }) }));
+  ASSERT_EQ("root\n├── a\n└── b\n    └── c\n", o);
+  o = p->p_tree(({ "x", "y" }));
+  ASSERT_EQ("├── x\n└── y\n", o);
+
+  // bar chart scales to the widest value
+  o = p->p_bars(({ ({ "ab", 4 }), ({ "c", 2 }) }), ([ "width": 4 ]));
+  ASSERT_EQ("ab ████ 4\nc  ██ 2\n", o);
+
+  // sparkline
+  ASSERT_EQ("▁█", p->p_spark(({ 1, 8 })));
+  ASSERT_EQ("▁▄█", p->p_spark(({ 0, 4, 8 })));
+
+  // progress string
+  ASSERT_EQ("█████░░░░░  50%", p->p_progress(50, 10));
+  ASSERT_EQ("░░░░░░░░░░   0%", p->p_progress(-5, 10));
+  ASSERT_EQ("██████████ 100%", p->p_progress(150, 10));
+
+  // panel
+  o = p->p_panel("t", "ab\n你");
+  ASSERT(strsrch(o, "─ t ") != -1);
+  ASSERT(strsrch(o, "│ ab") != -1);
+  ASSERT(strsrch(o, "│ 你") != -1);
+  ASSERT(strsrch(o, "└") != -1);
+
+  // bullets nest by depth
+  ASSERT_EQ("• x\n  ◦ y\n    ▪ z\n", p->p_bullets(({ "x", ({ 1, "y" }), ({ 2, "z" }) })));
+
+  // header centers inside a styled bar
+  ASSERT_EQ("\e[1;7m  hi  \e[0m\n", p->p_header("hi", 6));
+
+  // prefixes
+  ASSERT(strsrch(p->p_info("m"), "INFO") != -1);
+  ASSERT(strsrch(p->p_success("m"), " OK ") != -1);
+  ASSERT(strsrch(p->p_warn("m"), "WARN") != -1);
+  ASSERT(strsrch(p->p_error("m"), "FAIL") != -1);
+
+  // bigtext renders via /std/bitmap_font (or degrades to plain text)
+  o = p->p_bigtext("A");
+  ASSERT(stringp(o) && strlen(o) > 0);
+
+  destruct(p);
+}

--- a/testsuite/single/tests/std/tui/readline.lpc
+++ b/testsuite/single/tests/std/tui/readline.lpc
@@ -1,0 +1,202 @@
+// /std/tui/readline: whole editing sessions scripted as event arrays.
+
+#include <tui.h>
+
+private object r;
+
+private void feed_text(string s) {
+  int i;
+
+  for (i = 0; i < strlen(s); i++) r->rl_feed(s[i..i]);
+}
+
+private void feed(mixed *evs) {
+  foreach (mixed ev in evs) r->rl_feed(ev);
+}
+
+void do_tests() {
+  string o;
+
+  r = clone_object(TUI_READLINE);
+  r->rl_set_width(40);
+
+  // --- basic editing -------------------------------------------------
+  o = r->rl_begin();
+  ASSERT(strsrch(o, "> ") != -1);  // initial paint shows the prompt
+  feed_text("hello");
+  ASSERT_EQ("hello", r->rl_line());
+  ASSERT_EQ(5, r->rl_cursor());
+
+  feed(({ TUI_KEY_LEFT, TUI_KEY_LEFT }));
+  ASSERT_EQ(3, r->rl_cursor());
+  feed_text("X");
+  ASSERT_EQ("helXlo", r->rl_line());
+  feed(({ TUI_KEY_BACKSPACE }));
+  ASSERT_EQ("hello", r->rl_line());
+  feed(({ TUI_KEY_HOME }));
+  ASSERT_EQ(0, r->rl_cursor());
+  feed(({ TUI_KEY_DELETE }));
+  ASSERT_EQ("ello", r->rl_line());
+  feed(({ TUI_CTRL('e') }));
+  ASSERT_EQ(4, r->rl_cursor());
+  feed(({ TUI_CTRL('a') }));
+  ASSERT_EQ(0, r->rl_cursor());
+
+  // kill to end / yank
+  feed(({ TUI_CTRL('k') }));
+  ASSERT_EQ("", r->rl_line());
+  feed(({ TUI_CTRL('y') }));
+  ASSERT_EQ("ello", r->rl_line());
+
+  // accept
+  ASSERT_EQ(TUI_RL_DONE, r->rl_feed(TUI_KEY_ENTER));
+  ASSERT_EQ("ello", r->rl_line());
+  ASSERT_EQ(({ "ello" }), r->rl_history());
+  o = r->rl_take_output();
+  ASSERT(strsrch(o, "\r\n") != -1);  // finishing emits a newline
+
+  // events after completion are ignored until the next begin
+  ASSERT_EQ(TUI_RL_DONE, r->rl_feed("x"));
+  ASSERT_EQ("ello", r->rl_line());
+
+  // --- word motion and kills ------------------------------------------
+  r->rl_begin();
+  feed_text("foo bar baz");
+  feed(({ TUI_MOD_ALT | 'b' }));
+  ASSERT_EQ(8, r->rl_cursor());              // start of "baz"
+  feed(({ TUI_MOD_ALT | 'b' }));
+  ASSERT_EQ(4, r->rl_cursor());              // start of "bar"
+  feed(({ TUI_MOD_ALT | 'f' }));
+  ASSERT_EQ(7, r->rl_cursor());              // end of "bar"
+  feed(({ TUI_KEY_END, TUI_CTRL('w') }));
+  ASSERT_EQ("foo bar ", r->rl_line());       // C-w killed "baz"
+  feed(({ TUI_CTRL('u') }));
+  ASSERT_EQ("", r->rl_line());
+  feed(({ TUI_CTRL('y') }));
+  ASSERT_EQ("foo bar ", r->rl_line());
+
+  // transpose
+  r->rl_begin("ab");
+  feed(({ TUI_CTRL('t') }));
+  ASSERT_EQ("ba", r->rl_line());
+
+  // EOF only on an empty line
+  r->rl_begin();
+  ASSERT_EQ(TUI_RL_EOF, r->rl_feed(TUI_CTRL('d')));
+  r->rl_begin("x");
+  feed(({ TUI_KEY_HOME }));
+  ASSERT_EQ(TUI_RL_MORE, r->rl_feed(TUI_CTRL('d')));  // deletes instead
+  ASSERT_EQ("", r->rl_line());
+
+  // abort
+  ASSERT_EQ(TUI_RL_ABORT, r->rl_feed(TUI_CTRL('c')));
+
+  // --- history ---------------------------------------------------------
+  destruct(r);
+  r = clone_object(TUI_READLINE);
+  r->rl_set_width(40);
+  r->rl_set_history(({ "first", "second", "third" }));
+
+  r->rl_begin();
+  feed_text("live");
+  feed(({ TUI_KEY_UP }));
+  ASSERT_EQ("third", r->rl_line());
+  feed(({ TUI_KEY_UP, TUI_KEY_UP }));
+  ASSERT_EQ("first", r->rl_line());
+  feed(({ TUI_KEY_UP }));                    // already at the oldest
+  ASSERT_EQ("first", r->rl_line());
+  feed(({ TUI_KEY_DOWN, TUI_KEY_DOWN, TUI_KEY_DOWN }));
+  ASSERT_EQ("live", r->rl_line());           // the live edit came back
+
+  // duplicates are not appended
+  r->rl_begin("third");
+  r->rl_feed(TUI_KEY_ENTER);
+  ASSERT_EQ(({ "first", "second", "third" }), r->rl_history());
+
+  // --- incremental search -----------------------------------------------
+  destruct(r);
+  r = clone_object(TUI_READLINE);
+  r->rl_set_width(40);
+  r->rl_set_history(({ "make bread", "eat soup", "make tea" }));
+
+  r->rl_begin();
+  r->rl_feed(TUI_CTRL('r'));
+  ASSERT_EQ(1, r->rl_searching());
+  o = r->rl_take_output();
+  ASSERT(strsrch(o, "reverse-i-search") != -1);
+  feed_text("ma");
+  ASSERT_EQ("make tea", r->rl_line());       // newest match first
+  r->rl_feed(TUI_CTRL('r'));
+  ASSERT_EQ("make bread", r->rl_line());     // step to the older match
+  ASSERT_EQ(TUI_RL_DONE, r->rl_feed(TUI_KEY_ENTER));  // accept & submit
+  ASSERT_EQ("make bread", r->rl_line());
+
+  // C-g restores the pre-search line
+  r->rl_begin("draft");
+  r->rl_feed(TUI_CTRL('r'));
+  feed_text("soup");
+  ASSERT_EQ("eat soup", r->rl_line());
+  r->rl_feed(TUI_CTRL('g'));
+  ASSERT_EQ(0, r->rl_searching());
+  ASSERT_EQ("draft", r->rl_line());
+
+  // failed search flags itself in the prompt
+  r->rl_begin();
+  r->rl_feed(TUI_CTRL('r'));
+  feed_text("zzz");
+  o = r->rl_take_output();
+  ASSERT(strsrch(o, "failed") != -1);
+
+  // --- masking ----------------------------------------------------------
+  destruct(r);
+  r = clone_object(TUI_READLINE);
+  r->rl_set_width(40);
+  r->rl_set_prompt("pw: ");
+  r->rl_set_masked(1);
+  r->rl_begin();
+  feed_text("secret");
+  o = r->rl_take_output();
+  ASSERT(strsrch(o, "secret") == -1);
+  ASSERT(strsrch(o, "******") != -1);
+  ASSERT_EQ("secret", r->rl_line());
+
+  // --- completion ---------------------------------------------------------
+  destruct(r);
+  r = clone_object(TUI_READLINE);
+  r->rl_set_width(40);
+  r->rl_set_completer((: ({ "look", "listen", "quit" }) :));
+  r->rl_begin();
+  feed_text("lo");
+  r->rl_feed(TUI_KEY_TAB);
+  ASSERT_EQ("look ", r->rl_line());          // unique match completes + space
+  r->rl_begin();
+  feed_text("l");
+  r->rl_feed(TUI_KEY_TAB);
+  ASSERT_EQ("l", r->rl_line());              // ambiguous: nothing to extend
+  r->rl_take_output();
+  r->rl_feed(TUI_KEY_TAB);                   // second Tab lists candidates
+  o = r->rl_take_output();
+  ASSERT(strsrch(o, "look  listen") != -1);
+
+  // --- horizontal scrolling ------------------------------------------------
+  destruct(r);
+  r = clone_object(TUI_READLINE);
+  r->rl_set_width(20);
+  r->rl_set_prompt("> ");
+  r->rl_begin();
+  feed_text("abcdefghijklmnopqrstuvwxyz");
+  ASSERT(r->rl_scroll() > 0);                // line longer than the viewport
+  o = r->rl_take_output();
+  ASSERT(strsrch(o, "<") != -1);             // left scroll marker shown
+  feed(({ TUI_KEY_HOME }));
+  ASSERT_EQ(0, r->rl_scroll());
+  o = r->rl_take_output();
+  ASSERT(strsrch(o, ">") != -1);             // right overflow marker shown
+
+  // width changes re-render sanely
+  r->rl_set_width(80);
+  ASSERT_EQ(0, r->rl_scroll());
+  ASSERT_EQ("abcdefghijklmnopqrstuvwxyz", r->rl_line());
+
+  destruct(r);
+}

--- a/testsuite/single/tests/std/tui/screen.lpc
+++ b/testsuite/single/tests/std/tui/screen.lpc
@@ -1,0 +1,85 @@
+// /std/tui/screen: cell grid, minimal-diff rendering, wide-char handling.
+
+#include <tui.h>
+
+void do_tests() {
+  object s = clone_object(TUI_SCREEN);
+  string f;
+
+  s->scr_resize(10, 3);
+
+  // first frame: reset + clear + hide cursor, nothing else (grid is blank)
+  ASSERT_EQ("\e[0m\e[2J\e[?25l", s->scr_frame());
+
+  // second frame paints only the touched cells
+  s->scr_put(1, 1, "hi", "1");
+  ASSERT_EQ("\e[2;2H\e[0;1mhi\e[0m", s->scr_frame());
+
+  // no change -> empty frame
+  ASSERT_EQ("", s->scr_frame());
+  s->scr_put(1, 1, "hi", "1");
+  ASSERT_EQ("", s->scr_frame());
+
+  // single-cell change repaints one cell
+  s->scr_put(2, 1, "o", "1");
+  ASSERT_EQ("\e[2;3H\e[0;1mo\e[0m", s->scr_frame());
+
+  // attribute-only change is a change
+  s->scr_put(1, 1, "h", "1;7");
+  f = s->scr_frame();
+  ASSERT(strsrch(f, "\e[0;1;7mh") != -1);
+
+  // scr_invalidate forces a full repaint
+  s->scr_invalidate();
+  f = s->scr_frame();
+  ASSERT(strsrch(f, "\e[2J") != -1);
+  ASSERT(strsrch(f, "hi") == -1);  // h and o have different attrs now
+  ASSERT(strsrch(f, "o") != -1);
+
+  // --- wide characters --------------------------------------------------
+  s->scr_resize(6, 2);
+  s->scr_frame();
+  s->scr_put(0, 0, "你a");
+  f = s->scr_frame();
+  ASSERT(strsrch(f, "你a") != -1);
+  // overwriting the continuation cell blanks the owner
+  s->scr_put(1, 0, "x");
+  f = s->scr_frame();
+  ASSERT(strsrch(f, "\e[1;1H") != -1);   // repaint starts at the owner
+  ASSERT(strsrch(f, " x") != -1);
+  ASSERT(strsrch(f, "你") == -1);
+  // a wide char that would cross the right edge is clipped entirely
+  s->scr_put(5, 1, "好");
+  ASSERT_EQ("", s->scr_frame());
+
+  // --- cursor -------------------------------------------------------------
+  s->scr_set_cursor(2, 1, 1);
+  f = s->scr_frame();
+  ASSERT(strsrch(f, "\e[?25h") != -1);
+  ASSERT(strsrch(f, "\e[2;3H") != -1);
+  s->scr_set_cursor(2, 1, 0);
+  f = s->scr_frame();
+  ASSERT(strsrch(f, "\e[?25l") != -1);
+
+  // --- box drawing ----------------------------------------------------------
+  s->scr_resize(5, 3);
+  s->scr_frame();
+  s->scr_box(0, 0, 5, 3, TUI_BOX_ASCII);
+  f = s->scr_frame();
+  ASSERT(strsrch(f, "+---+") != -1);
+  ASSERT(strsrch(f, "|") != -1);
+
+  s->scr_box(0, 0, 5, 3, TUI_BOX_SINGLE);
+  f = s->scr_frame();
+  ASSERT(strsrch(f, "┌──┐") == -1);  // 5-wide: ┌───┐
+  ASSERT(strsrch(f, "┌───┐") != -1);
+
+  // out-of-range writes are clipped, never error
+  s->scr_put(-3, 0, "abcdefghij");
+  s->scr_put(0, 99, "x");
+  s->scr_put(99, 0, "x");
+  s->scr_fill(-1, -1, 100, 100, ".", "");
+  s->scr_frame();
+
+  destruct(s);
+}

--- a/testsuite/single/tests/std/tui/widgets.lpc
+++ b/testsuite/single/tests/std/tui/widgets.lpc
@@ -1,0 +1,114 @@
+// /std/tui widget layer: list, textfield, app container — all headless.
+
+#include <tui.h>
+
+private mixed *events = ({});
+
+private void on_evt(object w, string what, mixed arg) {
+  events += ({ ({ what, arg }) });
+}
+
+void do_tests() {
+  object scr = clone_object(TUI_SCREEN);
+  object lst = new("/std/tui/w/list");
+  object fld = new("/std/tui/w/textfield");
+  object app;
+  string f;
+
+  scr->scr_resize(20, 5);
+  scr->scr_frame();
+
+  // --- list ---------------------------------------------------------------
+  lst->set_geometry(0, 0, 10, 3);
+  lst->set_items(({ "alpha", "bravo", "charlie", "delta" }));
+  lst->set_focused(1);
+  lst->set_on_event((: on_evt :));
+
+  ASSERT_EQ(0, lst->query_selected());
+  ASSERT_EQ(1, lst->handle_key(TUI_KEY_DOWN));
+  ASSERT_EQ(1, lst->query_selected());
+  lst->handle_key(TUI_KEY_END);
+  ASSERT_EQ(3, lst->query_selected());
+  ASSERT_EQ("delta", lst->query_selected_item());
+  lst->handle_key(TUI_KEY_ENTER);
+  ASSERT_EQ(({ "select", 3 }), events[<1]);
+  ASSERT_EQ(0, lst->handle_key("x"));        // unhandled falls through
+
+  // selection scrolls into view and is drawn highlighted
+  lst->draw(scr);
+  f = scr->scr_frame();
+  ASSERT(strsrch(f, "delta") != -1);
+  ASSERT(strsrch(f, "alpha") == -1);          // scrolled off (3 rows, sel=3)
+  ASSERT(strsrch(f, "\e[0;7mdelta") != -1);   // reverse video on selection
+
+  // mouse press selects
+  lst->handle_key(TUI_KEY_HOME);
+  lst->draw(scr);
+  scr->scr_frame();
+  ASSERT_EQ(1, lst->handle_mouse(({ TUI_EV_MOUSE, 0, 2, 1, 1 })));
+  ASSERT_EQ(1, lst->query_selected());
+
+  // --- textfield -------------------------------------------------------------
+  events = ({});
+  fld->set_geometry(0, 4, 10, 1);
+  fld->set_focused(1);
+  fld->set_on_event((: on_evt :));
+  foreach (string ch in explode("hi there", "")) fld->handle_key(ch);
+  ASSERT_EQ("hi there", fld->query_text());
+  fld->handle_key(TUI_CTRL('w'));
+  ASSERT_EQ("hi ", fld->query_text());
+  ASSERT_EQ(0, fld->handle_key(TUI_KEY_TAB));  // Tab left for focus cycling
+  fld->handle_key(TUI_KEY_ENTER);
+  ASSERT_EQ(({ "submit", "hi " }), events[<1]);
+  ASSERT_EQ("", fld->query_text());            // field resets after submit
+
+  fld->draw(scr);
+  f = scr->scr_frame();
+  ASSERT(strsrch(f, "\e[?25h") != -1);          // focused field shows cursor
+
+  destruct(scr);
+  lst->remove();
+  destruct(lst);
+  fld->remove();
+  destruct(fld);
+
+  // --- app container -----------------------------------------------------------
+  app = clone_object(TUI_APP);
+  lst = app->app_add(new("/std/tui/w/list"));
+  lst->set_items(({ "one", "two" }));
+  fld = app->app_add(new("/std/tui/w/textfield"));
+  lst->set_geometry(0, 0, 10, 2);
+  fld->set_geometry(0, 3, 10, 1);
+  app->on_open(0, 20, 5);
+
+  ASSERT_EQ(lst, app->app_focused());          // first focusable gets focus
+  ASSERT_EQ(1, lst->query_focused());
+  app->on_key(TUI_KEY_TAB);
+  ASSERT_EQ(fld, app->app_focused());
+  ASSERT_EQ(0, lst->query_focused());
+  app->on_key(TUI_MOD_SHIFT | TUI_KEY_TAB);
+  ASSERT_EQ(lst, app->app_focused());
+
+  // keys route to the focused widget
+  app->on_key(TUI_KEY_DOWN);
+  ASSERT_EQ(1, lst->query_selected());
+
+  // mouse focuses and routes
+  app->on_mouse(({ TUI_EV_MOUSE, 0, 1, 3, 1 }));
+  ASSERT_EQ(fld, app->app_focused());
+
+  f = app->render();
+  ASSERT(strsrch(f, "one") != -1);
+  ASSERT(strsrch(f, "two") != -1);
+
+  // resize keeps working
+  app->on_resize(30, 6);
+  f = app->render();
+  ASSERT(strsrch(f, "one") != -1);
+
+  // app_quit tears everything down (term is 0 here, so no terminal calls)
+  app->app_quit();
+  ASSERT_EQ(0, app);
+  ASSERT_EQ(0, lst);
+  ASSERT_EQ(0, fld);
+}

--- a/testsuite/single/tests/std/tui/widgets2.lpc
+++ b/testsuite/single/tests/std/tui/widgets2.lpc
@@ -1,0 +1,174 @@
+// The pterm/blessed-inspired widget set: progress, spinner, table, tree,
+// checklist, radiolist, button, log — all headless.
+
+#include <tui.h>
+
+private mixed *events = ({});
+
+private void on_evt(object w, string what, mixed arg) {
+  events += ({ ({ what, arg }) });
+}
+
+void do_tests() {
+  object scr = clone_object(TUI_SCREEN);
+  object w;
+  string f;
+
+  scr->scr_resize(30, 3);
+  scr->scr_frame();
+
+  // --- progress ---------------------------------------------------------
+  w = new("/std/tui/w/progress");
+  w->set_geometry(0, 0, 20, 1);
+  w->set_label("cpu");
+  w->set_percent(50);
+  ASSERT_EQ(50, w->query_percent());
+  w->set_percent(150);
+  ASSERT_EQ(100, w->query_percent());
+  w->set_percent(50);
+  w->draw(scr);
+  f = scr->scr_frame();
+  ASSERT(strsrch(f, "cpu") != -1);
+  ASSERT(strsrch(f, "50%") != -1);
+  ASSERT(strsrch(f, "█") != -1);
+  destruct(w);
+
+  // --- spinner ----------------------------------------------------------
+  w = new("/std/tui/w/spinner");
+  w->set_frames(({ "a", "b", "c" }));
+  ASSERT_EQ("a", w->query_frame());
+  w->tick();
+  ASSERT_EQ("b", w->query_frame());
+  w->tick();
+  w->tick();
+  ASSERT_EQ("a", w->query_frame());  // wraps
+  destruct(w);
+
+  // --- table -------------------------------------------------------------
+  events = ({});
+  w = new("/std/tui/w/table");
+  w->set_geometry(0, 0, 28, 3);  // header + 2 body rows
+  w->set_columns(({ "name", "hp" }));
+  w->set_rows(({ ({ "azalea", 90 }), ({ "borin", 80 }), ({ "celdor", 70 }) }));
+  w->set_focused(1);
+  w->set_on_event((: on_evt :));
+
+  ASSERT_EQ(0, w->query_selected());
+  ASSERT_EQ(1, w->handle_key(TUI_KEY_DOWN));
+  ASSERT_EQ(1, w->query_selected());
+  ASSERT_EQ(({ "change", 1 }), events[<1]);
+  w->handle_key(TUI_KEY_END);
+  ASSERT_EQ(2, w->query_selected());
+  ASSERT_EQ(({ "celdor", 70 }), w->query_selected_row());
+  w->handle_key(TUI_KEY_ENTER);
+  ASSERT_EQ(({ "select", 2 }), events[<1]);
+  ASSERT_EQ(0, w->handle_key("x"));
+
+  scr->scr_resize(30, 4);
+  scr->scr_frame();
+  w->draw(scr);
+  f = scr->scr_frame();
+  ASSERT(strsrch(f, "name") != -1);            // header
+  ASSERT(strsrch(f, "celdor") != -1);          // selected row scrolled into view
+  ASSERT(strsrch(f, "azalea") == -1);          // first row scrolled out (2 body rows)
+  destruct(w);
+
+  // --- tree ---------------------------------------------------------------
+  events = ({});
+  w = new("/std/tui/w/tree");
+  w->set_geometry(0, 0, 20, 6);
+  w->set_focused(1);
+  w->set_on_event((: on_evt :));
+  w->set_nodes(({ ({ "root", ({ "a", ({ "b", ({ "c" }) }) }) }), "leaf" }));
+
+  ASSERT_EQ(2, w->query_visible_count());     // collapsed: root + leaf
+  ASSERT_EQ("root", w->query_selected());
+  w->handle_key(TUI_KEY_RIGHT);                // expand root
+  ASSERT_EQ(4, w->query_visible_count());     // root a b leaf
+  w->handle_key(TUI_KEY_DOWN);
+  ASSERT_EQ("a", w->query_selected());
+  w->handle_key(TUI_KEY_ENTER);                // leaf: select event
+  ASSERT_EQ(({ "select", "a" }), events[<1]);
+  w->handle_key(TUI_KEY_DOWN);                 // to b
+  w->handle_key(TUI_KEY_ENTER);                // b has children: toggles
+  ASSERT_EQ(5, w->query_visible_count());
+  w->handle_key(TUI_KEY_LEFT);                 // collapse b again
+  ASSERT_EQ(4, w->query_visible_count());
+  w->expand_all();
+  ASSERT_EQ(5, w->query_visible_count());
+  w->handle_key(TUI_KEY_UP);                   // b -> a
+  ASSERT_EQ("a", w->query_selected());
+  w->handle_key(TUI_KEY_UP);                   // a -> root
+  ASSERT_EQ("root", w->query_selected());
+  destruct(w);
+
+  // --- checklist ------------------------------------------------------------
+  events = ({});
+  w = new("/std/tui/w/checklist");
+  w->set_geometry(0, 0, 20, 3);
+  w->set_items(({ "swords", "archery", "alchemy" }));
+  w->set_on_event((: on_evt :));
+
+  w->handle_key(" ");
+  w->handle_key(TUI_KEY_DOWN);
+  w->handle_key(" ");
+  ASSERT_EQ(({ 0, 1 }), w->query_checked());
+  w->handle_key(" ");                          // toggle off
+  ASSERT_EQ(({ 0 }), w->query_checked());
+  ASSERT_EQ(({ "swords" }), w->query_checked_items());
+  ASSERT_EQ(({ "change", 1 }), events[<1]);
+  w->set_checked(({ 2 }));
+  ASSERT_EQ(({ "alchemy" }), w->query_checked_items());
+  destruct(w);
+
+  // --- radiolist ---------------------------------------------------------------
+  events = ({});
+  w = new("/std/tui/w/radiolist");
+  w->set_geometry(0, 0, 20, 3);
+  w->set_items(({ "warrior", "mage", "thief" }));
+  w->set_on_event((: on_evt :));
+
+  ASSERT_EQ(0, w->query_picked());
+  w->handle_key(TUI_KEY_DOWN);
+  w->handle_key(" ");
+  ASSERT_EQ(1, w->query_picked());
+  ASSERT_EQ("mage", w->query_picked_item());
+  ASSERT_EQ(({ "change", 1 }), events[<1]);
+  destruct(w);
+
+  // --- button ---------------------------------------------------------------------
+  events = ({});
+  w = new("/std/tui/w/button");
+  w->set_label("OK");
+  w->set_on_event((: on_evt :));
+  ASSERT_EQ(1, w->handle_key(TUI_KEY_ENTER));
+  ASSERT_EQ(({ "press", 0 }), events[<1]);
+  ASSERT_EQ(0, w->handle_key(TUI_KEY_DOWN));
+  destruct(w);
+
+  // --- log ------------------------------------------------------------------------
+  w = new("/std/tui/w/log");
+  w->set_geometry(0, 0, 20, 2);
+  w->add_line("one");
+  w->add_line("two\nthree");
+  ASSERT_EQ(({ "one", "two", "three" }), w->query_lines());
+
+  scr->scr_resize(20, 2);
+  scr->scr_frame();
+  w->draw(scr);
+  f = scr->scr_frame();
+  ASSERT(strsrch(f, "two") != -1);             // bottom two lines visible
+  ASSERT(strsrch(f, "three") != -1);
+  ASSERT(strsrch(f, "one") == -1);
+
+  w->handle_key(TUI_KEY_PGUP);                 // scroll back
+  ASSERT(w->query_offset() > 0);
+  w->add_line("four");                         // new output snaps to bottom
+  ASSERT_EQ(0, w->query_offset());
+  w->set_max_lines(2);
+  w->add_line("five");
+  ASSERT_EQ(2, sizeof(w->query_lines()));
+  destruct(w);
+
+  destruct(scr);
+}

--- a/testsuite/std/tui/DESIGN.md
+++ b/testsuite/std/tui/DESIGN.md
@@ -1,0 +1,298 @@
+# LPC TUI Library — Design
+
+A terminal UI toolkit written in pure LPC, layered like `readline` + `ncurses`:
+line editing / history / incremental search for the prompt line, plus a screen
+buffer, diff renderer, and widget set for full-screen TUIs. Lives in
+`/std/tui/` of the testsuite mudlib and is portable to any FluffOS mudlib.
+
+## 1. Driver substrate (research summary)
+
+Everything the library needs already exists in the driver, with two quirks
+fixed as part of this work (see §6):
+
+| Capability | Mechanism |
+|---|---|
+| Raw keystrokes | `get_char(cb, flags)` — one key per callback, must be re-armed from inside the callback to stay in char mode (`src/comm.cc` `call_function_interactive` reverts to line mode otherwise). Flag `I_NOECHO` (0x1) keeps client echo off across re-arms. |
+| Echo control | `I_NOECHO` → driver sends telnet `IAC WILL ECHO` (`set_localecho`). |
+| Terminal size | `request_term_size()` → client NAWS → apply `window_size(int width, int height)` on the interactive object; re-fires on every resize. No query efun — the library caches it. |
+| Terminal type | `start_request_term_type()` → apply `terminal_type(string term)`. |
+| Raw ANSI output | `write()`/`tell_object()`/`receive()` pass ESC (0x1b) through unmolested; telnet layer only rewrites `\n`→CRLF (desirable) and doubles IAC (0xFF). |
+| Display width | `strwidth(s)` (UAX#11 columns), width-aware `sprintf` padding. Neither skips ANSI escapes — the library provides `visible_width()`. |
+| Timers | `call_out_walltime(fp, float)` for the lone-ESC disambiguation timeout. |
+
+Constraints that shaped the design:
+
+* **One byte-ish event per callback, one pending handler per user.** Escape
+  sequences (`ESC [ A` = arrow-up) arrive as separate `get_char` callbacks, so
+  the key decoder is an explicit state machine, and a *real* lone ESC can only
+  be distinguished by a short timeout (industry standard; we use a walltime
+  call_out driven by the glue layer, keeping the decoder itself time-agnostic
+  and unit-testable).
+* **No prompt interference:** while a `get_char` is pending the driver never
+  prints prompts, so the library owns the prompt line entirely.
+* **Char/echo/NAWS negotiation requires a telnet-speaking transport** (raw
+  telnet, websocket `telnet` subprotocol, or the WASM bridge — all supported;
+  the websocket `ascii` subprotocol is not).
+* The driver must not be configured with `__RC_NO_ANSI__` +
+  `__RC_STRIP_BEFORE_PROCESS_INPUT__` (that rewrites inbound ESC to a space).
+
+## 2. Architecture
+
+Five modules, strictly layered; each lower layer knows nothing about the ones
+above. Everything except `terminal.lpc` is a **pure state machine** — no
+efuns with side effects, no interactivity — so the whole stack is exercised by
+the non-interactive testsuite.
+
+```
+             ┌─────────────────────────────────────────────┐
+   apps      │  /command/tuidemo.lpc   (readline + widget demo)
+             ├─────────────────────────────────────────────┤
+   glue      │  /std/tui/terminal.lpc  (get_char loop, NAWS/TTYPE,
+             │      ESC timeout, cleanup; inherit into user objects)
+             ├──────────────┬──────────────────────────────┤
+   engines   │ readline.lpc │ screen.lpc   widget.lpc (+ widgets)
+             ├──────────────┴──────────────────────────────┤
+   input     │  keys.lpc   (bytes → key events)             │
+             ├─────────────────────────────────────────────┤
+   output    │  ansi.lpc   (escape builders, visible width) │
+             └─────────────────────────────────────────────┘
+              include/tui.h  (key codes, states, shared macros)
+```
+
+### 2.1 `ansi.lpc` — escape sequences & width (stateless, inheritable)
+
+Builders for the sequences a TUI needs: cursor addressing/motion (`CUP`,
+`CUU/CUD/CUF/CUB`), erase (`ED`, `EL`), SGR color/attribute (16-color,
+256-color, truecolor), alternate screen (`?1049`), cursor show/hide, SGR mouse
+reporting on/off, bracketed-paste on/off. Plus the width toolkit the driver
+lacks: `visible_width(s)` (display columns ignoring CSI/OSC runs),
+`visible_pad(s, w)`, `strip_ansi(s)`, and `width_slice(s, start_col, ncols)`
+(codepoint slice by display column, wide-char aware) used by readline's
+horizontal scrolling and screen clipping.
+
+### 2.2 `keys.lpc` — key decoder (clonable state machine)
+
+`feed(string chunk)` consumes what `get_char` delivered and returns an array
+of decoded events; `flush()` resolves a dangling ESC (called by the glue's
+timeout); `has_pending()` tells the glue whether to schedule that timeout.
+
+Event representation (no classes — portable across programs):
+
+* **string** — printable text (one character; a whole paste in one event).
+* **int** — everything else. Special keys are `0x110000 + n` (above the
+  Unicode range so they never collide with a codepoint); modifiers are bits
+  above that: `TUI_MOD_SHIFT/ALT/CTRL`. `Ctrl-A` is `TUI_MOD_CTRL | 'a'`,
+  `Alt-b` is `TUI_MOD_ALT | 'b'`, Ctrl-Right is `TUI_MOD_CTRL | TUI_KEY_RIGHT`.
+* **array** — mouse: `({ TUI_EV_MOUSE, button, x, y, pressed })` from SGR
+  (1006) reports.
+
+Grammar handled: CSI sequences with numeric params and modifier encoding
+(`ESC [ 1 ; 5 C`), SS3 (`ESC O P` F-keys/keypad), `ESC [ n ~` legacy keys,
+Alt-prefixed printables, bracketed paste (`ESC [ 200~ … 201~` → single text
+event), SGR mouse (`ESC [ < b;x;y M/m`), and bare control bytes (CR→ENTER,
+TAB, BS/DEL→BACKSPACE, C-a…C-z). Unknown sequences are swallowed and reported
+as `TUI_KEY_UNKNOWN` rather than leaking bytes into the app.
+
+### 2.3 `readline.lpc` — line editor (clonable state machine)
+
+The prompt-line centerpiece. Holds buffer, cursor (codepoint index), history,
+kill buffer, search state, and a horizontal-scroll viewport; consumes key
+events, accumulates ANSI output to repaint **its own line only** (no absolute
+cursor addressing — works at any scroll position using `\r`, `EL`, `CUF`).
+
+API (engine only — the glue below wires it to a real user):
+
+```c
+void   rl_set_width(int cols);            // from NAWS; re-render on resize
+void   rl_set_prompt(string p);           // may contain ANSI colour
+void   rl_set_history(string *lines);     // oldest first; shared/persistable
+void   rl_set_completer(function f);      // f(text, point) -> string *cands
+void   rl_set_masked(int on);             // password mode: render '*'s
+string rl_begin(string initial);          // reset + initial paint
+int    rl_feed(mixed ev);                 // TUI_RL_{MORE,DONE,ABORT,EOF}
+string rl_take_output();                  // drain pending repaint bytes
+string rl_line();                         // the accepted / current line
+string *rl_history();
+```
+
+Default keymap (emacs/readline):
+
+| Keys | Action |
+|---|---|
+| printables / paste | insert at cursor |
+| ←/→, C-b/C-f | move by char; C-←/→, M-b/M-f by word |
+| Home/End, C-a/C-e | line start/end |
+| BS / Del, C-d | delete back / forward (C-d on empty line = EOF) |
+| C-w / M-d / C-k / C-u | kill word-back / word-fwd / to-end / whole line, into kill buffer |
+| C-y | yank kill buffer |
+| C-t | transpose chars |
+| ↑/↓, C-p/C-n | history prev/next (current edit is preserved at the bottom) |
+| C-r / C-s | incremental history search (reverse/forward); type to refine, repeat to step, Enter accepts, C-g restores, other keys accept + execute normally |
+| Tab | completion: insert longest common prefix; on ambiguity, list candidates above the line |
+| Enter | accept → `TUI_RL_DONE` |
+| C-c | abort → `TUI_RL_ABORT` |
+| C-l | clear screen and repaint the line |
+
+Rendering: single logical line with horizontal scrolling when
+`visible_width(prompt+buffer) >= cols` (busybox/readline `--horizontal-scroll`
+style, with `<`/`>` scroll markers). Wide (CJK) characters are handled via
+column-aware slicing. Repaint is a full line rewrite (`\r` + prompt + view +
+`EL(0)` + cursor reposition) — simple, correct, and cheap at human typing
+rates. Multi-line soft-wrap is a possible v2 (see §7).
+
+### 2.4 `screen.lpc` + `widget.lpc` — full-screen TUIs
+
+`screen.lpc` (clonable) is the ncurses core: a virtual cell grid + damage
+tracking + minimal-update renderer.
+
+```c
+void   scr_resize(int cols, int rows);      // clears; call from window_size
+void   scr_clear();  void scr_invalidate(); // force full repaint next frame
+void   scr_put(int x, int y, string text, mixed attr);  // attr = SGR params ("1;36") or 0
+void   scr_fill(int x, int y, int w, int h, string ch, mixed attr);
+void   scr_hline/scr_vline(...);  void scr_box(x, y, w, h, style, attr);
+void   scr_set_cursor(int x, int y, int visible);
+string scr_frame();                          // ANSI delta vs. last frame
+```
+
+Cells store `({ grapheme, sgr_params, width })`; a wide char owns its left
+cell and marks the right cell as a continuation. `scr_frame()` diffs against
+the previously-emitted grid row by row, coalescing changed spans into
+`CUP + SGR + text` runs while tracking the current SGR state to avoid
+redundant attribute churn — the standard curses algorithm, minus insert/delete
+-line optimizations that don't pay at MUD line rates.
+
+`widget.lpc` is the inheritable widget base (geometry, focus, `draw(screen)`,
+`handle_key(ev)` → handled?), with a small set of shipped widgets, each a
+clonable inheriting it: `label`, `list` (scrollable, selectable), `textfield`
+(embeds the readline engine, width-clipped), and box/statusbar drawing via
+`screen` primitives. Widgets are deliberately minimal — the point is the
+protocol, on which mudlibs can build.
+
+### 2.5 `terminal.lpc` — the only impure module (inheritable)
+
+Inherit into an interactive object (user/login) to run either mode:
+
+* **Prompt mode** — `tui_readline(function done_cb, mapping opts)`: an
+  enhanced `input_to` replacement: raw mode on, run the readline engine,
+  restore line mode, call `done_cb(line_or_0, state)`. History is kept per
+  object (`opts` can seed/limit it), giving every prompt in the mudlib
+  line editing + ↑↓ history + C-r search with one call.
+* **App mode** — `tui_open(object app)` / `tui_close()`: alternate screen,
+  cursor hidden, optional mouse on; forwards decoded events to the app
+  (`on_key`, `on_mouse`, `on_resize(w,h)`, `on_open(term)`, `on_close`) and
+  gives it a `screen` clone to draw into.
+
+Responsibilities: `get_char(..., I_NOECHO)` re-arm on every keystroke *inside*
+the callback (so echo never flickers back on), NAWS/TTYPE request + caching
+(`window_size`/`terminal_type` applies, forwarded as resize events), the
+lone-ESC `call_out_walltime(0.05)` flush, and **guaranteed teardown** (restore
+line mode + echo + main screen + cursor + mouse off) on close, user
+disconnect, or object destruction. A safety net: if the driver reverts to
+line mode behind our back, the next line of input is handled gracefully.
+
+## 3. File layout
+
+```
+testsuite/include/tui.h                — key codes, states, macros (public contract)
+testsuite/std/tui/DESIGN.md            — this document
+testsuite/std/tui/ansi.lpc             — layer 0: output
+testsuite/std/tui/keys.lpc             — layer 1: input decoding
+testsuite/std/tui/readline.lpc         — layer 2: line editor
+testsuite/std/tui/screen.lpc           — layer 2: cell grid + diff renderer
+testsuite/std/tui/widget.lpc           — layer 2: widget base (inheritable)
+testsuite/std/tui/w/*.lpc              — shipped widgets (label, list, textfield)
+testsuite/std/tui/terminal.lpc         — layer 3: interactive glue
+testsuite/command/tuidemo.lpc          — demo command (prompt + app modes)
+testsuite/single/tests/std/tui_*.lpc   — testsuite coverage
+docs/concepts/general/tui.md           — user-facing documentation
+```
+
+## 4. Testing strategy
+
+Everything below the glue is a pure state machine, so tests are ordinary
+non-interactive testsuite files:
+
+* `tui_ansi.lpc` — sequence builders; `visible_width`/`width_slice` against
+  ANSI-laden and wide-char strings.
+* `tui_keys.lpc` — feed byte streams exactly as `get_char` would deliver them
+  (split across calls, batched, interleaved) and assert the event stream:
+  arrows, modified CSI, SS3, Alt-x, paste, mouse, lone ESC via `flush()`,
+  UTF-8 text.
+* `tui_readline.lpc` — script whole editing sessions as event arrays; assert
+  buffer, cursor, state transitions, history navigation/search results, and
+  selected render outputs (e.g. masked mode, horizontal scroll markers).
+* `tui_screen.lpc` — draw, frame, assert emitted ANSI; second frame after a
+  small change must touch only the damaged region; wide-char overwrite edge
+  cases.
+
+Clones are destructed at test end (DEBUGMALLOC `check_memory()` runs after
+every file). The interactive glue is kept too thin to need a terminal to
+verify; the demo command is the manual test.
+
+## 5. Conventions
+
+* Public API prefixes per module (`rl_`, `scr_`, `tui_`) — mudlibs mix these
+  into objects that already have dozens of functions; no generic names.
+* Events, not callbacks-into-the-decoder: lower layers *return* data; only
+  `terminal.lpc` calls outward (into the app object).
+* No `input_to`-style string callbacks — function pointers only.
+* 0-based x,y screen coordinates, `(0,0)` top-left, x = column.
+* All modules compile warning-free.
+* Control characters in the edit buffer (e.g. from a bracketed paste) are
+  kept verbatim in the data but rendered as nothing (they are zero-width);
+  the accepted line preserves them exactly.
+* The screen's rows are copy-on-write against the last emitted frame, so a
+  frame's cost is proportional to the rows actually touched, not W×H.
+
+## 6. Driver fixes bundled with this library
+
+Five driver quirks — found by building this library and verifying it over a
+live telnet connection — made a clean LPC implementation impossible; all are
+fixed alongside (documented in `docs/efun/interactive/get_char.md`; the
+UTF-8 tail logic is pinned by GTest `src/tests/test_strutils.cc`):
+
+1. **BS/DEL erasure** (`comm.cc first_cmd_in_buf`): char mode zeroed
+   `0x08`/`0x7f` before delivery, so the callback received `""` for
+   Backspace — BS, DEL and NUL were indistinguishable. Now the literal byte
+   is delivered. (Line-mode in-buffer BS editing is unchanged.)
+2. **UTF-8 byte-splitting** (`comm.cc cmd_in_buf`/`first_cmd_in_buf`): char
+   mode delivered one *byte* per callback, so a multi-byte character arrived
+   as 2–4 invalid one-byte strings. Char-mode extraction is now UTF-8-aware:
+   a complete multi-byte sequence is one callback carrying one valid
+   character. Malformed bytes fall back to byte-at-a-time delivery (no
+   stalls).
+3. **Inbound ESC stripping** (`comm.cc on_user_input`): with `no ansi` +
+   `strip before process input` (both default **on**), inbound ESC was
+   rewritten to a space — arrow keys arrived as literal `[A`. The rewrite is
+   an anti-ANSI-injection protection for *line-mode commands*; char mode now
+   always passes ESC through (the mudlib asked for raw keystrokes).
+4. **UTF-8 split across TCP segments** (`net/telnet.cc on_telnet_data` +
+   `u8_incomplete_tail()` in `base/internal/strutils`): each received chunk
+   was `u8_sanitize`d independently, so a multi-byte character straddling a
+   segment boundary became U+FFFD before reaching the input buffer — in any
+   input mode. An incomplete trailing sequence is now carried over
+   (`interactive_t::u8_carry`) and prepended to the next chunk.
+5. **NAWS lost at logon** (`net/telnet.cc` + `comm.cc on_user_logon`): fast
+   clients answer the initial `DO NAWS` while `ip->ob` is still the master
+   object, so the `window_size` apply fired on the wrong object and the size
+   was unrecoverable (clients only re-send NAWS on resize). The last report
+   is now cached in `interactive_t` and the apply is replayed on the user
+   object at logon.
+
+The decoder additionally copes with the old `""`-for-Backspace behavior, so
+the library degrades gracefully on older drivers for everything except
+non-ASCII input and escape sequences under default configs.
+
+## 7. Deliberate v1 scope cuts
+
+* **Multi-line soft-wrapped editing** (readline renders one terminal row with
+  horizontal scroll). The engine's render layer is isolated, so a wrap
+  renderer can replace it without touching editing logic.
+* **Undo** (C-_), **kill ring** beyond a single buffer, vi keymap.
+* **Grapheme-cluster cursor motion** — cursor moves by codepoint; combining
+  marks may take two arrow presses. (Display width is still correct.)
+* **terminfo** — we emit the VT100/xterm common subset that every MUD client,
+  xterm.js, and modern terminal understands; `terminal_type` is cached and
+  exposed so apps can special-case, but the library does not vary output.
+* **Scroll-region / insert-line diff optimizations** in the renderer.

--- a/testsuite/std/tui/README.md
+++ b/testsuite/std/tui/README.md
@@ -15,6 +15,7 @@ portable to any FluffOS mudlib.
 | `tuidemo` | readline prompt: editing, ↑/↓ history, Ctrl-R search, Tab completion |
 | `tuidemo select` | inline select → multiselect → confirm prompt chain |
 | `tuidemo print` | the pterm-style printers, in plain line mode |
+| `tuidemo charts` | vertical bars, braille line chart, heatmap, sparkline |
 | `tuidemo app` | minimal full-screen app (list + textfield) |
 | `tuidemo dashboard` | animated spinner, progress bars, sparkline, live table + log |
 | `tuidemo form` | textfield, radio group, checkbox list, buttons |
@@ -197,6 +198,7 @@ inspired by the pterm and blessed catalogs):
 | `progress` | label + bar + percentage | — |
 | `spinner` | braille spinner; app drives `tick()` from its own call_out | — |
 | `log` | bottom-anchored scrollback pane (PgUp/PgDn) | — |
+| `chart` | braille line chart with rolling history (`add_point()`), multi-series | — |
 
 ### 2.5 `print.lpc` — inline printers (stateless, inheritable)
 
@@ -209,6 +211,20 @@ for widgets. `p_table(rows, opts)` (boxed, width-aware, header rule),
 `p_progress(pct, width)`, `p_info/p_success/p_warn/p_error(text)` prefix
 printers, and `p_bigtext(text)` (banner letters via `/std/bitmap_font`).
 All wide-char aware; tables/trees/panels accept the `TUI_BOX_*` styles.
+
+Charts, on top of `canvas.lpc` — a braille dot canvas (each cell is a 2×4
+dot grid, U+2800 block; the blessed-contrib/drawille technique) with
+`c_set/c_line/c_plot` in dot coordinates and per-cell colour:
+
+* `p_chart(series, opts)` — braille line chart, multiple coloured series,
+  y-axis gutter and legend (`series` = `({ ({ label, values, attr }) })`).
+* `p_vbars(items, opts)` — vertical bar chart with eighth-block partial
+  tops (`▁▂▃▄▅▆▇█`), optional value row.
+* `p_heatmap(grid, opts)` — 2D matrix as 256-colour cells with a
+  cool→hot ramp and optional axis labels.
+* `w/chart.lpc` — the same line chart as a live widget: `add_series()`,
+  `add_point()` (rolling window sized to the widget), auto- or fixed
+  y-range; drives the dashboard's traffic graph.
 
 ### 2.6 `menu.lpc` — inline select/multiselect (clonable state machine)
 
@@ -252,7 +268,8 @@ line mode behind our back, the next line of input is handled gracefully.
 testsuite/include/tui.h                — key codes, states, macros (public contract)
 testsuite/std/tui/README.md            — this document
 testsuite/std/tui/ansi.lpc             — layer 0: escapes + width toolkit
-testsuite/std/tui/print.lpc            — layer 0: pterm-style inline printers
+testsuite/std/tui/canvas.lpc           — layer 0: braille dot canvas
+testsuite/std/tui/print.lpc            — layer 0: pterm-style inline printers + charts
 testsuite/std/tui/keys.lpc             — layer 1: input decoding
 testsuite/std/tui/readline.lpc         — layer 2: line editor
 testsuite/std/tui/menu.lpc             — layer 2: inline select/multiselect
@@ -290,6 +307,9 @@ non-interactive testsuite files:
   width math, scaling).
 * `tui/menu.lpc` — scripted select/multiselect sessions: navigation,
   toggling, windowing, accept/abort, the collapsed answer line.
+* `tui/charts.lpc` — canvas dot/braille math (exact glyphs), line
+  drawing, `c_plot` endpoints, and exact `p_vbars` output; chart/heatmap
+  structure checks; the chart widget's rolling window.
 
 Clones are destructed at test end (DEBUGMALLOC `check_memory()` runs after
 every file). The interactive glue is kept too thin to need a terminal to
@@ -363,7 +383,7 @@ non-ASCII input and escape sequences under default configs.
 * **Scroll-region / insert-line diff optimizations** in the renderer.
 * **Fuzzy filtering in select/multiselect** (pterm types-to-filter; our menu
   navigates only — the engine's input path has room for it).
-* From the pterm/blessed catalogs, deliberately not ported: pterm's Area /
-  Heatmap / theming, blessed's FileManager, Terminal, Image/Video and
+* From the pterm/blessed catalogs, deliberately not ported: pterm's Area
+  and theming, blessed's FileManager, Terminal, Image/Video and
   absolute-positioned Layout manager — MUD-side value didn't justify the
   surface area.

--- a/testsuite/std/tui/README.md
+++ b/testsuite/std/tui/README.md
@@ -281,7 +281,7 @@ testsuite/std/tui/terminal.lpc         — layer 3: interactive glue
 testsuite/command/tuidemo.lpc          — the showcases (see top of file)
 testsuite/clone/tuidemo_*.lpc          — full-screen showcase apps
 testsuite/single/tests/std/tui/*.lpc   — testsuite coverage
-docs/concepts/general/tui.md           — user-facing documentation
+docs/stdlib/tui.md                     — user-facing documentation
 ```
 
 ## 4. Testing strategy

--- a/testsuite/std/tui/README.md
+++ b/testsuite/std/tui/README.md
@@ -1,13 +1,27 @@
-# LPC TUI Library — Design
+# /std/tui — the LPC TUI library
 
-A terminal UI toolkit written in pure LPC, layered like `readline` + `ncurses`:
-line editing / history / incremental search for the prompt line, plus a screen
-buffer, diff renderer, and widget set for full-screen TUIs. Lives in
-`/std/tui/` of the testsuite mudlib and is portable to any FluffOS mudlib.
+A terminal UI toolkit written in pure LPC, layered like `readline` +
+`ncurses` + `pterm`: line editing / history / incremental search for the
+prompt line, inline select/multiselect/confirm prompts and pretty-printers
+for ordinary output, plus a screen buffer, diff renderer, and widget set for
+full-screen TUIs. Lives in `/std/tui/` of the testsuite mudlib and is
+portable to any FluffOS mudlib.
+
+**Try it**: boot the testsuite (`driver etc/config.test`), telnet to port
+4000, and run the showcases:
+
+| Command | Shows |
+|---|---|
+| `tuidemo` | readline prompt: editing, ↑/↓ history, Ctrl-R search, Tab completion |
+| `tuidemo select` | inline select → multiselect → confirm prompt chain |
+| `tuidemo print` | the pterm-style printers, in plain line mode |
+| `tuidemo app` | minimal full-screen app (list + textfield) |
+| `tuidemo dashboard` | animated spinner, progress bars, sparkline, live table + log |
+| `tuidemo form` | textfield, radio group, checkbox list, buttons |
 
 ## 1. Driver substrate (research summary)
 
-Everything the library needs already exists in the driver, with two quirks
+Everything the library needs already exists in the driver, with the quirks
 fixed as part of this work (see §6):
 
 | Capability | Mechanism |
@@ -44,18 +58,20 @@ efuns with side effects, no interactivity — so the whole stack is exercised by
 the non-interactive testsuite.
 
 ```
-             ┌─────────────────────────────────────────────┐
-   apps      │  /command/tuidemo.lpc   (readline + widget demo)
-             ├─────────────────────────────────────────────┤
-   glue      │  /std/tui/terminal.lpc  (get_char loop, NAWS/TTYPE,
-             │      ESC timeout, cleanup; inherit into user objects)
-             ├──────────────┬──────────────────────────────┤
-   engines   │ readline.lpc │ screen.lpc   widget.lpc (+ widgets)
-             ├──────────────┴──────────────────────────────┤
-   input     │  keys.lpc   (bytes → key events)             │
-             ├─────────────────────────────────────────────┤
-   output    │  ansi.lpc   (escape builders, visible width) │
-             └─────────────────────────────────────────────┘
+             ┌──────────────────────────────────────────────────────┐
+   apps      │  /command/tuidemo.lpc  + /clone/tuidemo_*.lpc demos  │
+             ├──────────────────────────────────────────────────────┤
+   glue      │  terminal.lpc   (get_char loop, NAWS/TTYPE, ESC      │
+             │    timeout, cleanup; inherit into user objects;      │
+             │    tui_readline / tui_select / tui_confirm / tui_open)│
+             ├──────────────┬──────────┬────────────────────────────┤
+   engines   │ readline.lpc │ menu.lpc │ screen.lpc  widget.lpc     │
+             │ (line editor)│ (select) │ (+ w/* widget set)  app.lpc│
+             ├──────────────┴──────────┴────────────────────────────┤
+   input     │  keys.lpc   (bytes → key events)                     │
+             ├──────────────────────────────────────────────────────┤
+   output    │  ansi.lpc (escapes, widths)   print.lpc (printers)   │
+             └──────────────────────────────────────────────────────┘
               include/tui.h  (key codes, states, shared macros)
 ```
 
@@ -163,13 +179,47 @@ redundant attribute churn — the standard curses algorithm, minus insert/delete
 -line optimizations that don't pay at MUD line rates.
 
 `widget.lpc` is the inheritable widget base (geometry, focus, `draw(screen)`,
-`handle_key(ev)` → handled?), with a small set of shipped widgets, each a
-clonable inheriting it: `label`, `list` (scrollable, selectable), `textfield`
-(embeds the readline engine, width-clipped), and box/statusbar drawing via
-`screen` primitives. Widgets are deliberately minimal — the point is the
-protocol, on which mudlibs can build.
+`handle_key(ev)` → handled?, the on-event callback), and `app.lpc` is the
+application container (screen ownership, Tab focus cycling, key/mouse
+routing, Ctrl-C quit). The shipped widget set (each a clonable in `w/`,
+inspired by the pterm and blessed catalogs):
 
-### 2.5 `terminal.lpc` — the only impure module (inheritable)
+| Widget | Behavior | Events |
+|---|---|---|
+| `label` | static (multi-line) text | — |
+| `list` | scrollable single-select list | `select`, `change` |
+| `table` | column-aligned rows + header, scroll + selection | `select`, `change` |
+| `tree` | collapsible tree (`▸`/`▾`), ←/→/Enter fold | `select`, `change` |
+| `textfield` | single-line input backed by a full readline engine | `submit` |
+| `checklist` | `[x]` multi-select, Space toggles | `change` |
+| `radiolist` | `(•)` single-choice group | `change` |
+| `button` | `[ OK ]`, Enter/Space presses | `press` |
+| `progress` | label + bar + percentage | — |
+| `spinner` | braille spinner; app drives `tick()` from its own call_out | — |
+| `log` | bottom-anchored scrollback pane (PgUp/PgDn) | — |
+
+### 2.5 `print.lpc` — inline printers (stateless, inheritable)
+
+The pterm side of the library: string builders that compose with plain
+`write()` — no raw mode, no full screen — and double as rendering helpers
+for widgets. `p_table(rows, opts)` (boxed, width-aware, header rule),
+`p_tree(nodes)` (`├──`/`└──`), `p_bars(items)` (horizontal bar chart),
+`p_spark(values)` (▁▂▃▅▇ sparkline), `p_panel(title, body)`,
+`p_bullets(items)` (depth-nested), `p_header(text)` (centered banner),
+`p_progress(pct, width)`, `p_info/p_success/p_warn/p_error(text)` prefix
+printers, and `p_bigtext(text)` (banner letters via `/std/bitmap_font`).
+All wide-char aware; tables/trees/panels accept the `TUI_BOX_*` styles.
+
+### 2.6 `menu.lpc` — inline select/multiselect (clonable state machine)
+
+pterm's interactive prompts, MUD-style: a prompt plus a scrolling choice
+list rendered *in the normal output flow* and repainted in place with
+relative cursor movement; on completion it collapses to a one-line
+`? prompt: answer` record. Space toggles in multi mode, Enter accepts,
+Esc/Ctrl-C aborts, long lists window with `height`. Same engine API shape
+as readline: `m_begin/m_feed/m_take_output/m_result`.
+
+### 2.7 `terminal.lpc` — the only impure module (inheritable)
 
 Inherit into an interactive object (user/login) to run either mode:
 
@@ -178,6 +228,11 @@ Inherit into an interactive object (user/login) to run either mode:
   restore line mode, call `done_cb(line_or_0, state)`. History is kept per
   object (`opts` can seed/limit it), giving every prompt in the mudlib
   line editing + ↑↓ history + C-r search with one call.
+* **Inline prompts** — `tui_select(cb, prompt, choices, opts)` →
+  `cb(index, item, state)`; `tui_multiselect(...)` →
+  `cb(indexes, items, state)`; `tui_confirm(cb, prompt, default)` →
+  `cb(yes, state)`. All run the menu engine (or a one-keystroke y/n loop)
+  over the same char-mode plumbing as readline.
 * **App mode** — `tui_open(object app)` / `tui_close()`: alternate screen,
   cursor hidden, optional mouse on; forwards decoded events to the app
   (`on_key`, `on_mouse`, `on_resize(w,h)`, `on_open(term)`, `on_close`) and
@@ -195,16 +250,20 @@ line mode behind our back, the next line of input is handled gracefully.
 
 ```
 testsuite/include/tui.h                — key codes, states, macros (public contract)
-testsuite/std/tui/DESIGN.md            — this document
-testsuite/std/tui/ansi.lpc             — layer 0: output
+testsuite/std/tui/README.md            — this document
+testsuite/std/tui/ansi.lpc             — layer 0: escapes + width toolkit
+testsuite/std/tui/print.lpc            — layer 0: pterm-style inline printers
 testsuite/std/tui/keys.lpc             — layer 1: input decoding
 testsuite/std/tui/readline.lpc         — layer 2: line editor
+testsuite/std/tui/menu.lpc             — layer 2: inline select/multiselect
 testsuite/std/tui/screen.lpc           — layer 2: cell grid + diff renderer
 testsuite/std/tui/widget.lpc           — layer 2: widget base (inheritable)
-testsuite/std/tui/w/*.lpc              — shipped widgets (label, list, textfield)
+testsuite/std/tui/w/*.lpc              — the widget set (see §2.4)
+testsuite/std/tui/app.lpc              — layer 2: application container
 testsuite/std/tui/terminal.lpc         — layer 3: interactive glue
-testsuite/command/tuidemo.lpc          — demo command (prompt + app modes)
-testsuite/single/tests/std/tui_*.lpc   — testsuite coverage
+testsuite/command/tuidemo.lpc          — the showcases (see top of file)
+testsuite/clone/tuidemo_*.lpc          — full-screen showcase apps
+testsuite/single/tests/std/tui/*.lpc   — testsuite coverage
 docs/concepts/general/tui.md           — user-facing documentation
 ```
 
@@ -225,6 +284,12 @@ non-interactive testsuite files:
 * `tui_screen.lpc` — draw, frame, assert emitted ANSI; second frame after a
   small change must touch only the damaged region; wide-char overwrite edge
   cases.
+* `tui/widgets.lpc` + `tui/widgets2.lpc` — the whole widget set headless:
+  navigation, events, scrolling, toggle state, and selected render output.
+* `tui/print.lpc` — exact expected strings for the printers (box drawing,
+  width math, scaling).
+* `tui/menu.lpc` — scripted select/multiselect sessions: navigation,
+  toggling, windowing, accept/abort, the collapsed answer line.
 
 Clones are destructed at test end (DEBUGMALLOC `check_memory()` runs after
 every file). The interactive glue is kept too thin to need a terminal to
@@ -284,7 +349,7 @@ The decoder additionally copes with the old `""`-for-Backspace behavior, so
 the library degrades gracefully on older drivers for everything except
 non-ASCII input and escape sequences under default configs.
 
-## 7. Deliberate v1 scope cuts
+## 7. Deliberate scope cuts
 
 * **Multi-line soft-wrapped editing** (readline renders one terminal row with
   horizontal scroll). The engine's render layer is isolated, so a wrap
@@ -296,3 +361,9 @@ non-ASCII input and escape sequences under default configs.
   xterm.js, and modern terminal understands; `terminal_type` is cached and
   exposed so apps can special-case, but the library does not vary output.
 * **Scroll-region / insert-line diff optimizations** in the renderer.
+* **Fuzzy filtering in select/multiselect** (pterm types-to-filter; our menu
+  navigates only — the engine's input path has room for it).
+* From the pterm/blessed catalogs, deliberately not ported: pterm's Area /
+  Heatmap / theming, blessed's FileManager, Terminal, Image/Video and
+  absolute-positioned Layout manager — MUD-side value didn't justify the
+  surface area.

--- a/testsuite/std/tui/ansi.lpc
+++ b/testsuite/std/tui/ansi.lpc
@@ -1,0 +1,126 @@
+// /std/tui/ansi — layer 0 of the TUI library: ANSI/VT100 escape builders and
+// the display-width toolkit the driver lacks (strwidth() counts escape bytes;
+// visible_width() does not).  Stateless: inherit it, or call it as an object.
+//
+// Colour helpers (ansi_fg/ansi_bg/ansi_rgb_fg/ansi_rgb_bg) return SGR
+// *parameter strings* ("36", "48;5;208"), so they compose into the attr
+// strings used by /std/tui/screen; wrap with ansi_sgr() to emit directly.
+
+#include <tui.h>
+
+// --- cursor -----------------------------------------------------------
+
+// Absolute addressing, 0-based x (column), y (row).
+string ansi_cup(int x, int y) { return sprintf("\e[%d;%dH", y + 1, x + 1); }
+
+string ansi_up(int n) { return n > 0 ? sprintf("\e[%dA", n) : ""; }
+string ansi_down(int n) { return n > 0 ? sprintf("\e[%dB", n) : ""; }
+string ansi_fwd(int n) { return n > 0 ? sprintf("\e[%dC", n) : ""; }
+string ansi_back(int n) { return n > 0 ? sprintf("\e[%dD", n) : ""; }
+
+string ansi_save_cursor() { return "\e7"; }
+string ansi_restore_cursor() { return "\e8"; }
+string ansi_cursor_visible(int on) { return on ? "\e[?25h" : "\e[?25l"; }
+
+// --- erase ------------------------------------------------------------
+
+// 0 = to end, 1 = to start, 2 = whole line/screen
+string ansi_el(int mode) { return sprintf("\e[%dK", mode); }
+string ansi_ed(int mode) { return sprintf("\e[%dJ", mode); }
+
+// --- attributes -------------------------------------------------------
+
+string ansi_sgr(string params) { return "\e[" + params + "m"; }
+string ansi_reset() { return "\e[0m"; }
+
+// SGR parameter strings.  color: 0-7 normal, 8-15 bright, 16-255 palette.
+string ansi_fg(int color) {
+  if (color < 8) return "" + (30 + color);
+  if (color < 16) return "" + (90 + color - 8);
+  return "38;5;" + color;
+}
+
+string ansi_bg(int color) {
+  if (color < 8) return "" + (40 + color);
+  if (color < 16) return "" + (100 + color - 8);
+  return "48;5;" + color;
+}
+
+string ansi_rgb_fg(int r, int g, int b) { return sprintf("38;2;%d;%d;%d", r, g, b); }
+string ansi_rgb_bg(int r, int g, int b) { return sprintf("48;2;%d;%d;%d", r, g, b); }
+
+// --- modes ------------------------------------------------------------
+
+string ansi_alt_screen(int on) { return on ? "\e[?1049h" : "\e[?1049l"; }
+string ansi_bracketed_paste(int on) { return on ? "\e[?2004h" : "\e[?2004l"; }
+// Button-event tracking + SGR extended coordinates.
+string ansi_mouse(int on) { return on ? "\e[?1002h\e[?1006h" : "\e[?1006l\e[?1002l"; }
+
+// --- visible width ----------------------------------------------------
+
+// Index just past the escape sequence starting at s[i] (s[i] == ESC).
+private int skip_escape(string s, int i) {
+  int n = strlen(s);
+  int j = i + 1;
+
+  if (j >= n) return n;
+  switch (s[j]) {
+    case '[':  // CSI: parameter/intermediate bytes 0x20-0x3f, final 0x40-0x7e
+      for (j++; j < n; j++) {
+        if (s[j] >= 0x40 && s[j] <= 0x7e) return j + 1;
+      }
+      return n;
+    case ']':  // OSC: terminated by BEL or ST (ESC \)
+      for (j++; j < n; j++) {
+        if (s[j] == 7) return j + 1;
+        if (s[j] == 27 && j + 1 < n && s[j + 1] == '\\') return j + 2;
+      }
+      return n;
+    default:  // two-character escape (ESC 7, ESC 8, ESC = ...)
+      return j + 1;
+  }
+}
+
+// s with all escape sequences removed.
+string strip_ansi(string s) {
+  string out = "";
+  int i = 0, seg = 0, n = strlen(s);
+
+  while (i < n) {
+    if (s[i] == 27) {
+      if (i > seg) out += s[seg..i - 1];
+      i = skip_escape(s, i);
+      seg = i;
+    } else {
+      i++;
+    }
+  }
+  if (i > seg) out += s[seg..i - 1];
+  return out;
+}
+
+// Display columns of s, not counting escape sequences.
+int visible_width(string s) { return strwidth(strip_ansi(s)); }
+
+// The substring of plain (escape-free) text s covering display columns
+// [col, col + ncols).  A wide character only partially inside the window is
+// excluded, so the result can be up to one column narrower at either edge.
+string wslice(string s, int col, int ncols) {
+  string out = "";
+  int i, n = strlen(s), c = 0, lo = col, hi = col + ncols;
+
+  if (ncols <= 0) return "";
+  for (i = 0; i < n && c < hi; i++) {
+    string ch = s[i..i];
+    int cw = strwidth(ch);
+    if (c >= lo && c + cw <= hi && cw > 0) out += ch;
+    c += cw;
+  }
+  return out;
+}
+
+// Pad plain text s with spaces to display width w (no truncation).
+string wpad(string s, int w) {
+  int sw = strwidth(s);
+  return sw < w ? s + repeat_string(" ", w - sw) : s;
+}

--- a/testsuite/std/tui/app.lpc
+++ b/testsuite/std/tui/app.lpc
@@ -1,0 +1,126 @@
+// /std/tui/app — application container: screen ownership, widget list,
+// focus cycling, event routing.  Inherit it, override on_layout() (position
+// your widgets; called on open and on every resize) and optionally
+// on_unhandled_key() / on_close().
+//
+// The terminal glue (/std/tui/terminal) drives it: on_open/on_resize/
+// on_key/on_mouse arrive from there, and render() is collected after each
+// event batch.  Call app_quit() to leave the TUI.
+
+#include <tui.h>
+
+private object screen;
+private object *widgets = ({});
+private int focus = -1;
+private object term;
+
+void app_quit();  // forward (used by on_key before its definition)
+
+object app_screen() { return screen; }
+object app_terminal() { return term; }
+object *app_widgets() { return widgets[0..]; }
+
+object app_add(object w) {
+  widgets += ({ w });
+  return w;
+}
+
+object app_focused() {
+  return focus >= 0 && focus < sizeof(widgets) ? widgets[focus] : 0;
+}
+
+void app_focus(object w) {
+  int i = member_array(w, widgets);
+
+  if (i == -1 || !widgets[i]->query_focusable()) return;
+  if (focus >= 0 && focus < sizeof(widgets)) widgets[focus]->set_focused(0);
+  focus = i;
+  widgets[i]->set_focused(1);
+}
+
+void app_cycle_focus(int dir) {
+  int i, n = sizeof(widgets);
+
+  if (!n) return;
+  for (i = 1; i <= n; i++) {
+    int j = (focus + dir * i + n * i) % n;
+    if (widgets[j]->query_focusable()) {
+      app_focus(widgets[j]);
+      return;
+    }
+  }
+}
+
+// --- overridables ---
+void on_layout(int w, int h) {}
+int on_unhandled_key(mixed ev) { return 0; }
+void on_closed() {}
+
+void on_open(object t, int w, int h) {
+  term = t;
+  if (!screen) screen = clone_object(TUI_SCREEN);
+  screen->scr_resize(w, h);
+  on_layout(w, h);
+  if (focus == -1) app_cycle_focus(1);
+}
+
+void on_resize(int w, int h) {
+  if (!screen) return;
+  screen->scr_resize(w, h);
+  on_layout(w, h);
+}
+
+void on_key(mixed ev) {
+  object f = app_focused();
+
+  if (ev == TUI_CTRL('c')) {  // always quits, whatever has focus
+    app_quit();
+    return;
+  }
+  if (f && f->handle_key(ev)) return;
+  if (ev == TUI_KEY_TAB) {
+    app_cycle_focus(1);
+    return;
+  }
+  if (ev == (TUI_MOD_SHIFT | TUI_KEY_TAB)) {
+    app_cycle_focus(-1);
+    return;
+  }
+  if (on_unhandled_key(ev)) return;
+  if (ev == "q" || ev == TUI_CTRL('c')) app_quit();
+}
+
+void on_mouse(mixed *ev) {
+  foreach (object w in widgets) {
+    if (w->contains(ev[2], ev[3])) {
+      if (w->query_focusable()) app_focus(w);
+      w->handle_mouse(ev);
+      return;
+    }
+  }
+}
+
+string render() {
+  if (!screen) return "";
+  foreach (object w in widgets) {
+    if (w->query_visible()) w->draw(screen);
+  }
+  return screen->scr_frame();
+}
+
+void app_quit() {
+  object t = term;
+
+  term = 0;
+  if (t) t->tui_close();
+  on_closed();
+  foreach (object w in widgets) {
+    if (w) {
+      w->remove();
+      if (w) destruct(w);
+    }
+  }
+  widgets = ({});
+  if (screen) destruct(screen);
+  destruct(this_object());
+}

--- a/testsuite/std/tui/canvas.lpc
+++ b/testsuite/std/tui/canvas.lpc
@@ -1,0 +1,142 @@
+// /std/tui/canvas — braille dot canvas (the blessed-contrib/drawille trick).
+//
+// Each terminal cell is a 2×4 grid of braille dots (U+2800 block), giving
+// sub-cell resolution for line charts, scatter plots and freehand drawing:
+// a W×H cell canvas addresses (2·W)×(4·H) dots, (0,0) top-left.
+//
+// Dots carry an optional SGR attr (last writer wins per CELL).  Render as
+// one string (c_render), per-row strings (c_rows), or per-cell ({ ch, attr })
+// pairs (c_cell — what /std/tui/w/chart uses to blit into a screen).
+//
+// Pure state machine: clone, draw, render.
+
+#include <tui.h>
+
+inherit TUI_ANSI;
+
+private int W = 40, H = 10;   // cells
+private int *dots;            // per-cell braille bitmask
+private string *attrs;        // per-cell SGR params ("" = default)
+
+// braille bit for dot (dx 0-1, dy 0-3) inside a cell
+private int *bit_row = ({ 1, 2, 4, 64 });      // dx == 0
+private int *bit_row2 = ({ 8, 16, 32, 128 });  // dx == 1
+
+void c_clear() {
+  dots = allocate(W * H);
+  attrs = allocate(W * H);
+}
+
+void c_resize(int w, int h) {
+  W = w < 1 ? 1 : w;
+  H = h < 1 ? 1 : h;
+  c_clear();
+}
+
+void create() { c_clear(); }
+
+int c_width() { return W; }
+int c_height() { return H; }
+int c_width_dots() { return W * 2; }
+int c_height_dots() { return H * 4; }
+
+varargs void c_set(int x, int y, string attr) {
+  int cx, cy, i;
+
+  if (x < 0 || y < 0 || x >= W * 2 || y >= H * 4) return;
+  cx = x / 2;
+  cy = y / 4;
+  i = cy * W + cx;
+  dots[i] |= (x & 1 ? bit_row2 : bit_row)[y & 3];
+  if (stringp(attr)) attrs[i] = attr;
+}
+
+void c_unset(int x, int y) {
+  if (x < 0 || y < 0 || x >= W * 2 || y >= H * 4) return;
+  dots[(y / 4) * W + x / 2] &= ~((x & 1 ? bit_row2 : bit_row)[y & 3]);
+}
+
+int c_get(int x, int y) {
+  if (x < 0 || y < 0 || x >= W * 2 || y >= H * 4) return 0;
+  return dots[(y / 4) * W + x / 2] & (x & 1 ? bit_row2 : bit_row)[y & 3] ? 1 : 0;
+}
+
+// Bresenham, in dot coordinates.
+varargs void c_line(int x0, int y0, int x1, int y1, string attr) {
+  int dx = x1 - x0, dy = y1 - y0;
+  int sx = dx < 0 ? -1 : 1, sy = dy < 0 ? -1 : 1;
+  int err, e2;
+
+  if (dx < 0) dx = -dx;
+  if (dy < 0) dy = -dy;
+  err = dx - dy;
+  while (1) {
+    c_set(x0, y0, attr);
+    if (x0 == x1 && y0 == y1) return;
+    e2 = 2 * err;
+    if (e2 > -dy) {
+      err -= dy;
+      x0 += sx;
+    }
+    if (e2 < dx) {
+      err += dx;
+      y0 += sy;
+    }
+  }
+}
+
+// The cell at (cx, cy) as ({ ch, attr }); ({ " ", "" }) when empty.
+mixed *c_cell(int cx, int cy) {
+  int i;
+
+  if (cx < 0 || cy < 0 || cx >= W || cy >= H) return ({ " ", "" });
+  i = cy * W + cx;
+  if (!dots[i]) return ({ " ", "" });
+  return ({ sprintf("%c", 0x2800 | dots[i]), attrs[i] ? attrs[i] : "" });
+}
+
+// Plot values as a connected line across the full canvas, y-scaled to
+// [lo, hi] (bottom to top).  The shared engine behind p_chart() and
+// /std/tui/w/chart.
+varargs void c_plot(int *values, int lo, int hi, string attr) {
+  int n, i, wd = W * 2 - 1, hd = H * 4 - 1;
+
+  if (!arrayp(values) || !(n = sizeof(values))) return;
+  if (hi <= lo) hi = lo + 1;
+  if (n == 1) {
+    c_set(0, hd - (values[0] - lo) * hd / (hi - lo), attr);
+    return;
+  }
+  for (i = 0; i + 1 < n; i++) {
+    c_line(i * wd / (n - 1), hd - (values[i] - lo) * hd / (hi - lo),
+           (i + 1) * wd / (n - 1), hd - (values[i + 1] - lo) * hd / (hi - lo), attr);
+  }
+}
+
+// One row as a printable string with minimal SGR switching.
+string c_row(int cy) {
+  string out = "", cur = "";
+  int cx;
+
+  for (cx = 0; cx < W; cx++) {
+    mixed *c = c_cell(cx, cy);
+
+    if (c[1] != cur) {
+      out += c[1] == "" ? ansi_reset() : ansi_sgr("0;" + c[1]);
+      cur = c[1];
+    }
+    out += c[0];
+  }
+  if (cur != "") out += ansi_reset();
+  return out;
+}
+
+string *c_rows() {
+  string *r = ({});
+  int cy;
+
+  for (cy = 0; cy < H; cy++) r += ({ c_row(cy) });
+  return r;
+}
+
+string c_render() { return implode(c_rows(), "\n") + "\n"; }

--- a/testsuite/std/tui/keys.lpc
+++ b/testsuite/std/tui/keys.lpc
@@ -1,0 +1,321 @@
+// /std/tui/keys — layer 1 of the TUI library: the keystroke decoder.
+//
+// get_char() delivers one keystroke per callback (a character, or one byte
+// of an escape sequence).  feed() consumes those strings and returns the
+// decoded events; see include/tui.h for the event representation.
+//
+// The decoder is time-agnostic: a lone ESC is indistinguishable from the
+// start of a sequence, so when has_pending() is true after a feed(), the
+// caller schedules a short timeout and calls flush() — which resolves a
+// dangling ESC to TUI_KEY_ESC.  A partially received CSI/SS3 sequence is
+// NOT flushed (mid-sequence bytes are only ever split by network lag; the
+// rest will arrive).  Pure state machine: clone one per connection.
+
+#include <tui.h>
+
+#define S_NONE  0
+#define S_ESC   1
+#define S_CSI   2
+#define S_SS3   3
+#define S_OSC   4
+#define S_PASTE 5
+
+private int state = S_NONE;
+private string csi = "";       // accumulated CSI parameter/intermediate bytes
+private string paste = "";     // accumulated bracketed-paste content
+private int osc_esc = 0;       // saw ESC inside OSC (looking for ST)
+private int pending_cr = 0;    // last plain char was CR: swallow a following LF
+
+void reset() {
+  state = S_NONE;
+  csi = paste = "";
+  osc_esc = pending_cr = 0;
+}
+
+// Only a bare ESC needs timer-based disambiguation.
+int has_pending() { return state == S_ESC; }
+
+// xterm modifier parameter -> TUI_MOD_* bits (2=shift 3=alt 5=ctrl ...).
+private int mods_of(int m) {
+  int r = 0;
+
+  if (m < 2) return 0;
+  m--;
+  if (m & 1) r |= TUI_MOD_SHIFT;
+  if (m & 2) r |= TUI_MOD_ALT;
+  if (m & 4) r |= TUI_MOD_CTRL;
+  return r;
+}
+
+private mixed *csi_tilde(int *ps) {
+  int k = sizeof(ps) ? ps[0] : 0;
+  int mod = sizeof(ps) > 1 ? mods_of(ps[1]) : 0;
+
+  switch (k) {
+    case 1:
+    case 7:
+      return ({ mod | TUI_KEY_HOME });
+    case 2:
+      return ({ mod | TUI_KEY_INSERT });
+    case 3:
+      return ({ mod | TUI_KEY_DELETE });
+    case 4:
+    case 8:
+      return ({ mod | TUI_KEY_END });
+    case 5:
+      return ({ mod | TUI_KEY_PGUP });
+    case 6:
+      return ({ mod | TUI_KEY_PGDN });
+    case 11..15:
+      return ({ mod | (TUI_KEY_F1 + k - 11) });
+    case 17..21:
+      return ({ mod | (TUI_KEY_F6 + k - 17) });
+    case 23:
+      return ({ mod | TUI_KEY_F11 });
+    case 24:
+      return ({ mod | TUI_KEY_F12 });
+    case 200:  // bracketed paste begins
+      state = S_PASTE;
+      paste = "";
+      return ({});
+    case 201:  // stray paste terminator
+      return ({});
+  }
+  return ({ TUI_KEY_UNKNOWN });
+}
+
+// CSI-u (modifyOtherKeys / kitty): "code;mods u"
+private mixed *csi_u(int *ps) {
+  int code = sizeof(ps) ? ps[0] : 0;
+  int mod = sizeof(ps) > 1 ? mods_of(ps[1]) : 0;
+
+  switch (code) {
+    case 13:
+      return ({ mod | TUI_KEY_ENTER });
+    case 9:
+      return ({ mod | TUI_KEY_TAB });
+    case 27:
+      return ({ mod | TUI_KEY_ESC });
+    case 8:
+    case 127:
+      return ({ mod | TUI_KEY_BACKSPACE });
+  }
+  if (!code) return ({ TUI_KEY_UNKNOWN });
+  if (!mod && code >= 32) return ({ sprintf("%c", code) });
+  return ({ mod | code });
+}
+
+private mixed *csi_final(string p, int c) {
+  int *ps = ({});
+  int mod = 0;
+
+  // SGR mouse: ESC [ < b ; x ; y M/m
+  if (strlen(p) && p[0] == '<' && (c == 'M' || c == 'm')) {
+    string *parts = explode(p[1..], ";");
+    if (sizeof(parts) == 3) {
+      return ({ ({ TUI_EV_MOUSE, to_int(parts[0]), to_int(parts[1]) - 1,
+                   to_int(parts[2]) - 1, c == 'M' }) });
+    }
+    return ({ TUI_KEY_UNKNOWN });
+  }
+
+  if (p != "") {
+    foreach (string part in explode(p, ";")) ps += ({ to_int(part) });
+  }
+  if (sizeof(ps) > 1) mod = mods_of(ps[1]);
+
+  switch (c) {
+    case 'A':
+      return ({ mod | TUI_KEY_UP });
+    case 'B':
+      return ({ mod | TUI_KEY_DOWN });
+    case 'C':
+      return ({ mod | TUI_KEY_RIGHT });
+    case 'D':
+      return ({ mod | TUI_KEY_LEFT });
+    case 'H':
+      return ({ mod | TUI_KEY_HOME });
+    case 'F':
+      return ({ mod | TUI_KEY_END });
+    case 'Z':
+      return ({ TUI_MOD_SHIFT | TUI_KEY_TAB });
+    case '~':
+      return csi_tilde(ps);
+    case 'u':
+      return csi_u(ps);
+    case 'P':
+      return ({ mod | TUI_KEY_F1 });
+    case 'Q':
+      return ({ mod | TUI_KEY_F2 });
+    case 'S':
+      return ({ mod | TUI_KEY_F4 });
+    case 'R':  // cursor position report (response to ESC[6n)
+      if (sizeof(ps) == 2) return ({ ({ TUI_EV_CPR, ps[0], ps[1] }) });
+      return ({ mod | TUI_KEY_F3 });
+  }
+  return ({ TUI_KEY_UNKNOWN });
+}
+
+private mixed *ss3_final(int c) {
+  switch (c) {
+    case 'A':
+      return ({ TUI_KEY_UP });
+    case 'B':
+      return ({ TUI_KEY_DOWN });
+    case 'C':
+      return ({ TUI_KEY_RIGHT });
+    case 'D':
+      return ({ TUI_KEY_LEFT });
+    case 'H':
+      return ({ TUI_KEY_HOME });
+    case 'F':
+      return ({ TUI_KEY_END });
+    case 'M':
+      return ({ TUI_KEY_ENTER });
+    case 'P':
+      return ({ TUI_KEY_F1 });
+    case 'Q':
+      return ({ TUI_KEY_F2 });
+    case 'R':
+      return ({ TUI_KEY_F3 });
+    case 'S':
+      return ({ TUI_KEY_F4 });
+  }
+  return ({ TUI_KEY_UNKNOWN });
+}
+
+private mixed *plain(string ch, int c) {
+  int was_cr = pending_cr;
+
+  pending_cr = 0;
+  switch (c) {
+    case 27:
+      state = S_ESC;
+      return ({});
+    case 13:
+      pending_cr = 1;
+      return ({ TUI_KEY_ENTER });
+    case 10:
+      return was_cr ? ({}) : ({ TUI_KEY_ENTER });
+    case 9:
+      return ({ TUI_KEY_TAB });
+    case 8:
+    case 127:
+      return ({ TUI_KEY_BACKSPACE });
+    case 1..7:
+    case 11:
+    case 12:
+    case 14..26:
+      return ({ TUI_MOD_CTRL | (c + 96) });  // C-a .. C-z
+    case 28..31:
+      return ({ TUI_MOD_CTRL | (c + 64) });  // C-\ C-] C-^ C-_
+    case 0:
+      return ({});
+  }
+  return ({ ch });
+}
+
+private mixed *esc_second(string ch, int c) {
+  switch (c) {
+    case '[':
+      state = S_CSI;
+      csi = "";
+      return ({});
+    case 'O':
+      state = S_SS3;
+      return ({});
+    case ']':
+      state = S_OSC;
+      osc_esc = 0;
+      return ({});
+    case 27:  // ESC ESC: emit one, stay armed for the next
+      return ({ TUI_KEY_ESC });
+    case 8:
+    case 127:
+      state = S_NONE;
+      return ({ TUI_MOD_ALT | TUI_KEY_BACKSPACE });
+    case 13:
+      state = S_NONE;
+      return ({ TUI_MOD_ALT | TUI_KEY_ENTER });
+    case 9:
+      state = S_NONE;
+      return ({ TUI_MOD_ALT | TUI_KEY_TAB });
+  }
+  state = S_NONE;
+  if (c < 32) return ({ TUI_MOD_ALT | TUI_MOD_CTRL | (c + 96) });
+  return ({ TUI_MOD_ALT | c });
+}
+
+private mixed *step(string ch) {
+  int c = ch[0];
+
+  switch (state) {
+    case S_NONE:
+      return plain(ch, c);
+
+    case S_ESC:
+      return esc_second(ch, c);
+
+    case S_CSI:
+      if (c >= 0x40 && c <= 0x7e) {
+        string p = csi;
+        state = S_NONE;
+        csi = "";
+        return csi_final(p, c);
+      }
+      if (strlen(csi) > 64) {  // runaway guard
+        state = S_NONE;
+        csi = "";
+        return ({ TUI_KEY_UNKNOWN });
+      }
+      csi += ch;
+      return ({});
+
+    case S_SS3:
+      state = S_NONE;
+      return ss3_final(c);
+
+    case S_OSC:
+      if (c == 7 || (osc_esc && c == '\\')) {
+        state = S_NONE;
+      } else {
+        osc_esc = c == 27;
+      }
+      return ({});
+
+    case S_PASTE:
+      paste += ch;
+      if (strlen(paste) >= 6 && paste[<6..] == "\e[201~") {
+        string text = paste[0..<7];
+        state = S_NONE;
+        paste = "";
+        return text == "" ? ({}) : ({ text });
+      }
+      return ({});
+  }
+  return ({});
+}
+
+// Decode a chunk of input exactly as get_char() delivered it.  Also accepts
+// longer strings (tests, pastes replayed in one piece).  Returns the array
+// of decoded events, possibly empty.
+mixed *feed(string chunk) {
+  mixed *evs = ({});
+  int i, n;
+
+  if (!stringp(chunk)) return evs;
+  if (chunk == "") {
+    // pre-2026 drivers delivered "" for Backspace/Delete in char mode
+    return state == S_NONE ? ({ TUI_KEY_BACKSPACE }) : ({});
+  }
+  n = strlen(chunk);
+  for (i = 0; i < n; i++) evs += step(chunk[i..i]);
+  return evs;
+}
+
+// Resolve a dangling lone ESC (called by the glue layer on timeout).
+mixed *flush() {
+  if (state != S_ESC) return ({});
+  state = S_NONE;
+  return ({ TUI_KEY_ESC });
+}

--- a/testsuite/std/tui/menu.lpc
+++ b/testsuite/std/tui/menu.lpc
@@ -1,0 +1,141 @@
+// /std/tui/menu — inline select / multiselect engine (pterm-style).
+//
+// Renders a prompt plus a scrolling choice list *in the normal output flow*
+// (no alternate screen), repainting in place with relative cursor movement.
+// Pure state machine like /std/tui/readline: feed key events, drain output;
+// /std/tui/terminal wires it to a live user via tui_select()/tui_multiselect().
+//
+//   ? Pick a class:
+//     ❯ warrior
+//       mage        (multiselect adds [x] marks; space toggles)
+//       thief
+//
+// Keys: ↑/↓/C-p/C-n move, PgUp/PgDn page, space toggles (multiselect),
+// Enter accepts, C-c/ESC aborts.  On completion the list collapses to a
+// single "? prompt: answer" line.
+
+#include <tui.h>
+
+inherit TUI_ANSI;
+
+private string prompt = "";
+private string *items = ({});
+private int multi = 0;
+private int sel = 0;
+private int top = 0;
+private int height = 7;          // max visible choices
+private mapping checked = ([]);
+private int state = TUI_RL_MORE;
+private string out = "";
+private int drawn = 0;           // lines currently on screen
+private int began = 0;
+
+int m_state() { return state; }
+string m_take_output() { string o = out; out = ""; return o; }
+
+// selected index (single), or the sorted checked indexes (multi)
+mixed m_result() {
+  if (multi) {
+    int *r = ({});
+    int i;
+
+    for (i = 0; i < sizeof(items); i++) {
+      if (checked[i]) r += ({ i });
+    }
+    return r;
+  }
+  return sel;
+}
+
+string m_item(int i) { return i >= 0 && i < sizeof(items) ? items[i] : 0; }
+
+private string answer_text() {
+  if (!multi) return state == TUI_RL_DONE ? items[sel] : "-";
+  if (state != TUI_RL_DONE) return "-";
+  return implode(map(m_result(), (: items[$1] :)), ", ");
+}
+
+private void render() {
+  string *lines = ({ "? " + prompt });
+  int i, n = sizeof(items);
+
+  if (sel < top) top = sel;
+  if (sel >= top + height) top = sel - height + 1;
+  for (i = top; i < n && i < top + height; i++) {
+    string mark = multi ? (checked[i] ? "[x] " : "[ ] ") : "";
+    string line;
+
+    if (i == sel) {
+      line = "  ❯ " + mark + ansi_sgr("7") + items[i] + ansi_reset();
+    } else {
+      line = "    " + mark + items[i];
+    }
+    lines += ({ line });
+  }
+  if (top + height < n) lines += ({ "    …" });
+
+  out += "\r" + ansi_up(drawn);
+  foreach (string l in lines) out += l + ansi_el(0) + "\r\n";
+  out += ansi_ed(0);
+  drawn = sizeof(lines);
+}
+
+private void finish() {
+  out += "\r" + ansi_up(drawn) + "? " + prompt + " " + ansi_sgr("1;36") + answer_text() +
+         ansi_reset() + ansi_el(0) + "\r\n" + ansi_ed(0);
+  drawn = 0;
+  began = 0;
+}
+
+varargs string m_begin(string p, string *choices, mapping opts) {
+  prompt = stringp(p) ? p : "";
+  items = arrayp(choices) ? choices[0..] : ({});
+  if (!mapp(opts)) opts = ([]);
+  multi = opts["multi"];
+  height = opts["height"] > 0 ? opts["height"] : 7;
+  sel = opts["initial"] >= 0 && opts["initial"] < sizeof(items) ? opts["initial"] : 0;
+  checked = ([]);
+  if (arrayp(opts["checked"])) {
+    foreach (int i in opts["checked"]) checked[i] = 1;
+  }
+  top = 0;
+  state = sizeof(items) ? TUI_RL_MORE : TUI_RL_ABORT;
+  out = "";
+  drawn = 0;
+  began = 1;
+  render();
+  return m_take_output();
+}
+
+int m_feed(mixed ev) {
+  if (state != TUI_RL_MORE || !began) return state;
+
+  if (ev == TUI_KEY_UP || ev == TUI_CTRL('p')) {
+    if (sel > 0) sel--;
+  } else if (ev == TUI_KEY_DOWN || ev == TUI_CTRL('n')) {
+    if (sel < sizeof(items) - 1) sel++;
+  } else if (ev == TUI_KEY_PGUP) {
+    sel = sel - height < 0 ? 0 : sel - height;
+  } else if (ev == TUI_KEY_PGDN) {
+    sel = sel + height >= sizeof(items) ? sizeof(items) - 1 : sel + height;
+  } else if (ev == TUI_KEY_HOME) {
+    sel = 0;
+  } else if (ev == TUI_KEY_END) {
+    sel = sizeof(items) - 1;
+  } else if (multi && ev == " ") {
+    checked[sel] = !checked[sel];
+  } else if (ev == TUI_KEY_ENTER) {
+    if (multi && !sizeof(m_result())) checked[sel] = 1;  // enter picks under cursor
+    state = TUI_RL_DONE;
+    finish();
+    return state;
+  } else if (ev == TUI_CTRL('c') || ev == TUI_KEY_ESC) {
+    state = TUI_RL_ABORT;
+    finish();
+    return state;
+  } else {
+    return state;  // ignored key: no repaint
+  }
+  render();
+  return state;
+}

--- a/testsuite/std/tui/print.lpc
+++ b/testsuite/std/tui/print.lpc
@@ -1,0 +1,234 @@
+// /std/tui/print — pterm-style inline printers.
+//
+// Stateless string builders for prompt-mode output (write(p_table(...)))
+// and for widgets to render with.  Everything returns a string ending in
+// "\n" when multi-line.  All width math is display-column based
+// (wide-char aware); attrs are SGR parameter strings as everywhere in
+// /std/tui.
+
+#include <tui.h>
+
+inherit TUI_ANSI;
+
+// style -> ({ corners tl tr bl br, junctions t x b l r, h, v })
+private string *table_chars(int style) {
+  switch (style) {
+    case TUI_BOX_DOUBLE:
+      return ({ "╔", "╗", "╚", "╝", "╦", "╬", "╩", "╠", "╣", "═", "║" });
+    case TUI_BOX_ROUND:
+      return ({ "╭", "╮", "╰", "╯", "┬", "┼", "┴", "├", "┤", "─", "│" });
+    case TUI_BOX_ASCII:
+      return ({ "+", "+", "+", "+", "+", "+", "+", "+", "+", "-", "|" });
+  }
+  return ({ "┌", "┐", "└", "┘", "┬", "┼", "┴", "├", "┤", "─", "│" });
+}
+
+private string table_rule(int *w, string l, string j, string r, string h) {
+  string *segs = ({});
+
+  foreach (int cw in w) segs += ({ repeat_string(h, cw + 2) });
+  return l + implode(segs, j) + r + "\n";
+}
+
+// Render rows (arrays of cell values) as a boxed table.
+// opts: "header": 1 (first row is a header with a separator rule),
+//       "style": TUI_BOX_* (default single).
+varargs string p_table(mixed *rows, mapping opts) {
+  string *chars;
+  int *w = ({});
+  string out = "";
+  int i, j, cols = 0, style, header;
+
+  if (!arrayp(rows) || !sizeof(rows)) return "";
+  if (!mapp(opts)) opts = ([]);
+  style = opts["style"];
+  header = opts["header"];
+  chars = table_chars(style);
+
+  foreach (mixed row in rows) {
+    if (arrayp(row) && sizeof(row) > cols) cols = sizeof(row);
+  }
+  for (j = 0; j < cols; j++) {
+    int best = 0;
+    for (i = 0; i < sizeof(rows); i++) {
+      int cw = j < sizeof(rows[i]) ? visible_width("" + rows[i][j]) : 0;
+      if (cw > best) best = cw;
+    }
+    w += ({ best });
+  }
+
+  out += table_rule(w, chars[0], chars[4], chars[1], chars[9]);
+  for (i = 0; i < sizeof(rows); i++) {
+    string line = chars[10];
+    for (j = 0; j < cols; j++) {
+      string cell = j < sizeof(rows[i]) ? "" + rows[i][j] : "";
+      line += " " + cell + repeat_string(" ", w[j] - visible_width(cell)) + " " + chars[10];
+    }
+    out += line + "\n";
+    if (header && i == 0 && sizeof(rows) > 1) {
+      out += table_rule(w, chars[7], chars[5], chars[8], chars[9]);
+    }
+  }
+  out += table_rule(w, chars[2], chars[6], chars[3], chars[9]);
+  return out;
+}
+
+// Tree nodes: a node is a string (leaf) or ({ label, ({ children... }) }).
+private void tree_walk(mixed *nodes, string prefix, mixed *acc) {
+  int i, n = sizeof(nodes);
+
+  for (i = 0; i < n; i++) {
+    mixed node = nodes[i];
+    int last = i == n - 1;
+    string label = arrayp(node) ? "" + node[0] : "" + node;
+
+    acc[0] += prefix + (last ? "└── " : "├── ") + label + "\n";
+    if (arrayp(node) && sizeof(node) > 1 && arrayp(node[1])) {
+      tree_walk(node[1], prefix + (last ? "    " : "│   "), acc);
+    }
+  }
+}
+
+varargs string p_tree(mixed root, mapping opts) {
+  mixed *acc = ({ "" });
+
+  if (stringp(root)) return root + "\n";
+  if (!arrayp(root)) return "";
+  if (sizeof(root) == 2 && stringp(root[0]) && arrayp(root[1])) {
+    acc[0] = root[0] + "\n";
+    tree_walk(root[1], "", acc);
+  } else {
+    tree_walk(root, "", acc);
+  }
+  return acc[0];
+}
+
+// Horizontal bar chart.  items: ({ ({ label, value }), ... })
+// opts: "width": bar columns (default 30), "attr": SGR params for the bars.
+varargs string p_bars(mixed *items, mapping opts) {
+  int width, max = 1, lw = 0;
+  string out = "", attr;
+
+  if (!arrayp(items) || !sizeof(items)) return "";
+  if (!mapp(opts)) opts = ([]);
+  width = opts["width"] > 0 ? opts["width"] : 30;
+  attr = stringp(opts["attr"]) ? opts["attr"] : "";
+
+  foreach (mixed it in items) {
+    if (it[1] > max) max = it[1];
+    if (visible_width("" + it[0]) > lw) lw = visible_width("" + it[0]);
+  }
+  foreach (mixed it in items) {
+    int n = it[1] * width / max;
+    string bar = repeat_string("█", n);
+
+    if (attr != "") bar = ansi_sgr(attr) + bar + ansi_reset();
+    out += wpad("" + it[0], lw) + " " + bar + " " + it[1] + "\n";
+  }
+  return out;
+}
+
+// Sparkline: one line, one char per value.
+string p_spark(int *values) {
+  string *ticks = ({ "▁", "▂", "▃", "▄", "▅", "▆", "▇", "█" });
+  string out = "";
+  int max = 1;
+
+  if (!arrayp(values) || !sizeof(values)) return "";
+  foreach (int v in values) {
+    if (v > max) max = v;
+  }
+  foreach (int v in values) {
+    int i = v > 0 ? (v * 8 - 1) / max : 0;
+    out += ticks[i > 7 ? 7 : i];
+  }
+  return out;
+}
+
+// "████████░░░░░░  57%"
+varargs string p_progress(int pct, int width, mapping opts) {
+  int filled;
+
+  if (width < 1) width = 20;
+  if (pct < 0) pct = 0;
+  if (pct > 100) pct = 100;
+  filled = width * pct / 100;
+  return repeat_string("█", filled) + repeat_string("░", width - filled) +
+         sprintf(" %3d%%", pct);
+}
+
+// A titled box around body text.
+// opts: "style": TUI_BOX_*, "width": inner width (default: fit content).
+varargs string p_panel(string title, string body, mapping opts) {
+  string *chars, *lines;
+  string out;
+  int inner = 0, style;
+
+  if (!mapp(opts)) opts = ([]);
+  style = opts["style"];
+  chars = table_chars(style);
+  lines = stringp(body) && body != "" ? explode(body, "\n") : ({});
+  title = stringp(title) && title != "" ? " " + title + " " : "";
+
+  foreach (string l in lines) {
+    if (visible_width(l) > inner) inner = visible_width(l);
+  }
+  if (visible_width(title) + 2 > inner) inner = visible_width(title) + 2;
+  if (opts["width"] > inner) inner = opts["width"];
+
+  out = chars[0] + chars[9] + title +
+        repeat_string(chars[9], inner - visible_width(title) + 1) + chars[1] + "\n";
+  foreach (string l in lines) {
+    out += chars[10] + " " + l + repeat_string(" ", inner - visible_width(l)) + " " + chars[10] + "\n";
+  }
+  out += chars[2] + repeat_string(chars[9], inner + 2) + chars[3] + "\n";
+  return out;
+}
+
+// Bullet list.  Items: strings, or ({ depth, text }) for nesting.
+string p_bullets(mixed *items) {
+  string *marks = ({ "•", "◦", "▪" });
+  string out = "";
+
+  if (!arrayp(items)) return "";
+  foreach (mixed it in items) {
+    int depth = arrayp(it) ? it[0] : 0;
+    string text = arrayp(it) ? "" + it[1] : "" + it;
+
+    if (depth < 0) depth = 0;
+    out += repeat_string("  ", depth) + marks[depth < 3 ? depth : 2] + " " + text + "\n";
+  }
+  return out;
+}
+
+// Full-width banner with the text centered.
+varargs string p_header(string text, int width, string attr) {
+  int pad;
+
+  if (width < visible_width(text) + 2) width = visible_width(text) + 2;
+  if (!stringp(attr)) attr = "1;7";
+  pad = (width - visible_width(text)) / 2;
+  return ansi_sgr(attr) + repeat_string(" ", pad) + text +
+         repeat_string(" ", width - pad - visible_width(text)) + ansi_reset() + "\n";
+}
+
+// pterm-style prefix printers.
+private string prefixed(string tag, string attr, string text) {
+  return ansi_sgr(attr) + " " + tag + " " + ansi_reset() + " " + text + "\n";
+}
+
+string p_info(string text) { return prefixed("INFO", "30;46", text); }
+string p_success(string text) { return prefixed(" OK ", "30;42", text); }
+string p_warn(string text) { return prefixed("WARN", "30;43", text); }
+string p_error(string text) { return prefixed("FAIL", "97;41", text); }
+
+// Large banner text via /std/bitmap_font (falls back to plain text if the
+// font files are unavailable).
+varargs string p_bigtext(string text, string fcolor) {
+  string big;
+
+  if (catch (big = (string)"/std/bitmap_font"->bitmap_font(text, 12, "█", " ", fcolor, ""))) {
+    return text + "\n";
+  }
+  return stringp(big) ? big : text + "\n";
+}

--- a/testsuite/std/tui/print.lpc
+++ b/testsuite/std/tui/print.lpc
@@ -128,6 +128,160 @@ varargs string p_bars(mixed *items, mapping opts) {
   return out;
 }
 
+// Vertical bar chart with eighth-block partial tops (pterm Barchart).
+// items: ({ ({ label, value }), ... })
+// opts: "height": bar rows (default 6), "attr": SGR for the bars,
+//       "values": 1 to print each value above its bar.
+varargs string p_vbars(mixed *items, mapping opts) {
+  string *eighths = ({ " ", "▁", "▂", "▃", "▄", "▅", "▆", "▇" });
+  int *colw = ({}), *ev = ({});
+  int height, max = 1, r, i;
+  string out = "", attr;
+
+  if (!arrayp(items) || !sizeof(items)) return "";
+  if (!mapp(opts)) opts = ([]);
+  height = opts["height"] > 0 ? opts["height"] : 6;
+  attr = stringp(opts["attr"]) ? opts["attr"] : "";
+
+  foreach (mixed it in items) {
+    int w = visible_width("" + it[0]);
+
+    if (opts["values"] && visible_width("" + it[1]) > w) w = visible_width("" + it[1]);
+    if (w < 3) w = 3;
+    colw += ({ w });
+    if (it[1] > max) max = it[1];
+  }
+  for (i = 0; i < sizeof(items); i++) ev += ({ items[i][1] * height * 8 / max });
+
+  if (opts["values"]) {
+    string line = "";
+    for (i = 0; i < sizeof(items); i++) line += wpad("" + items[i][1], colw[i]) + " ";
+    out += line + "\n";
+  }
+  for (r = height - 1; r >= 0; r--) {  // r = rows above the baseline
+    string line = "";
+    for (i = 0; i < sizeof(items); i++) {
+      int e = ev[i] - r * 8;
+      string seg = e >= 8 ? "█" : eighths[e > 0 ? e : 0];
+      line += repeat_string(seg, colw[i]) + " ";
+    }
+    out += (attr != "" ? ansi_sgr(attr) + line + ansi_reset() : line) + "\n";
+  }
+  for (i = 0; i < sizeof(items); i++) {
+    out += wpad(wslice("" + items[i][0], 0, colw[i]), colw[i]) + " ";
+  }
+  return out + "\n";
+}
+
+// Braille line chart (blessed-contrib style).
+// series: a plain int* for one line, or ({ ({ label, int *values, attr }), ... }).
+// opts: "width"/"height" in cells (default 56×10), "min"/"max" range
+//       override, "axis": 0 to drop the y-axis gutter.
+varargs string p_chart(mixed series, mapping opts) {
+  object cv;
+  string *rows, *legend = ({});
+  string out = "";
+  int width, height, lo, hi, have_range = 0, cy, gw;
+
+  if (!mapp(opts)) opts = ([]);
+  if (arrayp(series) && sizeof(series) && intp(series[0])) {
+    series = ({ ({ "", series, "" }) });
+  }
+  if (!arrayp(series) || !sizeof(series)) return "";
+  width = opts["width"] > 0 ? opts["width"] : 56;
+  height = opts["height"] > 0 ? opts["height"] : 10;
+
+  foreach (mixed s in series) {
+    foreach (int v in s[1]) {
+      if (!have_range) {
+        lo = hi = v;
+        have_range = 1;
+      }
+      if (v < lo) lo = v;
+      if (v > hi) hi = v;
+    }
+  }
+  if (!undefinedp(opts["min"])) lo = opts["min"];
+  if (!undefinedp(opts["max"])) hi = opts["max"];
+  if (hi <= lo) hi = lo + 1;
+
+  cv = clone_object(TUI_CANVAS);
+  cv->c_resize(width, height);
+  foreach (mixed s in series) {
+    cv->c_plot(s[1], lo, hi, stringp(s[2]) ? s[2] : "");
+    if (stringp(s[0]) && s[0] != "") {
+      legend += ({ (stringp(s[2]) && s[2] != "" ? ansi_sgr(s[2]) + "●" + ansi_reset() : "●") +
+                   " " + s[0] });
+    }
+  }
+  rows = cv->c_rows();
+  destruct(cv);
+
+  if (opts["axis"] == 0 && !undefinedp(opts["axis"])) {
+    out = implode(rows, "\n") + "\n";
+  } else {
+    gw = visible_width("" + hi);
+    if (visible_width("" + lo) > gw) gw = visible_width("" + lo);
+    for (cy = 0; cy < height; cy++) {
+      if (cy == 0) out += wpad("" + hi, gw) + "┤";
+      else if (cy == height - 1) out += wpad("" + lo, gw) + "┤";
+      else out += repeat_string(" ", gw) + "│";
+      out += rows[cy] + "\n";
+    }
+  }
+  if (sizeof(legend)) out += implode(legend, "  ") + "\n";
+  return out;
+}
+
+// Heatmap: a 2D int matrix as coloured cells (pterm Heatmap).
+// opts: "ramp": int* of 256-colour indexes (cool → hot),
+//       "xlabels"/"ylabels": string*, "cellw": cell width (default 2).
+varargs string p_heatmap(mixed *grid, mapping opts) {
+  int *ramp;
+  string *ylab;
+  int lo, hi, have = 0, gw = 0, cellw, y, x;
+  string out = "";
+
+  if (!arrayp(grid) || !sizeof(grid)) return "";
+  if (!mapp(opts)) opts = ([]);
+  ramp = arrayp(opts["ramp"]) ? opts["ramp"]
+                              : ({ 17, 18, 19, 20, 26, 32, 38, 44, 50, 220, 214, 208, 202, 196 });
+  cellw = opts["cellw"] > 0 ? opts["cellw"] : 2;
+  ylab = arrayp(opts["ylabels"]) ? opts["ylabels"] : 0;
+
+  foreach (mixed row in grid) {
+    foreach (int v in row) {
+      if (!have) {
+        lo = hi = v;
+        have = 1;
+      }
+      if (v < lo) lo = v;
+      if (v > hi) hi = v;
+    }
+  }
+  if (hi <= lo) hi = lo + 1;
+  if (ylab) {
+    foreach (string l in ylab) {
+      if (visible_width(l) > gw) gw = visible_width(l);
+    }
+  }
+
+  for (y = 0; y < sizeof(grid); y++) {
+    if (ylab) out += wpad(y < sizeof(ylab) ? ylab[y] : "", gw) + " ";
+    for (x = 0; x < sizeof(grid[y]); x++) {
+      int idx = (grid[y][x] - lo) * (sizeof(ramp) - 1) / (hi - lo);
+      out += ansi_sgr("48;5;" + ramp[idx]) + repeat_string(" ", cellw);
+    }
+    out += ansi_reset() + "\n";
+  }
+  if (arrayp(opts["xlabels"])) {
+    if (ylab) out += repeat_string(" ", gw + 1);
+    foreach (string l in opts["xlabels"]) out += wpad(wslice(l, 0, cellw), cellw);
+    out += "\n";
+  }
+  return out;
+}
+
 // Sparkline: one line, one char per value.
 string p_spark(int *values) {
   string *ticks = ({ "▁", "▂", "▃", "▄", "▅", "▆", "▇", "█" });

--- a/testsuite/std/tui/readline.lpc
+++ b/testsuite/std/tui/readline.lpc
@@ -1,0 +1,472 @@
+// /std/tui/readline — layer 2 of the TUI library: the line editor.
+//
+// A pure state machine: rl_feed() consumes key events (from /std/tui/keys),
+// mutates the edit buffer, and accumulates ANSI repaint bytes which the
+// caller drains with rl_take_output() and writes to the user.  The engine
+// repaints only its own line (no absolute cursor addressing), so it works at
+// any scroll position — this is the "better input_to" for prompt lines.
+//
+// Emacs/readline keymap: motion (C-a/C-e/C-b/C-f, M-b/M-f, Home/End,
+// arrows), kill/yank (C-k/C-u/C-w/M-d/C-y), transpose (C-t), history
+// (Up/Down/C-p/C-n), incremental search (C-r/C-s), completion (Tab),
+// accept (Enter), abort (C-c), EOF (C-d on an empty line).
+//
+// Clone one per user; it is reusable: each rl_begin() starts a fresh line
+// while history and configuration persist.
+
+#include <tui.h>
+
+inherit TUI_ANSI;
+
+// --- configuration ---
+private string prompt = "> ";
+private int width = 80;
+private int masked = 0;
+private function completer = 0;
+private int hist_max = 500;
+
+// --- line state ---
+private string buf = "";
+private int pos = 0;              // cursor, codepoint index into buf
+private int state = TUI_RL_MORE;
+private string out = "";          // pending repaint bytes
+private int scroll = 0;           // viewport start column
+private int began = 0;
+private string kill_buf = "";
+private int last_tab = 0;
+
+// --- history ---
+private string *hist = ({});
+private int hidx = 0;             // == sizeof(hist) while editing the live line
+private string hsave = "";        // the live line, saved while browsing
+
+// --- incremental search ---
+private int is_dir = 0;           // 0 off, -1 reverse (C-r), 1 forward (C-s)
+private string is_q = "";
+private int is_match = -1;        // hist index of current match
+private int is_fail = 0;
+private string is_save = "";
+private int is_pos_save = 0;
+
+private nosave mapping keymap;
+
+// forward declarations (used before their definitions)
+void rl_add_history(string line);
+string rl_take_output();
+
+// ----------------------------------------------------------------------
+// small string helpers (codepoint-index slicing with safe bounds)
+
+private string pre(string s, int i) { return i <= 0 ? "" : (i >= strlen(s) ? s : s[0..i - 1]); }
+private string post(string s, int i) { return i >= strlen(s) ? "" : (i <= 0 ? s : s[i..]); }
+
+private int is_word(int c) {
+  return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') ||
+         c == '_' || c > 127;
+}
+
+private int word_back() {
+  int i = pos;
+
+  while (i > 0 && !is_word(buf[i - 1])) i--;
+  while (i > 0 && is_word(buf[i - 1])) i--;
+  return i;
+}
+
+private int word_fwd() {
+  int i = pos, n = strlen(buf);
+
+  while (i < n && !is_word(buf[i])) i++;
+  while (i < n && is_word(buf[i])) i++;
+  return i;
+}
+
+// ----------------------------------------------------------------------
+// rendering
+
+private string isearch_prompt() {
+  return (is_fail ? "(failed " : "(") + (is_dir < 0 ? "reverse-i-search" : "i-search") +
+         ")`" + is_q + "': ";
+}
+
+// Repaint the whole line: \r prompt view EL, then park the cursor.
+private void render() {
+  string disp = masked ? repeat_string("*", strlen(buf)) : buf;
+  string pfx = is_dir ? isearch_prompt() : prompt;
+  int pw = visible_width(pfx);
+  int avail = width - pw - 1;  // leave the last column free (no autowrap)
+  int cur, total;
+  string view;
+
+  if (avail < 8) avail = 8;
+  cur = strwidth(pre(disp, pos));
+  total = strwidth(disp);
+
+  // keep the cursor inside the viewport, with a margin column where a
+  // scroll marker is displayed
+  if (cur < scroll + (scroll > 0 ? 1 : 0)) scroll = cur > 1 ? cur - 1 : 0;
+  if (total - scroll > avail && cur - scroll >= avail - 1) scroll = cur - avail + 2;
+  if (cur - scroll >= avail) scroll = cur - avail + 1;
+  if (scroll < 0) scroll = 0;
+
+  view = wslice(disp, scroll, avail);
+  if (scroll > 0) view = "<" + wslice(disp, scroll + 1, avail - 1);
+  if (total - scroll > avail) view = wslice(disp, scroll, avail - 1) + ">";
+
+  out += "\r" + pfx + view + ansi_el(0) + "\r" + ansi_fwd(pw + cur - scroll);
+}
+
+// Final repaint with the cursor at end-of-line, then newline.
+private void finish_line() {
+  is_dir = 0;
+  pos = strlen(buf);
+  render();
+  out += "\r\n";
+  began = 0;
+}
+
+// ----------------------------------------------------------------------
+// editing primitives
+
+private void insert(string text) {
+  if (!stringp(text) || text == "") return;
+  buf = pre(buf, pos) + text + post(buf, pos);
+  pos += strlen(text);
+}
+
+private void accept_line() {
+  rl_add_history(buf);
+  state = TUI_RL_DONE;
+  finish_line();
+}
+
+private void hist_move(int dir) {
+  int n = sizeof(hist);
+  int ni = hidx + dir;
+
+  if (ni < 0 || ni > n) return;
+  if (hidx == n) hsave = buf;
+  hidx = ni;
+  buf = ni == n ? hsave : hist[ni];
+  pos = strlen(buf);
+}
+
+// ----------------------------------------------------------------------
+// incremental history search
+
+private void isearch_find(int advance) {
+  int i, start, n = sizeof(hist);
+
+  is_fail = 0;
+  if (is_q == "") return;
+  if (is_dir < 0) {
+    start = is_match == -1 ? n - 1 : is_match - advance;
+    for (i = start; i >= 0; i--) {
+      if (strsrch(hist[i], is_q) != -1) break;
+    }
+    if (i < 0) i = -1;
+  } else {
+    start = is_match == -1 ? 0 : is_match + advance;
+    for (i = start; i < n; i++) {
+      if (strsrch(hist[i], is_q) != -1) break;
+    }
+    if (i >= n) i = -1;
+  }
+  if (i == -1) {
+    is_fail = 1;
+    return;
+  }
+  is_match = i;
+  hidx = i;
+  buf = hist[i];
+  pos = strsrch(buf, is_q) + strlen(is_q);
+}
+
+private void isearch_start(int dir) {
+  if (!is_dir) {
+    is_save = buf;
+    is_pos_save = pos;
+    is_q = "";
+    is_match = -1;
+    is_fail = 0;
+  }
+  is_dir = dir;
+}
+
+private void dispatch(mixed ev);  // forward
+
+private void isearch_feed(mixed ev) {
+  if (stringp(ev)) {
+    is_q += ev;
+    isearch_find(0);
+  } else if (ev == TUI_CTRL('r') || ev == TUI_CTRL('s')) {
+    is_dir = ev == TUI_CTRL('r') ? -1 : 1;
+    if (is_match != -1) isearch_find(1);
+    else isearch_find(0);
+  } else if (ev == TUI_KEY_BACKSPACE) {
+    if (is_q != "") is_q = pre(is_q, strlen(is_q) - 1);
+    is_match = -1;
+    isearch_find(0);
+  } else if (ev == TUI_CTRL('g')) {  // cancel: restore the pre-search line
+    buf = is_save;
+    pos = is_pos_save;
+    hidx = sizeof(hist);
+    is_dir = 0;
+  } else if (ev == TUI_KEY_ESC) {  // accept the result, keep editing
+    is_dir = 0;
+  } else {  // any other key accepts the result and acts normally
+    is_dir = 0;
+    dispatch(ev);
+    return;
+  }
+  render();
+}
+
+// ----------------------------------------------------------------------
+// completion
+
+private int common_prefix_len(string *words) {
+  int i, j, n;
+  string first;
+
+  if (!sizeof(words)) return 0;
+  first = words[0];
+  n = strlen(first);
+  for (i = 1; i < sizeof(words); i++) {
+    int m = strlen(words[i]);
+    if (m < n) n = m;
+    for (j = 0; j < n; j++) {
+      if (words[i][j] != first[j]) break;
+    }
+    n = j;
+  }
+  return n;
+}
+
+private void complete() {
+  mixed cands;
+  string frag;
+  string *matches = ({});
+  int fs, lcp;
+
+  if (!functionp(completer)) return;
+  cands = evaluate(completer, buf, pos);
+  if (!arrayp(cands) || !sizeof(cands)) return;
+
+  fs = word_back();
+  frag = pos > fs ? buf[fs..pos - 1] : "";
+  foreach (mixed c in cands) {
+    if (stringp(c) && strlen(c) >= strlen(frag) && pre(c, strlen(frag)) == frag) {
+      matches += ({ c });
+    }
+  }
+  if (!sizeof(matches)) return;
+
+  lcp = common_prefix_len(matches);
+  if (lcp > strlen(frag)) {
+    insert(matches[0][strlen(frag)..lcp - 1]);
+    if (sizeof(matches) == 1) insert(" ");
+  } else if (sizeof(matches) > 1 && last_tab) {
+    // second Tab with nothing to extend: list the candidates above the line
+    out += "\r\n" + implode(matches, "  ") + "\r\n";
+  }
+}
+
+// ----------------------------------------------------------------------
+// key dispatch
+
+private void kb_left() { if (pos > 0) pos--; }
+private void kb_right() { if (pos < strlen(buf)) pos++; }
+private void kb_home() { pos = 0; }
+private void kb_end() { pos = strlen(buf); }
+private void kb_word_back() { pos = word_back(); }
+private void kb_word_fwd() { pos = word_fwd(); }
+
+private void kb_backspace() {
+  if (!pos) return;
+  buf = pre(buf, pos - 1) + post(buf, pos);
+  pos--;
+}
+
+private void kb_delete() {
+  if (pos < strlen(buf)) buf = pre(buf, pos) + post(buf, pos + 1);
+}
+
+private void kb_delete_or_eof() {
+  if (buf == "") {
+    state = TUI_RL_EOF;
+    finish_line();
+    return;
+  }
+  kb_delete();
+}
+
+private void kb_kill_to_end() {
+  if (pos < strlen(buf)) kill_buf = post(buf, pos);
+  buf = pre(buf, pos);
+}
+
+private void kb_kill_to_start() {
+  if (pos > 0) kill_buf = pre(buf, pos);
+  buf = post(buf, pos);
+  pos = 0;
+}
+
+private void kb_kill_word_back() {
+  int b = word_back();
+
+  if (b >= pos) return;
+  kill_buf = buf[b..pos - 1];
+  buf = pre(buf, b) + post(buf, pos);
+  pos = b;
+}
+
+private void kb_kill_word_fwd() {
+  int e = word_fwd();
+
+  if (e <= pos) return;
+  kill_buf = buf[pos..e - 1];
+  buf = pre(buf, pos) + post(buf, e);
+}
+
+private void kb_yank() { insert(kill_buf); }
+
+private void kb_transpose() {
+  int n = strlen(buf), p;
+  string a, b;
+
+  if (n < 2) return;
+  p = pos == n ? n - 1 : pos;
+  if (p == 0) p = 1;
+  a = buf[p - 1..p - 1];
+  b = buf[p..p];
+  buf = pre(buf, p - 1) + b + a + post(buf, p + 1);
+  pos = p + 1 > n ? n : p + 1;
+}
+
+private void kb_hist_prev() { hist_move(-1); }
+private void kb_hist_next() { hist_move(1); }
+private void kb_isearch_rev() { isearch_start(-1); }
+private void kb_isearch_fwd() { isearch_start(1); }
+private void kb_abort() { state = TUI_RL_ABORT; finish_line(); }
+private void kb_clear() { out += ansi_ed(2) + ansi_cup(0, 0); }
+private void kb_tab() { complete(); last_tab = 2; }  // survives the end-of-dispatch clear
+
+private void build_keymap() {
+  keymap = ([
+    TUI_KEY_ENTER: (: accept_line :),
+    TUI_KEY_LEFT: (: kb_left :),
+    TUI_CTRL('b'): (: kb_left :),
+    TUI_KEY_RIGHT: (: kb_right :),
+    TUI_CTRL('f'): (: kb_right :),
+    TUI_KEY_HOME: (: kb_home :),
+    TUI_CTRL('a'): (: kb_home :),
+    TUI_KEY_END: (: kb_end :),
+    TUI_CTRL('e'): (: kb_end :),
+    TUI_MOD_ALT | 'b': (: kb_word_back :),
+    TUI_MOD_CTRL | TUI_KEY_LEFT: (: kb_word_back :),
+    TUI_MOD_ALT | 'f': (: kb_word_fwd :),
+    TUI_MOD_CTRL | TUI_KEY_RIGHT: (: kb_word_fwd :),
+    TUI_KEY_BACKSPACE: (: kb_backspace :),
+    TUI_KEY_DELETE: (: kb_delete :),
+    TUI_CTRL('d'): (: kb_delete_or_eof :),
+    TUI_CTRL('k'): (: kb_kill_to_end :),
+    TUI_CTRL('u'): (: kb_kill_to_start :),
+    TUI_CTRL('w'): (: kb_kill_word_back :),
+    TUI_MOD_ALT | 'd': (: kb_kill_word_fwd :),
+    TUI_MOD_ALT | TUI_KEY_BACKSPACE: (: kb_kill_word_back :),
+    TUI_CTRL('y'): (: kb_yank :),
+    TUI_CTRL('t'): (: kb_transpose :),
+    TUI_KEY_UP: (: kb_hist_prev :),
+    TUI_CTRL('p'): (: kb_hist_prev :),
+    TUI_KEY_DOWN: (: kb_hist_next :),
+    TUI_CTRL('n'): (: kb_hist_next :),
+    TUI_CTRL('r'): (: kb_isearch_rev :),
+    TUI_CTRL('s'): (: kb_isearch_fwd :),
+    TUI_CTRL('c'): (: kb_abort :),
+    TUI_CTRL('l'): (: kb_clear :),
+    TUI_KEY_TAB: (: kb_tab :),
+  ]);
+}
+
+void create() { build_keymap(); }
+
+private void dispatch(mixed ev) {
+  if (stringp(ev)) {
+    insert(ev);
+  } else if (intp(ev)) {
+    function f = keymap[ev];
+    if (f) evaluate(f);
+  }
+  // else: mouse/CPR arrays are not the line editor's business
+  if (last_tab) last_tab--;
+  if (state == TUI_RL_MORE) render();
+}
+
+// ----------------------------------------------------------------------
+// public API
+
+void rl_set_prompt(string p) { if (stringp(p)) prompt = p; }
+void rl_set_masked(int on) { masked = on; }
+void rl_set_completer(function f) { completer = f; }
+void rl_set_hist_max(int n) { if (n > 0) hist_max = n; }
+
+void rl_set_width(int w) {
+  if (w < 20) w = 20;
+  width = w;
+  if (began && state == TUI_RL_MORE) render();
+}
+
+void rl_set_history(string *h) {
+  hist = arrayp(h) ? h[0..] : ({});
+  hidx = sizeof(hist);
+}
+
+string *rl_history() { return hist[0..]; }
+
+void rl_add_history(string line) {
+  if (!stringp(line) || line == "") return;
+  if (sizeof(hist) && hist[<1] == line) return;
+  hist += ({ line });
+  if (sizeof(hist) > hist_max) hist = hist[sizeof(hist) - hist_max..];
+}
+
+// Start (or restart) editing.  Returns the initial repaint.
+varargs string rl_begin(string initial) {
+  buf = stringp(initial) ? initial : "";
+  pos = strlen(buf);
+  state = TUI_RL_MORE;
+  out = "";
+  scroll = 0;
+  hidx = sizeof(hist);
+  hsave = "";
+  is_dir = 0;
+  last_tab = 0;
+  began = 1;
+  render();
+  return rl_take_output();
+}
+
+// Feed one key event; returns the engine state (TUI_RL_*).
+int rl_feed(mixed ev) {
+  if (state != TUI_RL_MORE || !began) return state;
+  if (is_dir) {
+    isearch_feed(ev);
+  } else {
+    dispatch(ev);
+  }
+  return state;
+}
+
+string rl_take_output() {
+  string o = out;
+
+  out = "";
+  return o;
+}
+
+int rl_state() { return state; }
+string rl_line() { return buf; }
+int rl_cursor() { return pos; }
+int rl_scroll() { return scroll; }
+int rl_searching() { return is_dir != 0; }

--- a/testsuite/std/tui/screen.lpc
+++ b/testsuite/std/tui/screen.lpc
@@ -1,0 +1,227 @@
+// /std/tui/screen — layer 2 of the TUI library: virtual screen + renderer.
+//
+// A cell grid you draw into with scr_put()/scr_box()/scr_fill(); scr_frame()
+// returns the ANSI bytes that transform what the terminal currently shows
+// into the current grid — a full paint on the first call (or after
+// scr_invalidate()/scr_resize()), a minimal diff afterwards.
+//
+// Cells are ({ grapheme, sgr-params }) pairs; a double-width character owns
+// its left cell and marks the right cell with 0.  Attributes are SGR
+// parameter strings ("1;36" — compose them with ansi_fg()/ansi_bg()), and ""
+// means default.  Coordinates are 0-based, (0,0) top-left.
+//
+// Pure state machine: no I/O; the caller writes the returned bytes.
+
+#include <tui.h>
+
+inherit TUI_ANSI;
+
+private int W = 80, H = 24;
+private mixed *grid;              // H rows of W cells
+private mixed *prev = 0;          // grid as of the last scr_frame(); 0 = full paint
+private int cx = 0, cy = 0, cvis = 0;
+private int pvis = -1;            // cursor visibility already emitted
+
+private mixed *blank_row() {
+  mixed *row = allocate(W);
+  int x;
+
+  for (x = 0; x < W; x++) row[x] = ({ " ", "" });
+  return row;
+}
+
+void scr_clear() {
+  int y;
+
+  grid = allocate(H);
+  for (y = 0; y < H; y++) grid[y] = blank_row();
+}
+
+void scr_resize(int w, int h) {
+  W = w < 1 ? 1 : w;
+  H = h < 1 ? 1 : h;
+  scr_clear();
+  prev = 0;
+}
+
+void scr_invalidate() { prev = 0; }
+
+int scr_width() { return W; }
+int scr_height() { return H; }
+
+void scr_set_cursor(int x, int y, int visible) {
+  cx = x;
+  cy = y;
+  cvis = visible;
+}
+
+void create() { scr_clear(); }
+
+// Copy-on-write: after scr_frame(), grid rows are shared with prev; the
+// first write to a row in a new frame takes a private copy, so untouched
+// rows stay identity-equal to prev and the diff skips them wholesale.
+// (Cells themselves are immutable by convention — writes always assign
+// fresh ({ ch, attr }) arrays — which is what makes row sharing safe.)
+private mixed *row_for_write(int y) {
+  mixed *row = grid[y];
+
+  if (prev && row == prev[y]) {
+    row = row[0..];
+    grid[y] = row;
+  }
+  return row;
+}
+
+// Blank out the wide character occupying (or spilling into) column x.
+private void unwide(mixed *row, int x) {
+  if (x < 0 || x >= W) return;
+  if (!row[x]) {  // continuation: blank its owner
+    if (x > 0 && arrayp(row[x - 1])) row[x - 1] = ({ " ", row[x - 1][1] });
+    row[x] = ({ " ", "" });
+  } else if (x + 1 < W && !row[x + 1] && strwidth(row[x][0]) == 2) {
+    row[x + 1] = ({ " ", "" });  // owner is being overwritten: free its tail
+  }
+}
+
+// Write plain text (no escape sequences) at (x, y) with an SGR attr string.
+varargs void scr_put(int x, int y, string text, string attr) {
+  mixed *row;
+  int i, n;
+
+  if (y < 0 || y >= H || !stringp(text)) return;
+  if (!stringp(attr)) attr = "";
+  row = row_for_write(y);
+  n = strlen(text);
+  for (i = 0; i < n; i++) {
+    string ch = text[i..i];
+    int cw = strwidth(ch);
+
+    if (cw <= 0) continue;  // control / zero-width: not representable in cells
+    if (x < 0) {
+      x += cw;
+      continue;
+    }
+    if (x + cw > W) break;
+    unwide(row, x);
+    if (cw == 2) {
+      unwide(row, x + 1);
+      row[x] = ({ ch, attr });
+      row[x + 1] = 0;
+    } else {
+      row[x] = ({ ch, attr });
+    }
+    x += cw;
+  }
+}
+
+varargs void scr_fill(int x, int y, int w, int h, string ch, string attr) {
+  int i;
+  string line;
+
+  if (w <= 0 || h <= 0) return;
+  if (!stringp(ch) || strwidth(ch) != 1) ch = " ";
+  line = repeat_string(ch, w);
+  for (i = 0; i < h; i++) scr_put(x, y + i, line, attr);
+}
+
+varargs void scr_hline(int x, int y, int w, string ch, string attr) {
+  if (!stringp(ch)) ch = "─";
+  scr_fill(x, y, w, 1, ch, attr);
+}
+
+varargs void scr_vline(int x, int y, int h, string ch, string attr) {
+  int i;
+
+  if (!stringp(ch)) ch = "│";
+  for (i = 0; i < h; i++) scr_put(x, y + i, ch, attr);
+}
+
+varargs void scr_box(int x, int y, int w, int h, int style, string attr) {
+  string *chars;
+
+  if (w < 2 || h < 2) return;
+  switch (style) {
+    case TUI_BOX_DOUBLE:
+      chars = ({ "╔", "╗", "╚", "╝", "═", "║" });
+      break;
+    case TUI_BOX_ROUND:
+      chars = ({ "╭", "╮", "╰", "╯", "─", "│" });
+      break;
+    case TUI_BOX_ASCII:
+      chars = ({ "+", "+", "+", "+", "-", "|" });
+      break;
+    default:
+      chars = ({ "┌", "┐", "└", "┘", "─", "│" });
+      break;
+  }
+  scr_hline(x + 1, y, w - 2, chars[4], attr);
+  scr_hline(x + 1, y + h - 1, w - 2, chars[4], attr);
+  scr_vline(x, y + 1, h - 2, chars[5], attr);
+  scr_vline(x + w - 1, y + 1, h - 2, chars[5], attr);
+  scr_put(x, y, chars[0], attr);
+  scr_put(x + w - 1, y, chars[1], attr);
+  scr_put(x, y + h - 1, chars[2], attr);
+  scr_put(x + w - 1, y + h - 1, chars[3], attr);
+}
+
+private int cell_eq(mixed a, mixed b) {
+  if (!arrayp(a) || !arrayp(b)) return a == b;
+  return a[0] == b[0] && a[1] == b[1];
+}
+
+// The ANSI delta that brings the terminal up to date with the grid.
+string scr_frame() {
+  string o = "";
+  string cur_attr = 0;  // unknown at frame start
+  mixed *base = prev;
+  int x, y;
+
+  if (!base) {
+    o += ansi_sgr("0") + ansi_ed(2);
+    cur_attr = "";
+    base = allocate(H);
+    for (y = 0; y < H; y++) base[y] = blank_row();
+  }
+
+  for (y = 0; y < H; y++) {
+    mixed *row = grid[y];
+    mixed *brow = base[y];
+
+    if (row == brow) continue;  // row untouched since the last frame
+    x = 0;
+    while (x < W) {
+      if (cell_eq(row[x], brow[x])) {
+        x++;
+        continue;
+      }
+      // a changed span begins; a continuation cell repaints from its owner
+      if (!row[x] && x > 0) x--;
+      o += ansi_cup(x, y);
+      while (x < W && !cell_eq(row[x], brow[x])) {
+        mixed *c = row[x];
+
+        if (!c) {  // continuation of an unchanged owner: repaint the owner
+          c = row[x - 1];
+          o += ansi_cup(x - 1, y);
+          x--;
+        }
+        if (cur_attr != c[1]) {
+          o += ansi_sgr(c[1] == "" ? "0" : "0;" + c[1]);
+          cur_attr = c[1];
+        }
+        o += c[0];
+        x += strwidth(c[0]);
+      }
+    }
+  }
+
+  if (stringp(cur_attr) && cur_attr != "") o += ansi_sgr("0");
+  if (cvis != pvis) {
+    o += ansi_cursor_visible(cvis);
+    pvis = cvis;
+  }
+  if (cvis) o += ansi_cup(cx, cy);
+
+  prev = grid[0..];  // rows are now shared; row_for_write() un-shares on write
+  return o;
+}

--- a/testsuite/std/tui/terminal.lpc
+++ b/testsuite/std/tui/terminal.lpc
@@ -1,0 +1,200 @@
+// /std/tui/terminal — layer 3 of the TUI library: the interactive glue.
+//
+// Inherit this into an interactive object (user/login).  Two modes:
+//
+//   Prompt mode — tui_readline(cb [, opts]) is an input_to() replacement
+//     giving the prompt line full editing, ↑/↓ history and Ctrl-R search.
+//     cb(line, state) is called on completion: state is TUI_RL_DONE (line
+//     is the string), or TUI_RL_ABORT / TUI_RL_EOF (line is 0).
+//     opts: ([ "prompt": str, "initial": str, "masked": int,
+//              "completer": function, "history": string* ]).
+//     History persists across calls for the lifetime of this object.
+//
+//   App mode — tui_open(app) hands the terminal to an application object
+//     (inherit /std/tui/app), on the alternate screen with the cursor
+//     hidden; tui_close() restores the terminal (the app's app_quit()
+//     calls it for you).
+//
+// The glue owns: the get_char re-arm loop (one keystroke per callback; the
+// no-echo flag on every re-arm keeps client echo off), NAWS/TTYPE caching
+// via the window_size/terminal_type applies, and the lone-ESC timeout.
+//
+// If this object can be destructed or lose its connection while a TUI is
+// active, call tui_destroy() from your remove()/net_dead() paths.
+
+#include <tui.h>
+
+inherit TUI_ANSI;
+
+#define MODE_IDLE 0
+#define MODE_RL   1
+#define MODE_APP  2
+
+private nosave object k_dec;      // /std/tui/keys clone
+private nosave object rl;         // /std/tui/readline clone (persistent history)
+private nosave object cur_app;
+private nosave function rl_cb = 0;
+private nosave int tui_mode = MODE_IDLE;
+private nosave int term_w = 80, term_h = 24;
+private nosave int have_naws = 0;
+private nosave string term_type = "";
+private nosave int esc_pending = 0;
+private nosave int negotiated = 0;
+
+int tui_width() { return term_w; }
+int tui_height() { return term_h; }
+string tui_term() { return term_type; }
+int tui_active() { return tui_mode != MODE_IDLE; }
+object tui_editor() { return rl; }
+
+void tui_send(string s) {
+  if (stringp(s) && s != "") receive(s);
+}
+
+// --- driver applies (this object must be the interactive) ---------------
+
+void window_size(int w, int h) {
+  term_w = w;
+  term_h = h;
+  have_naws = 1;
+  if (tui_mode == MODE_RL && rl) {
+    rl->rl_set_width(w);
+    tui_send(rl->rl_take_output());
+  } else if (tui_mode == MODE_APP && cur_app) {
+    cur_app->on_resize(w, h);
+    tui_send(cur_app->render());
+  }
+}
+
+void terminal_type(string term) { term_type = term; }
+
+// --- internals -----------------------------------------------------------
+
+private void negotiate() {
+  if (negotiated) return;
+  negotiated = 1;
+  request_term_size();
+  start_request_term_type();
+}
+
+protected void _tui_char(string ch);  // forward
+
+private void arm() { get_char((: _tui_char :), 1); }
+
+private void finish_readline(int st) {
+  function cb = rl_cb;
+  string line = st == TUI_RL_DONE ? rl->rl_line() : 0;
+
+  rl_cb = 0;
+  tui_mode = MODE_IDLE;
+  tui_send(ansi_bracketed_paste(0));
+  if (functionp(cb)) evaluate(cb, line, st);
+}
+
+private void dispatch(mixed ev) {
+  switch (tui_mode) {
+    case MODE_RL: {
+      int st = rl->rl_feed(ev);
+
+      tui_send(rl->rl_take_output());
+      if (st != TUI_RL_MORE) finish_readline(st);
+      return;
+    }
+    case MODE_APP:
+      if (arrayp(ev) && sizeof(ev) && ev[0] == TUI_EV_MOUSE) {
+        cur_app->on_mouse(ev);
+      } else {
+        cur_app->on_key(ev);
+      }
+      // the app may have quit (tui_close() zeroes cur_app / destructs it)
+      if (cur_app) tui_send(cur_app->render());
+      return;
+  }
+}
+
+private void esc_flush() {
+  esc_pending = 0;
+  if (tui_mode == MODE_IDLE || !k_dec) return;
+  foreach (mixed ev in k_dec->flush()) {
+    if (tui_mode != MODE_IDLE) dispatch(ev);
+  }
+  if (tui_mode == MODE_IDLE) remove_get_char(this_object());
+}
+
+protected void _tui_char(string ch) {
+  mixed *evs;
+
+  if (tui_mode == MODE_IDLE) return;  // stray keystroke after teardown
+  evs = k_dec->feed(ch);
+  foreach (mixed ev in evs) {
+    if (tui_mode != MODE_IDLE) dispatch(ev);
+  }
+  if (tui_mode != MODE_IDLE) {
+    arm();
+    if (k_dec->has_pending() && !esc_pending) {
+      esc_pending = 1;
+      call_out_walltime((: esc_flush :), 0.06);
+    }
+  }
+}
+
+private void ensure_clones() {
+  if (!k_dec) k_dec = clone_object(TUI_KEYS);
+  if (!rl) rl = clone_object(TUI_READLINE);
+}
+
+// --- public API ------------------------------------------------------------
+
+varargs void tui_readline(function cb, mapping opts) {
+  if (tui_mode != MODE_IDLE) error("tui_readline: a TUI is already active.\n");
+  if (!functionp(cb)) error("tui_readline: callback required.\n");
+  ensure_clones();
+  negotiate();
+  k_dec->reset();
+  if (!mapp(opts)) opts = ([]);
+  rl->rl_set_prompt(stringp(opts["prompt"]) ? opts["prompt"] : "> ");
+  rl->rl_set_masked(opts["masked"]);
+  rl->rl_set_completer(opts["completer"]);
+  if (arrayp(opts["history"])) rl->rl_set_history(opts["history"]);
+  rl->rl_set_width(term_w);
+  rl_cb = cb;
+  tui_mode = MODE_RL;
+  tui_send(ansi_bracketed_paste(1) + rl->rl_begin(opts["initial"]));
+  arm();
+}
+
+varargs void tui_open(object app, mapping opts) {
+  if (tui_mode != MODE_IDLE) error("tui_open: a TUI is already active.\n");
+  if (!objectp(app)) error("tui_open: app object required.\n");
+  ensure_clones();
+  negotiate();
+  k_dec->reset();
+  if (!mapp(opts)) opts = ([]);
+  cur_app = app;
+  tui_mode = MODE_APP;
+  tui_send(ansi_alt_screen(1) + ansi_cursor_visible(0) + ansi_bracketed_paste(1) +
+           (opts["mouse"] ? ansi_mouse(1) : ""));
+  app->on_open(this_object(), term_w, term_h);
+  tui_send(app->render());
+  arm();
+}
+
+void tui_close() {
+  if (tui_mode == MODE_APP) {
+    tui_send(ansi_mouse(0) + ansi_bracketed_paste(0) + ansi_cursor_visible(1) +
+             ansi_sgr("0") + ansi_alt_screen(0));
+  } else if (tui_mode == MODE_RL) {
+    tui_send(ansi_bracketed_paste(0) + "\r\n");
+  }
+  cur_app = 0;
+  rl_cb = 0;
+  tui_mode = MODE_IDLE;
+  remove_get_char(this_object());
+}
+
+// Full teardown: call from remove() / net_dead() of the inheriting object.
+void tui_destroy() {
+  if (tui_mode != MODE_IDLE) tui_close();
+  if (k_dec) destruct(k_dec);
+  if (rl) destruct(rl);
+}

--- a/testsuite/std/tui/terminal.lpc
+++ b/testsuite/std/tui/terminal.lpc
@@ -26,14 +26,20 @@
 
 inherit TUI_ANSI;
 
-#define MODE_IDLE 0
-#define MODE_RL   1
-#define MODE_APP  2
+#define MODE_IDLE    0
+#define MODE_RL      1
+#define MODE_APP     2
+#define MODE_MENU    3
+#define MODE_CONFIRM 4
 
 private nosave object k_dec;      // /std/tui/keys clone
 private nosave object rl;         // /std/tui/readline clone (persistent history)
+private nosave object menu;       // /std/tui/menu clone
 private nosave object cur_app;
 private nosave function rl_cb = 0;
+private nosave function menu_cb = 0;
+private nosave function confirm_cb = 0;
+private nosave int confirm_def = 0;
 private nosave int tui_mode = MODE_IDLE;
 private nosave int term_w = 80, term_h = 24;
 private nosave int have_naws = 0;
@@ -91,6 +97,39 @@ private void finish_readline(int st) {
   if (functionp(cb)) evaluate(cb, line, st);
 }
 
+private void finish_menu(int st) {
+  function cb = menu_cb;
+  mixed res = menu->m_result();
+
+  menu_cb = 0;
+  tui_mode = MODE_IDLE;
+  if (!functionp(cb)) return;
+  if (arrayp(res)) {  // multiselect: cb(int *indexes, string *items, int state)
+    if (st != TUI_RL_DONE) res = ({});
+    evaluate(cb, res, map(res, (: menu->m_item($1) :)), st);
+  } else {            // select: cb(int index, string item, int state)
+    if (st != TUI_RL_DONE) res = -1;
+    evaluate(cb, res, res >= 0 ? menu->m_item(res) : 0, st);
+  }
+}
+
+private void confirm_feed(mixed ev) {
+  function cb;
+  int yes, st = TUI_RL_DONE;
+
+  if (ev == "y" || ev == "Y") yes = 1;
+  else if (ev == "n" || ev == "N") yes = 0;
+  else if (ev == TUI_KEY_ENTER) yes = confirm_def;
+  else if (ev == TUI_CTRL('c') || ev == TUI_KEY_ESC) st = TUI_RL_ABORT;
+  else return;  // ignore anything else
+
+  cb = confirm_cb;
+  confirm_cb = 0;
+  tui_mode = MODE_IDLE;
+  tui_send((st == TUI_RL_ABORT ? "^C" : (yes ? "yes" : "no")) + "\r\n");
+  if (functionp(cb)) evaluate(cb, yes, st);
+}
+
 private void dispatch(mixed ev) {
   switch (tui_mode) {
     case MODE_RL: {
@@ -100,6 +139,16 @@ private void dispatch(mixed ev) {
       if (st != TUI_RL_MORE) finish_readline(st);
       return;
     }
+    case MODE_MENU: {
+      int st = menu->m_feed(ev);
+
+      tui_send(menu->m_take_output());
+      if (st != TUI_RL_MORE) finish_menu(st);
+      return;
+    }
+    case MODE_CONFIRM:
+      confirm_feed(ev);
+      return;
     case MODE_APP:
       if (arrayp(ev) && sizeof(ev) && ev[0] == TUI_EV_MOUSE) {
         cur_app->on_mouse(ev);
@@ -141,6 +190,7 @@ protected void _tui_char(string ch) {
 private void ensure_clones() {
   if (!k_dec) k_dec = clone_object(TUI_KEYS);
   if (!rl) rl = clone_object(TUI_READLINE);
+  if (!menu) menu = clone_object(TUI_MENU);
 }
 
 // --- public API ------------------------------------------------------------
@@ -160,6 +210,60 @@ varargs void tui_readline(function cb, mapping opts) {
   rl_cb = cb;
   tui_mode = MODE_RL;
   tui_send(ansi_bracketed_paste(1) + rl->rl_begin(opts["initial"]));
+  arm();
+}
+
+// Inline single-choice menu: cb(int index, string item, int state);
+// index is -1 when aborted.  opts: "height", "initial".
+varargs void tui_select(function cb, string prompt, string *choices, mapping opts) {
+  if (tui_mode != MODE_IDLE) error("tui_select: a TUI is already active.\n");
+  if (!functionp(cb)) error("tui_select: callback required.\n");
+  ensure_clones();
+  negotiate();
+  k_dec->reset();
+  if (!mapp(opts)) opts = ([]);
+  map_delete(opts, "multi");
+  menu_cb = cb;
+  tui_mode = MODE_MENU;
+  tui_send(menu->m_begin(prompt, choices, opts));
+  if (menu->m_state() != TUI_RL_MORE) {  // e.g. empty choice list
+    finish_menu(menu->m_state());
+    return;
+  }
+  arm();
+}
+
+// Inline multi-choice menu: cb(int *indexes, string *items, int state).
+// opts: "height", "initial", "checked" (int * preselection).
+varargs void tui_multiselect(function cb, string prompt, string *choices, mapping opts) {
+  if (tui_mode != MODE_IDLE) error("tui_multiselect: a TUI is already active.\n");
+  if (!functionp(cb)) error("tui_multiselect: callback required.\n");
+  ensure_clones();
+  negotiate();
+  k_dec->reset();
+  if (!mapp(opts)) opts = ([]);
+  opts["multi"] = 1;
+  menu_cb = cb;
+  tui_mode = MODE_MENU;
+  tui_send(menu->m_begin(prompt, choices, opts));
+  if (menu->m_state() != TUI_RL_MORE) {
+    finish_menu(menu->m_state());
+    return;
+  }
+  arm();
+}
+
+// y/n prompt: cb(int yes, int state).  Enter picks the default.
+varargs void tui_confirm(function cb, string prompt, int def) {
+  if (tui_mode != MODE_IDLE) error("tui_confirm: a TUI is already active.\n");
+  if (!functionp(cb)) error("tui_confirm: callback required.\n");
+  ensure_clones();
+  negotiate();
+  k_dec->reset();
+  confirm_cb = cb;
+  confirm_def = def;
+  tui_mode = MODE_CONFIRM;
+  tui_send("? " + prompt + (def ? " [Y/n] " : " [y/N] "));
   arm();
 }
 
@@ -188,6 +292,8 @@ void tui_close() {
   }
   cur_app = 0;
   rl_cb = 0;
+  menu_cb = 0;
+  confirm_cb = 0;
   tui_mode = MODE_IDLE;
   remove_get_char(this_object());
 }
@@ -197,4 +303,5 @@ void tui_destroy() {
   if (tui_mode != MODE_IDLE) tui_close();
   if (k_dec) destruct(k_dec);
   if (rl) destruct(rl);
+  if (menu) destruct(menu);
 }

--- a/testsuite/std/tui/w/button.lpc
+++ b/testsuite/std/tui/w/button.lpc
@@ -1,0 +1,37 @@
+// /std/tui/w/button — push button.  Enter/Space -> ("press", 0).
+
+#include <tui.h>
+
+inherit TUI_WIDGET;
+inherit TUI_ANSI;
+
+private string label = "OK";
+private string attr = "";
+private string focus_attr = "7";
+
+void create() {
+  w_focusable = 1;
+  wh = 1;
+}
+
+void set_label(string l) { label = stringp(l) ? l : ""; }
+string query_label() { return label; }
+
+void set_attrs(string normal, string focused) {
+  if (stringp(normal)) attr = normal;
+  if (stringp(focused)) focus_attr = focused;
+}
+
+void draw(object scr) {
+  string text = "[ " + label + " ]";
+
+  scr->scr_put(wx, wy, wpad(wslice(text, 0, ww), ww), w_focused ? focus_attr : attr);
+}
+
+int handle_key(mixed ev) {
+  if (ev == TUI_KEY_ENTER || ev == " ") {
+    emit_event("press", 0);
+    return 1;
+  }
+  return 0;
+}

--- a/testsuite/std/tui/w/chart.lpc
+++ b/testsuite/std/tui/w/chart.lpc
@@ -1,0 +1,85 @@
+// /std/tui/w/chart — braille line-chart widget with rolling history
+// (blessed-contrib line chart).  Feed it points from your tick loop:
+//
+//   chart->add_series("traffic", "36");
+//   chart->add_point(0, value);      // keeps the last 2*width points
+//
+// Multiple series overlay with their own colours.  Auto-scales to the
+// visible data unless set_range() pins the y-range.
+
+#include <tui.h>
+
+inherit TUI_WIDGET;
+inherit TUI_ANSI;
+
+private object cv;
+private mixed *series = ({});   // ({ ({ name, int *values, attr }), ... })
+private int lo_fix, hi_fix, fixed = 0;
+
+void create() { cv = clone_object(TUI_CANVAS); }
+
+void remove() {
+  if (cv) destruct(cv);
+}
+
+int add_series(string name, string attr) {
+  series += ({ ({ stringp(name) ? name : "", ({}), stringp(attr) ? attr : "" }) });
+  return sizeof(series) - 1;
+}
+
+void set_data(int idx, int *values) {
+  if (idx < 0 || idx >= sizeof(series)) return;
+  series[idx][1] = arrayp(values) ? values[0..] : ({});
+}
+
+void add_point(int idx, int value) {
+  int keep = ww * 2;  // one point per dot column
+
+  if (idx < 0 || idx >= sizeof(series)) return;
+  series[idx][1] += ({ value });
+  if (keep > 0 && sizeof(series[idx][1]) > keep) {
+    series[idx][1] = series[idx][1][sizeof(series[idx][1]) - keep..];
+  }
+}
+
+int *query_data(int idx) {
+  return idx >= 0 && idx < sizeof(series) ? series[idx][1][0..] : ({});
+}
+
+void set_range(int lo, int hi) {
+  lo_fix = lo;
+  hi_fix = hi;
+  fixed = 1;
+}
+
+void clear_range() { fixed = 0; }
+
+void draw(object scr) {
+  int lo, hi, have = 0, cx, cy;
+
+  if (fixed) {
+    lo = lo_fix;
+    hi = hi_fix;
+  } else {
+    foreach (mixed s in series) {
+      foreach (int v in s[1]) {
+        if (!have) {
+          lo = hi = v;
+          have = 1;
+        }
+        if (v < lo) lo = v;
+        if (v > hi) hi = v;
+      }
+    }
+  }
+
+  cv->c_resize(ww, wh);
+  foreach (mixed s in series) cv->c_plot(s[1], lo, hi, s[2]);
+  for (cy = 0; cy < wh; cy++) {
+    for (cx = 0; cx < ww; cx++) {
+      mixed *c = cv->c_cell(cx, cy);
+
+      scr->scr_put(wx + cx, wy + cy, c[0], c[1]);
+    }
+  }
+}

--- a/testsuite/std/tui/w/checklist.lpc
+++ b/testsuite/std/tui/w/checklist.lpc
@@ -1,0 +1,95 @@
+// /std/tui/w/checklist — multi-select checkbox list (blessed Checkbox group /
+// pterm interactive multiselect, as a widget).
+//
+// Space toggles the highlighted item; events: ("change", index) on toggle.
+
+#include <tui.h>
+
+inherit TUI_WIDGET;
+inherit TUI_ANSI;
+
+private string *items = ({});
+private mapping checked = ([]);
+private int sel = 0;
+private int top = 0;
+private string attr = "";
+private string sel_attr = "7";
+
+void create() { w_focusable = 1; }
+
+void set_items(string *it) {
+  items = arrayp(it) ? it[0..] : ({});
+  checked = ([]);
+  sel = top = 0;
+}
+
+void set_checked(int *idx) {
+  checked = ([]);
+  if (arrayp(idx)) {
+    foreach (int i in idx) {
+      if (i >= 0 && i < sizeof(items)) checked[i] = 1;
+    }
+  }
+}
+
+int *query_checked() {
+  int *r = ({});
+  int i;
+
+  for (i = 0; i < sizeof(items); i++) {
+    if (checked[i]) r += ({ i });
+  }
+  return r;
+}
+
+string *query_checked_items() { return map(query_checked(), (: items[$1] :)); }
+int query_selected() { return sel; }
+
+void set_attrs(string normal, string selected) {
+  if (stringp(normal)) attr = normal;
+  if (stringp(selected)) sel_attr = selected;
+}
+
+void draw(object scr) {
+  int i;
+
+  if (sel < top) top = sel;
+  if (sel >= top + wh) top = sel - wh + 1;
+  if (top < 0) top = 0;
+  for (i = 0; i < wh; i++) {
+    int idx = top + i;
+    string line = "";
+
+    if (idx < sizeof(items)) {
+      line = wslice((checked[idx] ? "[x] " : "[ ] ") + items[idx], 0, ww);
+    }
+    scr->scr_put(wx, wy + i, wpad(line, ww),
+                 (idx == sel && idx < sizeof(items) && w_focused) ? sel_attr : attr);
+  }
+}
+
+int handle_key(mixed ev) {
+  if (ev == " " || ev == TUI_KEY_ENTER) {
+    if (sizeof(items)) {
+      checked[sel] = !checked[sel];
+      emit_event("change", sel);
+    }
+    return 1;
+  }
+  if (!intp(ev)) return 0;
+  switch (ev) {
+    case TUI_KEY_UP:
+      if (sel > 0) sel--;
+      return 1;
+    case TUI_KEY_DOWN:
+      if (sel < sizeof(items) - 1) sel++;
+      return 1;
+    case TUI_KEY_HOME:
+      sel = 0;
+      return 1;
+    case TUI_KEY_END:
+      if (sizeof(items)) sel = sizeof(items) - 1;
+      return 1;
+  }
+  return 0;
+}

--- a/testsuite/std/tui/w/label.lpc
+++ b/testsuite/std/tui/w/label.lpc
@@ -1,0 +1,21 @@
+// /std/tui/w/label — static (possibly multi-line) text.
+
+#include <tui.h>
+
+inherit TUI_WIDGET;
+inherit TUI_ANSI;
+
+private string *lines = ({ "" });
+private string attr = "";
+
+void set_text(string t) { lines = stringp(t) ? explode(t, "\n") : ({ "" }); }
+void set_attr(string a) { attr = stringp(a) ? a : ""; }
+
+void draw(object scr) {
+  int i, n = sizeof(lines);
+
+  for (i = 0; i < wh; i++) {
+    string line = i < n ? wslice(lines[i], 0, ww) : "";
+    scr->scr_put(wx, wy + i, wpad(line, ww), attr);
+  }
+}

--- a/testsuite/std/tui/w/list.lpc
+++ b/testsuite/std/tui/w/list.lpc
@@ -1,0 +1,105 @@
+// /std/tui/w/list — scrollable selectable list.
+//
+// Events: ("select", index) on Enter, ("change", index) when the selection
+// moves.
+
+#include <tui.h>
+
+inherit TUI_WIDGET;
+inherit TUI_ANSI;
+
+private string *items = ({});
+private int sel = 0;
+private int top = 0;
+private string attr = "";
+private string sel_attr = "7";  // reverse video
+
+void create() { w_focusable = 1; }
+
+void set_items(string *it) {
+  items = arrayp(it) ? it[0..] : ({});
+  if (sel >= sizeof(items)) sel = sizeof(items) - 1;
+  if (sel < 0) sel = 0;
+  top = 0;
+}
+
+string *query_items() { return items[0..]; }
+int query_selected() { return sel; }
+
+string query_selected_item() {
+  return sel >= 0 && sel < sizeof(items) ? items[sel] : 0;
+}
+
+void set_selected(int i) {
+  if (i >= 0 && i < sizeof(items)) sel = i;
+}
+
+void set_attrs(string normal, string selected) {
+  attr = stringp(normal) ? normal : "";
+  sel_attr = stringp(selected) ? selected : "7";
+}
+
+void draw(object scr) {
+  int i, n = sizeof(items);
+
+  if (sel < top) top = sel;
+  if (sel >= top + wh) top = sel - wh + 1;
+  if (top < 0) top = 0;
+  for (i = 0; i < wh; i++) {
+    int idx = top + i;
+    string line = idx < n ? wslice(items[idx], 0, ww) : "";
+
+    scr->scr_put(wx, wy + i, wpad(line, ww),
+                 (idx == sel && idx < n && w_focused) ? sel_attr : attr);
+  }
+}
+
+private void move_sel(int d) {
+  int n = sizeof(items);
+
+  if (!n) return;
+  sel += d;
+  if (sel < 0) sel = 0;
+  if (sel >= n) sel = n - 1;
+  emit_event("change", sel);
+}
+
+int handle_key(mixed ev) {
+  if (!intp(ev)) return 0;
+  switch (ev) {
+    case TUI_KEY_UP:
+      move_sel(-1);
+      return 1;
+    case TUI_KEY_DOWN:
+      move_sel(1);
+      return 1;
+    case TUI_KEY_PGUP:
+      move_sel(-wh);
+      return 1;
+    case TUI_KEY_PGDN:
+      move_sel(wh);
+      return 1;
+    case TUI_KEY_HOME:
+      move_sel(-sizeof(items));
+      return 1;
+    case TUI_KEY_END:
+      move_sel(sizeof(items));
+      return 1;
+    case TUI_KEY_ENTER:
+      if (sizeof(items)) emit_event("select", sel);
+      return 1;
+  }
+  return 0;
+}
+
+int handle_mouse(mixed *ev) {
+  int y = ev[3];
+
+  if (!ev[4]) return 0;  // only presses
+  if (y >= wy && y < wy + wh && top + y - wy < sizeof(items)) {
+    sel = top + y - wy;
+    emit_event("change", sel);
+    return 1;
+  }
+  return 0;
+}

--- a/testsuite/std/tui/w/log.lpc
+++ b/testsuite/std/tui/w/log.lpc
@@ -1,0 +1,68 @@
+// /std/tui/w/log — a log pane permanently scrolled to the bottom
+// (blessed Log), with PgUp/PgDn scrollback when focused.
+
+#include <tui.h>
+
+inherit TUI_WIDGET;
+inherit TUI_ANSI;
+
+private string *lines = ({});
+private int max_lines = 500;
+private int offset = 0;       // lines scrolled back from the bottom
+private string attr = "";
+
+void set_max_lines(int n) {
+  if (n > 0) max_lines = n;
+}
+
+void set_attr(string a) { attr = stringp(a) ? a : ""; }
+
+void add_line(string s) {
+  if (!stringp(s)) return;
+  lines += explode(s, "\n");
+  if (sizeof(lines) > max_lines) lines = lines[sizeof(lines) - max_lines..];
+  offset = 0;  // new output snaps back to the bottom
+}
+
+void clear_lines() {
+  lines = ({});
+  offset = 0;
+}
+
+string *query_lines() { return lines[0..]; }
+int query_offset() { return offset; }
+
+void draw(object scr) {
+  int n = sizeof(lines);
+  int first = n - wh - offset;
+  int i;
+
+  if (first < 0) first = 0;
+  for (i = 0; i < wh; i++) {
+    string line = first + i < n && first + i >= 0 ? wslice(lines[first + i], 0, ww) : "";
+
+    scr->scr_put(wx, wy + i, wpad(line, ww), attr);
+  }
+}
+
+int handle_key(mixed ev) {
+  int max_off = sizeof(lines) - wh;
+
+  if (max_off < 0) max_off = 0;
+  if (!intp(ev)) return 0;
+  switch (ev) {
+    case TUI_KEY_PGUP:
+      offset = offset + wh > max_off ? max_off : offset + wh;
+      return 1;
+    case TUI_KEY_PGDN:
+      offset = offset - wh < 0 ? 0 : offset - wh;
+      return 1;
+    case TUI_KEY_HOME:
+      offset = max_off;
+      return 1;
+    case TUI_KEY_END:
+      offset = 0;
+      return 1;
+  }
+  return 0;
+}

--- a/testsuite/std/tui/w/progress.lpc
+++ b/testsuite/std/tui/w/progress.lpc
@@ -1,0 +1,23 @@
+// /std/tui/w/progress — progress bar (pterm/blessed style).
+
+#include <tui.h>
+
+inherit TUI_WIDGET;
+inherit TUI_PRINT;  // brings the ansi/width helpers transitively
+
+private int pct = 0;
+private string label = "";
+private string attr = "";
+
+void set_percent(int p) { pct = p < 0 ? 0 : (p > 100 ? 100 : p); }
+int query_percent() { return pct; }
+void set_label(string l) { label = stringp(l) ? l : ""; }
+void set_attr(string a) { attr = stringp(a) ? a : ""; }
+
+void draw(object scr) {
+  string lbl = label != "" ? label + " " : "";
+  int bar_w = ww - visible_width(lbl) - 5;  // " 100%" suffix
+
+  if (bar_w < 1) bar_w = 1;
+  scr->scr_put(wx, wy, wpad(lbl + p_progress(pct, bar_w), ww), attr);
+}

--- a/testsuite/std/tui/w/radiolist.lpc
+++ b/testsuite/std/tui/w/radiolist.lpc
@@ -1,0 +1,73 @@
+// /std/tui/w/radiolist — single-choice radio group (blessed RadioSet).
+//
+// Space/Enter picks the highlighted item; events: ("change", index).
+
+#include <tui.h>
+
+inherit TUI_WIDGET;
+inherit TUI_ANSI;
+
+private string *items = ({});
+private int picked = 0;
+private int sel = 0;
+private int top = 0;
+private string attr = "";
+private string sel_attr = "7";
+
+void create() { w_focusable = 1; }
+
+void set_items(string *it) {
+  items = arrayp(it) ? it[0..] : ({});
+  picked = sel = top = 0;
+}
+
+void set_picked(int i) {
+  if (i >= 0 && i < sizeof(items)) picked = i;
+}
+
+int query_picked() { return picked; }
+string query_picked_item() { return picked < sizeof(items) ? items[picked] : 0; }
+int query_selected() { return sel; }
+
+void set_attrs(string normal, string selected) {
+  if (stringp(normal)) attr = normal;
+  if (stringp(selected)) sel_attr = selected;
+}
+
+void draw(object scr) {
+  int i;
+
+  if (sel < top) top = sel;
+  if (sel >= top + wh) top = sel - wh + 1;
+  if (top < 0) top = 0;
+  for (i = 0; i < wh; i++) {
+    int idx = top + i;
+    string line = "";
+
+    if (idx < sizeof(items)) {
+      line = wslice((idx == picked ? "(•) " : "( ) ") + items[idx], 0, ww);
+    }
+    scr->scr_put(wx, wy + i, wpad(line, ww),
+                 (idx == sel && idx < sizeof(items) && w_focused) ? sel_attr : attr);
+  }
+}
+
+int handle_key(mixed ev) {
+  if (ev == " " || ev == TUI_KEY_ENTER) {
+    if (sizeof(items) && picked != sel) {
+      picked = sel;
+      emit_event("change", picked);
+    }
+    return 1;
+  }
+  if (!intp(ev)) return 0;
+  switch (ev) {
+    case TUI_KEY_UP:
+      if (sel > 0) sel--;
+      return 1;
+    case TUI_KEY_DOWN:
+      if (sel < sizeof(items) - 1) sel++;
+      return 1;
+  }
+  return 0;
+}

--- a/testsuite/std/tui/w/spinner.lpc
+++ b/testsuite/std/tui/w/spinner.lpc
@@ -1,0 +1,32 @@
+// /std/tui/w/spinner — animated activity indicator.
+//
+// The spinner does not own a timer: the application advances it with
+// tick() from its own call_out loop (and re-renders), so headless tests
+// and different tick rates all work.
+
+#include <tui.h>
+
+inherit TUI_WIDGET;
+inherit TUI_ANSI;
+
+private string *frames = ({ "⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏" });
+private int frame = 0;
+private string label = "";
+private string attr = "36";
+
+void set_frames(string *f) {
+  if (arrayp(f) && sizeof(f)) {
+    frames = f[0..];
+    frame = 0;
+  }
+}
+
+void set_label(string l) { label = stringp(l) ? l : ""; }
+void set_attr(string a) { attr = stringp(a) ? a : ""; }
+string query_frame() { return frames[frame]; }
+
+void tick() { frame = (frame + 1) % sizeof(frames); }
+
+void draw(object scr) {
+  scr->scr_put(wx, wy, wpad(frames[frame] + " " + label, ww), attr);
+}

--- a/testsuite/std/tui/w/table.lpc
+++ b/testsuite/std/tui/w/table.lpc
@@ -1,0 +1,121 @@
+// /std/tui/w/table — scrollable data table with a selectable row
+// (blessed ListTable / pterm Table, interactive).
+//
+// Events: ("select", row-index) on Enter, ("change", row-index) on move.
+
+#include <tui.h>
+
+inherit TUI_WIDGET;
+inherit TUI_ANSI;
+
+private string *columns = ({});
+private mixed *rows = ({});
+private int sel = 0;
+private int top = 0;
+private string attr = "";
+private string head_attr = "1;4";
+private string sel_attr = "7";
+
+void create() { w_focusable = 1; }
+
+void set_columns(string *cols) { columns = arrayp(cols) ? cols[0..] : ({}); }
+
+void set_rows(mixed *r) {
+  rows = arrayp(r) ? r[0..] : ({});
+  if (sel >= sizeof(rows)) sel = sizeof(rows) - 1;
+  if (sel < 0) sel = 0;
+  top = 0;
+}
+
+void set_attrs(string normal, string header, string selected) {
+  if (stringp(normal)) attr = normal;
+  if (stringp(header)) head_attr = header;
+  if (stringp(selected)) sel_attr = selected;
+}
+
+int query_selected() { return sel; }
+mixed query_selected_row() { return sel >= 0 && sel < sizeof(rows) ? rows[sel] : 0; }
+
+private int *col_widths() {
+  int *w = ({});
+  int j, cols = sizeof(columns);
+
+  foreach (mixed row in rows) {
+    if (sizeof(row) > cols) cols = sizeof(row);
+  }
+  for (j = 0; j < cols; j++) {
+    int best = j < sizeof(columns) ? visible_width(columns[j]) : 0;
+    foreach (mixed row in rows) {
+      int cw = j < sizeof(row) ? visible_width("" + row[j]) : 0;
+      if (cw > best) best = cw;
+    }
+    w += ({ best });
+  }
+  return w;
+}
+
+private string fmt_row(mixed *cells, int *w) {
+  string line = "";
+  int j;
+
+  for (j = 0; j < sizeof(w); j++) {
+    string cell = j < sizeof(cells) ? "" + cells[j] : "";
+    line += wpad(cell, w[j]) + (j < sizeof(w) - 1 ? "  " : "");
+  }
+  return wslice(line, 0, ww);
+}
+
+void draw(object scr) {
+  int *w = col_widths();
+  int i, body = wh - (sizeof(columns) ? 1 : 0);
+
+  if (sizeof(columns)) scr->scr_put(wx, wy, wpad(fmt_row(columns, w), ww), head_attr);
+  if (sel < top) top = sel;
+  if (sel >= top + body) top = sel - body + 1;
+  if (top < 0) top = 0;
+  for (i = 0; i < body; i++) {
+    int idx = top + i;
+    string line = idx < sizeof(rows) ? fmt_row(rows[idx], w) : "";
+
+    scr->scr_put(wx, wy + (sizeof(columns) ? 1 : 0) + i, wpad(line, ww),
+                 (idx == sel && idx < sizeof(rows) && w_focused) ? sel_attr : attr);
+  }
+}
+
+private void move_sel(int d) {
+  int n = sizeof(rows);
+
+  if (!n) return;
+  sel += d;
+  if (sel < 0) sel = 0;
+  if (sel >= n) sel = n - 1;
+  emit_event("change", sel);
+}
+
+int handle_key(mixed ev) {
+  if (!intp(ev)) return 0;
+  switch (ev) {
+    case TUI_KEY_UP:
+      move_sel(-1);
+      return 1;
+    case TUI_KEY_DOWN:
+      move_sel(1);
+      return 1;
+    case TUI_KEY_PGUP:
+      move_sel(-(wh - 1));
+      return 1;
+    case TUI_KEY_PGDN:
+      move_sel(wh - 1);
+      return 1;
+    case TUI_KEY_HOME:
+      move_sel(-sizeof(rows));
+      return 1;
+    case TUI_KEY_END:
+      move_sel(sizeof(rows));
+      return 1;
+    case TUI_KEY_ENTER:
+      if (sizeof(rows)) emit_event("select", sel);
+      return 1;
+  }
+  return 0;
+}

--- a/testsuite/std/tui/w/textfield.lpc
+++ b/testsuite/std/tui/w/textfield.lpc
@@ -1,0 +1,68 @@
+// /std/tui/w/textfield — single-line input field.
+//
+// Editing is delegated to a private /std/tui/readline engine (so the field
+// gets the full keymap: word motion, kill/yank, history if you seed it);
+// the field renders the engine's buffer into the screen grid itself.
+//
+// Events: ("submit", line) on Enter.  Tab/Shift-Tab/Escape are not consumed,
+// so the app can cycle focus.
+
+#include <tui.h>
+
+inherit TUI_WIDGET;
+inherit TUI_ANSI;
+
+private object rl;
+private int scroll = 0;
+private string attr = "4";  // underline
+
+void create() {
+  w_focusable = 1;
+  wh = 1;
+  rl = clone_object(TUI_READLINE);
+  rl->rl_set_prompt("");
+  rl->rl_begin("");
+}
+
+void remove() {
+  if (rl) destruct(rl);
+}
+
+void set_attr(string a) { attr = stringp(a) ? a : ""; }
+void set_text(string t) { rl->rl_begin(stringp(t) ? t : ""); }
+string query_text() { return rl->rl_line(); }
+object query_editor() { return rl; }
+
+void draw(object scr) {
+  string disp = rl->rl_line();
+  int cpos = rl->rl_cursor();
+  int cur = cpos > 0 ? strwidth(disp[0..cpos - 1]) : 0;
+  string view;
+  if (cur < scroll) scroll = cur;
+  if (cur >= scroll + ww) scroll = cur - ww + 1;
+  view = wslice(disp, scroll, ww - 1);
+  scr->scr_put(wx, wy, wpad(view, ww), attr);
+  if (w_focused) scr->scr_set_cursor(wx + cur - scroll, wy, 1);
+}
+
+int handle_key(mixed ev) {
+  int st;
+
+  // leave focus / app navigation to the container
+  if (ev == TUI_KEY_TAB || ev == (TUI_MOD_SHIFT | TUI_KEY_TAB) || ev == TUI_KEY_ESC ||
+      ev == TUI_KEY_UP || ev == TUI_KEY_DOWN) {
+    return 0;
+  }
+  if (!stringp(ev) && !intp(ev)) return 0;
+  st = rl->rl_feed(ev);
+  rl->rl_take_output();  // the field draws itself; discard line-oriented bytes
+  if (st == TUI_RL_DONE) {
+    emit_event("submit", rl->rl_line());
+    rl->rl_begin("");
+    scroll = 0;
+  } else if (st != TUI_RL_MORE) {
+    rl->rl_begin("");
+    scroll = 0;
+  }
+  return 1;
+}

--- a/testsuite/std/tui/w/tree.lpc
+++ b/testsuite/std/tui/w/tree.lpc
@@ -1,0 +1,143 @@
+// /std/tui/w/tree — collapsible tree view (blessed/tview style).
+//
+// Nodes use the same shape as p_tree(): a node is a string (leaf) or
+// ({ label, ({ children... }) }).  Right/Enter expands, Left collapses,
+// Enter on a leaf emits ("select", label); moving emits ("change", label).
+
+#include <tui.h>
+
+inherit TUI_WIDGET;
+inherit TUI_ANSI;
+
+private mixed *nodes = ({});
+private mapping expanded = ([]);   // path-key -> 1
+private mixed *visible = ({});     // ({ ({ key, depth, label, has_children }) ... })
+private int sel = 0;
+private int top = 0;
+private string attr = "";
+private string sel_attr = "7";
+
+void create() { w_focusable = 1; }
+
+private void flatten(mixed *ns, string prefix, int depth) {
+  int i;
+
+  for (i = 0; i < sizeof(ns); i++) {
+    mixed node = ns[i];
+    string label = arrayp(node) ? "" + node[0] : "" + node;
+    string key = prefix + "/" + i;
+    int kids = arrayp(node) && sizeof(node) > 1 && arrayp(node[1]) && sizeof(node[1]);
+
+    visible += ({ ({ key, depth, label, kids }) });
+    if (kids && expanded[key]) flatten(node[1], key, depth + 1);
+  }
+}
+
+private mixed *node_by_key(string key) {
+  mixed *ns = nodes;
+  mixed node = 0;
+
+  foreach (string part in explode(key[1..], "/")) {
+    node = ns[to_int(part)];
+    ns = arrayp(node) && sizeof(node) > 1 ? node[1] : ({});
+  }
+  return node;
+}
+
+private void reflatten() {
+  visible = ({});
+  flatten(nodes, "", 0);
+  if (sel >= sizeof(visible)) sel = sizeof(visible) - 1;
+  if (sel < 0) sel = 0;
+}
+
+void set_nodes(mixed *ns) {
+  nodes = arrayp(ns) ? ns : ({});
+  expanded = ([]);
+  sel = top = 0;
+  reflatten();
+}
+
+void set_attrs(string normal, string selected) {
+  if (stringp(normal)) attr = normal;
+  if (stringp(selected)) sel_attr = selected;
+}
+
+private void expand_walk(mixed *ns, string prefix) {
+  int i;
+
+  for (i = 0; i < sizeof(ns); i++) {
+    if (arrayp(ns[i]) && sizeof(ns[i]) > 1 && arrayp(ns[i][1])) {
+      expanded[prefix + "/" + i] = 1;
+      expand_walk(ns[i][1], prefix + "/" + i);
+    }
+  }
+}
+
+void expand_all() {
+  expand_walk(nodes, "");
+  reflatten();
+}
+
+string query_selected() { return sizeof(visible) ? visible[sel][2] : 0; }
+int query_visible_count() { return sizeof(visible); }
+
+void draw(object scr) {
+  int i;
+
+  if (sel < top) top = sel;
+  if (sel >= top + wh) top = sel - wh + 1;
+  if (top < 0) top = 0;
+  for (i = 0; i < wh; i++) {
+    int idx = top + i;
+    string line = "";
+
+    if (idx < sizeof(visible)) {
+      mixed *v = visible[idx];
+      string arrow = v[3] ? (expanded[v[0]] ? "▾ " : "▸ ") : "  ";
+
+      line = wslice(repeat_string("  ", v[1]) + arrow + v[2], 0, ww);
+    }
+    scr->scr_put(wx, wy + i, wpad(line, ww),
+                 (idx == sel && idx < sizeof(visible) && w_focused) ? sel_attr : attr);
+  }
+}
+
+int handle_key(mixed ev) {
+  mixed *v;
+
+  if (!intp(ev) || !sizeof(visible)) return 0;
+  v = visible[sel];
+  switch (ev) {
+    case TUI_KEY_UP:
+      if (sel > 0) sel--;
+      emit_event("change", visible[sel][2]);
+      return 1;
+    case TUI_KEY_DOWN:
+      if (sel < sizeof(visible) - 1) sel++;
+      emit_event("change", visible[sel][2]);
+      return 1;
+    case TUI_KEY_RIGHT:
+      if (v[3] && !expanded[v[0]]) {
+        expanded[v[0]] = 1;
+        reflatten();
+      }
+      return 1;
+    case TUI_KEY_LEFT:
+      if (v[3] && expanded[v[0]]) {
+        map_delete(expanded, v[0]);
+        reflatten();
+      }
+      return 1;
+    case TUI_KEY_ENTER:
+      if (v[3]) {
+        if (expanded[v[0]]) map_delete(expanded, v[0]);
+        else expanded[v[0]] = 1;
+        reflatten();
+      } else {
+        emit_event("select", v[2]);
+      }
+      return 1;
+  }
+  return 0;
+}

--- a/testsuite/std/tui/widget.lpc
+++ b/testsuite/std/tui/widget.lpc
@@ -1,0 +1,51 @@
+// /std/tui/widget — widget base class (inherit into concrete widgets).
+//
+// The protocol an app container (/std/tui/app) speaks:
+//   draw(screen)        paint yourself into the screen clone
+//   handle_key(ev)      return 1 if the event was consumed
+//   query_focusable()   participates in Tab focus cycling
+//   set_focused(f)      focus state changed
+// Widgets report to the application through the on-event callback:
+//   evaluate(cb, widget, what, arg)  — e.g. ("select", index), ("submit", line)
+
+#include <tui.h>
+
+int wx, wy, ww = 10, wh = 1;
+int w_visible = 1;
+int w_focusable = 0;
+int w_focused = 0;
+private function w_on_event = 0;
+
+void set_geometry(int x, int y, int w, int h) {
+  wx = x;
+  wy = y;
+  ww = w < 1 ? 1 : w;
+  wh = h < 1 ? 1 : h;
+}
+
+int query_x() { return wx; }
+int query_y() { return wy; }
+int query_w() { return ww; }
+int query_h() { return wh; }
+
+void set_visible(int v) { w_visible = v; }
+int query_visible() { return w_visible; }
+
+int query_focusable() { return w_focusable && w_visible; }
+void set_focused(int f) { w_focused = f; }
+int query_focused() { return w_focused; }
+
+int contains(int x, int y) {
+  return w_visible && x >= wx && x < wx + ww && y >= wy && y < wy + wh;
+}
+
+void set_on_event(function f) { w_on_event = f; }
+
+protected varargs void emit_event(string what, mixed arg) {
+  if (functionp(w_on_event)) evaluate(w_on_event, this_object(), what, arg);
+}
+
+// --- overridables ---
+void draw(object scr) {}
+int handle_key(mixed ev) { return 0; }
+int handle_mouse(mixed *ev) { return 0; }


### PR DESCRIPTION
Five input-path fixes that make raw-keystroke (get_char) applications
viable, found by building the LPC TUI library on top of them:

- comm.cc: char mode delivered "" for Backspace/Delete (the byte was
  zeroed before delivery, making BS/DEL/NUL indistinguishable). The
  literal byte is now delivered; line-mode in-buffer editing unchanged.
- comm.cc: char mode delivered one *byte* per callback, splitting a
  multi-byte UTF-8 character into 2-4 invalid one-byte strings.
  Extraction is now UTF-8 aware: a complete sequence arrives as one
  callback carrying one valid character; malformed bytes still go
  byte-at-a-time (no stalls).
- comm.cc: the "no ansi" + "strip before process input" ESC->space
  rewrite (both default on) also applied to char mode, so arrow keys
  arrived as literal "[A". The rewrite is an anti-ANSI-injection
  protection for line-mode commands; char mode now always passes ESC
  through.
- net/telnet.cc: each received chunk was u8_sanitize()d independently,
  so a UTF-8 character split across TCP segments became U+FFFD in any
  input mode. An incomplete trailing sequence (new u8_incomplete_tail(),
  GTest-covered) is now carried over in interactive_t and prepended to
  the next chunk.
- net/telnet.cc + comm.cc: fast clients answer the initial DO NAWS
  while ip->ob is still the master object, so the window_size apply
  fired on the wrong object and the size was lost until the next
  resize. The last report is cached and replayed on the user object at
  logon.

docs/efun/interactive/get_char.md documents the delivery contract.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01RpXv4yGCWpkzbkifyZy9EE