### PR TITLE
Fix 61 memory-safety and correctness bugs found across a four-round codebase audit

### DIFF
--- a/src/base/internal/port.cc
+++ b/src/base/internal/port.cc
@@ -20,6 +20,10 @@ int64_t random_number(int64_t n) {
     called = true;
   }
 
+  // uniform_int_distribution(0, n-1) is UB when n <= 0 (requires a <= b).
+  if (n <= 0) {
+    return 0;
+  }
   std::uniform_int_distribution<int64_t> dist(0, n - 1);
   return dist(engine);
 }
@@ -33,6 +37,10 @@ int64_t secure_random_number(int64_t n) {
   // On linux & osx we use urandom by default
   static std::random_device rd("/dev/urandom");
 #endif
+  // uniform_int_distribution(0, n-1) is UB when n <= 0 (requires a <= b).
+  if (n <= 0) {
+    return 0;
+  }
   std::uniform_int_distribution<int64_t> dist(0, n - 1);
   return dist(rd);
 }

--- a/src/base/internal/stralloc.cc
+++ b/src/base/internal/stralloc.cc
@@ -97,7 +97,9 @@ void init_strings() {
 
   /* ensure that htable size is a power of 2 */
   y = CONFIG_INT(__SHARED_STRING_HASH_TABLE_SIZE__);
-  for (htable_size = 1; htable_size < y; htable_size <<= 1) {
+  /* Cap the round-up at 2^30: a larger configured value would shift past
+     2^31 and overflow signed int (UB), spinning this loop forever at boot. */
+  for (htable_size = 1; htable_size < y && htable_size < (1 << 30); htable_size <<= 1) {
   }
   CONFIG_INT(__SHARED_STRING_HASH_TABLE_SIZE__) = htable_size;
 

--- a/src/base/internal/strutils.cc
+++ b/src/base/internal/strutils.cc
@@ -111,6 +111,12 @@ int32_t u8_egc_find_as_offset(EGCIterator& iter, const char* needle, size_t need
     pos = std::string_view::npos;
     while ((pos = sv_haystack.rfind(sv_needle, pos)) != std::string_view::npos) {
       if (iter->isBoundary(pos) && iter->isBoundary(pos + sv_needle.length())) break;
+      // A match at offset 0 that is not grapheme-aligned must not decrement to
+      // npos and re-find offset 0 forever; report "no match" instead.
+      if (pos == 0) {
+        pos = std::string_view::npos;
+        break;
+      }
       pos--;
     }
   }

--- a/src/comm.cc
+++ b/src/comm.cc
@@ -875,11 +875,21 @@ static int call_function_interactive(interactive_t* i, char* str) {
     was_noecho = 1;
     i->iflags &= ~NOECHO;
   }
-  if (ob->flags & O_DESTRUCTED) {
-    /* Sorry, the object has selfdestructed ! */
+  /* Guard against input_to() aimed at a '#'-prefixed __INIT-style apply, which
+   * we must never call. This has to be decided BEFORE STACK_INC below: bailing
+   * out after the increment would leave an uninitialized svalue on the VM stack
+   * (and leak the sentence/object/carryover). Handle it with the same teardown
+   * as a self-destructed target. */
+  bool bad_init_call = false;
+  if (!(sent->flags & V_FUNCTION)) {
+    const char* fname = sent->function.s;
+    bad_init_call = (fname && fname[0] == APPLY___INIT_SPECIAL_CHAR);
+  }
+
+  if ((ob->flags & O_DESTRUCTED) || bad_init_call) {
+    /* Sorry, the object has selfdestructed (or the call is disallowed)! */
     free_object(&sent->ob, "call_function_interactive");
     free_sentence(sent);
-    i->input_to = nullptr;
     if (i->num_carry) {
       free_some_svalues(i->carryover, i->num_carry);
     }
@@ -902,9 +912,6 @@ static int call_function_interactive(interactive_t* i, char* str) {
       funp->hdr.ref++;
     } else {
       function = sent->function.s;
-      if (function && function[0] == APPLY___INIT_SPECIAL_CHAR) {
-        return 0;
-      }
       sp->type = T_STRING;
       sp->subtype = STRING_SHARED;
       sp->u.string = function;

--- a/src/compiler/internal/compiler.cc
+++ b/src/compiler/internal/compiler.cc
@@ -821,7 +821,9 @@ static void show_overload_warnings() {
   ovlwarn_t *p, *next;
   p = overload_warnings;
   while (p) {
-    yywarn(p->warn);
+    // p->warn is a precomposed message embedding program filenames, which
+    // can contain '%'; pass it as an argument, not the format.
+    yywarn("%s", p->warn);
     FREE(p->warn);
     next = p->next;
     FREE(p);

--- a/src/compiler/internal/disassembler.cc
+++ b/src/compiler/internal/disassembler.cc
@@ -678,14 +678,16 @@ static void disassemble(FILE* f, char* code, int start, int end, program_t* prog
         pc += stable;
         if (ttype == 0) {
           i = 0;
-          while (pc < aptr + etable - 4) {
+          // The table ends with a sizeof(LPC_INT)-wide minval (LPC_INT is
+          // 64-bit); stop the short-offset walk before it, not 4 bytes before.
+          while (pc < aptr + etable - (int)sizeof(LPC_INT)) {
             COPY_SHORT(&sarg, pc);
             fprintf(f, "\t%2d: %04x\n", i++, addr + sarg);
             pc += 2;
           }
           COPY_INT(&iarg, pc);
           fprintf(f, "\tminval = %" LPC_INT_FMTSTR_P "\n", iarg);
-          pc += 4;
+          pc += sizeof(LPC_INT);
         } else {
           while (pc < aptr + etable) {
             COPY_PTR(&parg, pc);

--- a/src/compiler/internal/grammar_rules_exprs.cc
+++ b/src/compiler/internal/grammar_rules_exprs.cc
@@ -1886,7 +1886,13 @@ void rule_expr_div(struct parse_node_t** result, struct parse_node_t* expr1,
           break;
         }
         *result = expr1;
-        expr1->v.number /= expr2->v.number;
+        if (expr2->v.number == -1) {
+          // x / -1 == -x; computed directly it traps (SIGFPE) for INT_MIN.
+          // Two's-complement negate for the well-defined wrapped result.
+          expr1->v.number = (LPC_INT)(0ULL - (uint64_t)expr1->v.number);
+        } else {
+          expr1->v.number /= expr2->v.number;
+        }
         break;
       }
       if (expr2->kind == NODE_REAL) {

--- a/src/compiler/internal/grammar_rules_types.cc
+++ b/src/compiler/internal/grammar_rules_types.cc
@@ -121,11 +121,19 @@ LPC_INT rule_param_decl_untyped_name(const ScratchString* name) {
 }
 
 void rule_argument_varargs(argument_t* result, argument_t* arg_list) {
-  int x = type_of_locals_ptr[max_num_locals - 1];
-  int lt = x & ~LOCAL_MODS;
-
   *result = *arg_list;
   result->flags |= ARG_IS_VARARGS;
+
+  // '...' needs a preceding named parameter to hold the remaining args; with
+  // none (e.g. `foo(void ...)`) max_num_locals is 0 and the type lookup below
+  // would read type_of_locals_ptr[-1].
+  if (max_num_locals <= 0) {
+    yyerror("'...' requires a preceding parameter to hold the remaining arguments.");
+    return;
+  }
+
+  int x = type_of_locals_ptr[max_num_locals - 1];
+  int lt = x & ~LOCAL_MODS;
 
   if (x & LOCAL_MOD_REF) {
     yyerror("Variable to hold remainder of args may not be a reference");

--- a/src/compiler/internal/lexer_rules_pp.cc
+++ b/src/compiler/internal/lexer_rules_pp.cc
@@ -985,6 +985,7 @@ static void dispatch_directive(std::string_view dir, std::string_view rest, void
         m.is_function_like = true;
         idx++;  // skip '('
         while (idx < rest.size() && rest[idx] != ')') {
+          size_t const before = idx;
           while (idx < rest.size() && (rest[idx] == ' ' || rest[idx] == '\t')) idx++;
           size_t ps = idx;
           while (idx < rest.size() &&
@@ -993,6 +994,12 @@ static void dispatch_directive(std::string_view dir, std::string_view rest, void
           if (idx > ps) m.params.emplace_back(rest.substr(ps, idx - ps));
           while (idx < rest.size() && (rest[idx] == ' ' || rest[idx] == '\t')) idx++;
           if (idx < rest.size() && rest[idx] == ',') idx++;
+          // A stray character (not identifier/comma/space/')' -- e.g. '@' or a
+          // UTF-8 lead byte) consumes nothing; bail instead of looping forever.
+          if (idx == before) {
+            lexerror("#define: malformed macro parameter list");
+            return;
+          }
         }
         if (idx < rest.size()) idx++;  // skip ')'
       }

--- a/src/compiler/internal/lexer_utils.cc
+++ b/src/compiler/internal/lexer_utils.cc
@@ -1412,10 +1412,26 @@ lname_linked_buf_t* lnamebuf = nullptr;
 int lb_index = 4096;
 
 static char* alloc_local_name(const char* name) {
-  int len = strlen(name) + 1;
+  size_t len = strlen(name) + 1;
   char* res;
 
-  if (lb_index + len > 4096) {
+  // A name that cannot fit in a whole block gets its own exactly-sized
+  // allocation, then we force the next request to start a fresh normal block.
+  // Previously the code only ever allocated fixed 4096-byte blocks and copied
+  // `len` bytes in unconditionally, so a >4096-char local variable/parameter
+  // name (identifiers are only capped at YYLMAX ~64KB) overran the heap block.
+  if (len > sizeof(lnamebuf->block)) {
+    auto* new_buf = reinterpret_cast<lname_linked_buf_t*>(DMALLOC(
+        sizeof(lname_linked_buf_t) - sizeof(lnamebuf->block) + len, TAG_COMPILER,
+        "alloc_local_name"));
+    new_buf->next = lnamebuf;
+    lnamebuf = new_buf;
+    lb_index = sizeof(new_buf->block);  // next alloc must open a fresh block
+    memcpy(new_buf->block, name, len);
+    return new_buf->block;
+  }
+
+  if (lb_index + len > sizeof(lnamebuf->block)) {
     lname_linked_buf_t* new_buf;
     new_buf = reinterpret_cast<lname_linked_buf_t*>(
         DMALLOC(sizeof(lname_linked_buf_t), TAG_COMPILER, "alloc_local_name"));
@@ -1424,7 +1440,7 @@ static char* alloc_local_name(const char* name) {
     lb_index = 0;
   }
   res = &(lnamebuf->block[lb_index]);
-  strcpy(res, name);
+  memcpy(res, name, len);
   lb_index += len;
   return res;
 }

--- a/src/compiler/internal/trees.cc
+++ b/src/compiler/internal/trees.cc
@@ -184,6 +184,11 @@ parse_node_t* binary_int_op(parse_node_t* l, parse_node_t* r, char op, const cha
             yyerror("Modulo by zero constant");
             break;
           }
+          if (r->v.number == -1) {
+            // a % -1 == 0; computing it directly traps (SIGFPE) for INT_MIN.
+            l->v.number = 0;
+            break;
+          }
           l->v.number %= r->v.number;
           break;
         default:

--- a/src/net/telnet.cc
+++ b/src/net/telnet.cc
@@ -360,6 +360,13 @@ static inline void on_telnet_subnegotiation(unsigned char cmd, const char* buf, 
       switch (action) {
         case LM_MODE:
           /* Don't do anything with an ACK */
+          // A LINEMODE MODE/DO/WILL sub-option carries a second byte; guard it
+          // since only size >= 1 (buf[0]) is guaranteed above -- a client can
+          // send a 1-byte sub-negotiation and make buf[1] an out-of-bounds
+          // read (reflected back to the client in the DO/WILL cases).
+          if (size < 2) {
+            break;
+          }
           if (!(buf[1] & MODE_ACK)) {
             /* Accept only EDIT and TRAPSIG && force them too */
             const unsigned char sb_ack[] = {LM_MODE, MODE_EDIT | MODE_TRAPSIG | MODE_ACK};
@@ -374,12 +381,18 @@ static inline void on_telnet_subnegotiation(unsigned char cmd, const char* buf, 
         }
         /* refuse FORWARDMASK */
         case TELNET_DO: {
+          if (size < 2) {
+            break;
+          }
           const unsigned char sb_wont[] = {WONT, static_cast<unsigned char>(buf[1])};
           telnet_subnegotiation(ip->telnet, TELNET_TELOPT_LINEMODE,
                                 reinterpret_cast<const char*>(sb_wont), sizeof(sb_wont));
           break;
         }
         case TELNET_WILL: {
+          if (size < 2) {
+            break;
+          }
           const unsigned char sb_dont[] = {DONT, static_cast<unsigned char>(buf[1])};
           telnet_subnegotiation(ip->telnet, TELNET_TELOPT_LINEMODE,
                                 reinterpret_cast<const char*>(sb_dont), sizeof(sb_dont));

--- a/src/net/telnet.cc
+++ b/src/net/telnet.cc
@@ -712,12 +712,14 @@ void on_telnet_do_zmp(const char** argv, unsigned long argc, interactive_t* ip) 
   // Push the command
   copy_and_push_string(argv[0]);
 
-  // Push the array
+  // Push the array of arguments (argv[0] is the command, already pushed).
+  // Destination index is i-1: filling item[1..argc-1] would write one past
+  // the argc-1 element array and leave item[0] uninitialized.
   array_t* arr = allocate_array(argc - 1);
   for (int i = 1; i < argc; i++) {
-    arr->item[i].u.string = string_copy(argv[i], "ZMP");
-    arr->item[i].type = T_STRING;
-    arr->item[i].subtype = STRING_MALLOC;
+    arr->item[i - 1].u.string = string_copy(argv[i], "ZMP");
+    arr->item[i - 1].type = T_STRING;
+    arr->item[i - 1].subtype = STRING_MALLOC;
   }
   push_refed_array(arr);
 

--- a/src/net/transport_libevent.cc
+++ b/src/net/transport_libevent.cc
@@ -374,6 +374,16 @@ void get_user_data(interactive_t* ip) {
   /* read the data from the socket */
   debug(connections, "get_user_data: read on fd %d\n", ip->fd);
 
+  // Never read more than buf holds. A malicious PORT_TYPE_MUD length prefix
+  // can make text_space negative, which would convert to a huge size_t and
+  // overflow buf; clamp to [0, sizeof(buf)] here regardless of protocol.
+  if (text_space < 0) {
+    text_space = 0;
+  }
+  if (text_space > static_cast<int>(sizeof(buf))) {
+    text_space = sizeof(buf);
+  }
+
   num_bytes = bufferevent_read(ip->ev_buffer, buf, text_space);
 
   if (num_bytes == -1) {
@@ -410,7 +420,10 @@ void get_user_data(interactive_t* ip) {
       if (num_bytes == text_space) {
         if (ip->text_end == 4) {
           *reinterpret_cast<volatile int*>(ip->text) = ntohl(*reinterpret_cast<int*>(ip->text));
-          if (*reinterpret_cast<volatile int*>(ip->text) > MAX_TEXT - 5) {
+          int const msg_len = *reinterpret_cast<volatile int*>(ip->text);
+          // Reject non-positive (a negative prefix would drive a negative
+          // text_space) and oversized message lengths.
+          if (msg_len <= 0 || msg_len > MAX_TEXT - 5) {
             remove_interactive(ip->ob, 0);
           }
         } else {

--- a/src/packages/async/async.cc
+++ b/src/packages/async/async.cc
@@ -6,6 +6,7 @@
 #include <deque>
 #include <memory>
 #include <mutex>
+#include <set>
 #include <string>
 #include <thread>
 
@@ -76,13 +77,19 @@ struct Work {
 std::deque<struct Work*> reqs;
 std::mutex reqs_lock;
 
-// The request a worker thread is CURRENTLY processing: popped from reqs
-// but not yet moved to finished_reqs. Guarded by reqs_lock so
-// async_mark_request() (main thread, via check_memory) can account for
-// its callback funptr during that window -- otherwise a DEBUGMALLOC
-// sweep that lands mid-processing false-flags the ref (Windows Debug
-// hit this on async_read.lpc).
-struct Work* current_work = nullptr;
+// Works a worker thread is CURRENTLY processing: popped from reqs but not yet
+// moved to finished_reqs. Guarded by reqs_lock so async_mark_request() (main
+// thread, via check_memory) can account for their callback funptr /
+// command_giver during that window -- otherwise a DEBUGMALLOC sweep that lands
+// mid-processing false-flags the ref (Windows Debug hit this on async_read.lpc).
+//
+// This is a SET, not a single pointer: do_stuff() spawns a fresh worker thread
+// whenever reqs is momentarily empty, which happens while an earlier worker is
+// still inside a slow w->func() (it has already popped its request). So two or
+// more workers can run at once; a single `current_work` pointer only tracked
+// the last one and left the others' refs unaccounted -> flaky "Bad ref count"
+// (gcc Debug hit this via the async_* tests firing in quick succession).
+std::set<struct Work*> current_works;
 
 std::deque<struct Request*> finished_reqs;
 std::mutex finished_reqs_lock;
@@ -97,12 +104,11 @@ void thread_func() {
     {
       std::lock_guard<std::mutex> const lock(reqs_lock);
       if (reqs.empty()) {
-        current_work = nullptr;
         return;
       }
       w = reqs.front();
       reqs.pop_front();
-      current_work = w;  // in-flight: keep it accountable while we process
+      current_works.insert(w);  // in-flight: keep it accountable while we process
     }
 
     if (w) {
@@ -118,12 +124,12 @@ void thread_func() {
         // order) so the funptr is marked exactly once across the move.
         std::lock_guard<std::mutex> const rlock(reqs_lock);
         std::lock_guard<std::mutex> const flock(finished_reqs_lock);
-        current_work = nullptr;
+        current_works.erase(w);
         finished_reqs.push_back(w->data);
         delete w;
       } else {
         std::lock_guard<std::mutex> const lock(reqs_lock);
-        current_work = nullptr;
+        current_works.erase(w);
         reqs.push_back(w);
       }
 
@@ -273,7 +279,11 @@ void* getdirthread(struct Request* req) {
   int i = 0;
   for (auto* de = readdir(dirp); de; de = readdir(dirp)) {
     if (strcmp(de->d_name, ".") == 0 || strcmp(de->d_name, "..") == 0) continue;
-    req->data.resize(req->data.size() + sizeof(dirent*));
+    // The buffer is used as an array of `struct dirent`, indexed by i, so it
+    // must grow by sizeof(dirent) per entry -- growing by sizeof(dirent*) (a
+    // pointer, ~8 bytes) undersized it and memcpy of the ~280-byte dirent
+    // overflowed the heap once a directory held enough entries.
+    req->data.resize(static_cast<size_t>(i + 1) * sizeof(struct dirent));
     memcpy(&((dirent*)(req->data.data()))[i], de, sizeof(*de));
     i++;
   }
@@ -306,6 +316,10 @@ int add_read(const char* fname, function_to_call_t* fun) {
     req->path = std::string(fname);
     return aio_gzread(req);
   }
+  // Denied path: no request will ever be created to free the callback the
+  // efun already ref-bumped and handed us, so release it before unwinding.
+  free_funp(fun->f.fp);
+  delete fun;
   error("permission denied\n");
 
   return 1;
@@ -325,6 +339,9 @@ int add_getdir(const char* fname, function_to_call_t* fun) {
     req->path = fname;
     return aio_getdir(req);
   }
+  // Denied path: free the callback the efun already ref-bumped and handed us.
+  free_funp(fun->f.fp);
+  delete fun;
   error("permission denied\n");
 
   return 1;
@@ -333,6 +350,9 @@ int add_getdir(const char* fname, function_to_call_t* fun) {
 
 int add_write(const char* fname, const char* buf, int size, char flags, function_to_call_t* fun) {
   if (!fname) {
+    // Denied path: free the callback the efun already ref-bumped and handed us.
+    free_funp(fun->f.fp);
+    delete fun;
     error("permission denied\n");
   }
 
@@ -589,14 +609,15 @@ void async_mark_request() {
     }
   }
 
-  // The request a worker is mid-processing (popped from reqs, not yet in
-  // finished_reqs); guarded by reqs_lock, held above.
-  if (current_work != nullptr) {
-    if (current_work->data->fun != nullptr) {
-      current_work->data->fun->f.fp->hdr.extra_ref++;
+  // Requests a worker is mid-processing (popped from reqs, not yet in
+  // finished_reqs); guarded by reqs_lock, held above. There may be several
+  // concurrent workers, so mark every in-flight work, not just one.
+  for (auto* work : current_works) {
+    if (work->data->fun != nullptr) {
+      work->data->fun->f.fp->hdr.extra_ref++;
     }
-    if (current_work->data->command_giver != nullptr) {
-      current_work->data->command_giver->extra_ref++;
+    if (work->data->command_giver != nullptr) {
+      work->data->command_giver->extra_ref++;
     }
   }
 

--- a/src/packages/compress/compress.cc
+++ b/src/packages/compress/compress.cc
@@ -309,6 +309,9 @@ void f_uncompress() {
     push_refed_buffer(buffer);
     FREE(compressed);
   } else {
+    if (output_data) {
+      FREE(output_data);
+    }
     FREE(compressed);
     error("inflate: no ZSTREAM_END\n");
   }

--- a/src/packages/contrib/contrib.cc
+++ b/src/packages/contrib/contrib.cc
@@ -1998,10 +1998,15 @@ void f_repeat_string() {
   if (repeat > 0) {
     str = sp->u.string;
     len = SVALUE_STRLEN(sp);
-    if ((newlen = len * repeat) > max_string_length) {
+    // Clamp repeat BEFORE multiplying: len * repeat in int can overflow and
+    // wrap to a small/zero newlen, driving an undersized allocation and a
+    // massive heap overflow in the copy loop. Also avoids div-by-zero on len==0.
+    if (len == 0) {
+      repeat = 0;
+    } else if (repeat > max_string_length / len) {
       repeat = max_string_length / len;
-      newlen = len * repeat;
     }
+    newlen = len * repeat;
   }
   if (repeat <= 0) {
     free_string_svalue(sp);

--- a/src/packages/contrib/contrib.cc
+++ b/src/packages/contrib/contrib.cc
@@ -2178,7 +2178,7 @@ void f_query_replaced_program() {
     free_object(&sp->u.ob, "f_query_replaced_program");
   } else {
     if (current_object->replaced_program) {
-      res = add_slash(sp->u.ob->replaced_program);
+      res = add_slash(current_object->replaced_program);
     }
     STACK_INC;
   }

--- a/src/packages/contrib/contrib.cc
+++ b/src/packages/contrib/contrib.cc
@@ -743,7 +743,11 @@ void f_terminal_colour() {
     // Look it up in the mapping.
     repused = 0;
     copy_and_push_string(parts[i]);
-    svalue_t* reptmp = apply(APPLY_TERMINAL_COLOUR_REPLACE, current_object, 1, ORIGIN_EFUN);
+    // safe_apply: a raw apply that error()s here would longjmp past the
+    // FREE(parts)/FREE(lens)/FREE_MSTR(savestr) at the end of this efun,
+    // leaking them. On error safe_apply returns null -> treated as no
+    // replacement, which is the desired robust behavior anyway.
+    svalue_t* reptmp = safe_apply(APPLY_TERMINAL_COLOUR_REPLACE, current_object, 1, ORIGIN_EFUN);
     if (reptmp && reptmp->type == T_STRING) {
       rep = reinterpret_cast<char*>(alloca(SVALUE_STRLEN(reptmp) + 1));
       strcpy(rep, reptmp->u.string);
@@ -1680,12 +1684,11 @@ void f_replaceable() {
   } else {
     if (st_num_arg == 2) {
       numignore = sp->u.arr->size;
-      if (numignore) {
-        ignore = reinterpret_cast<const char**>(
-            DCALLOC(numignore + 2, sizeof(char*), TAG_TEMPORARY, "replaceable"));
-      } else {
-        ignore = nullptr;
-      }
+      // Always allocate the 2 built-in slots (create/__INIT) plus one per
+      // ignore entry -- an empty ignore array must not leave ignore == NULL
+      // before the unconditional ignore[0]/ignore[1] writes below.
+      ignore = reinterpret_cast<const char**>(
+          DCALLOC(numignore + 2, sizeof(char*), TAG_TEMPORARY, "replaceable"));
       ignore[0] = findstring(APPLY_CREATE);
       ignore[1] = findstring(APPLY___INIT);
       for (i = 0; i < numignore; i++) {

--- a/src/packages/core/add_action.cc
+++ b/src/packages/core/add_action.cc
@@ -435,11 +435,13 @@ static int user_parser(char* buff) {
          it moved somewhere or dested itself */
       if (s == command_giver->sent) {
         char buf[256];
+        // s->verb is an arbitrary-length shared string; bound the format so a
+        // long verb cannot overflow buf (the result is only shown via error).
         if (s->flags & V_FUNCTION) {
-          sprintf(buf, "Verb '%s' bound to uncallable function pointer.\n", s->verb);
+          snprintf(buf, sizeof(buf), "Verb '%s' bound to uncallable function pointer.\n", s->verb);
           error("%s", buf);
         } else {
-          sprintf(buf, "Function for verb '%s' not found.\n", s->verb);
+          snprintf(buf, sizeof(buf), "Function for verb '%s' not found.\n", s->verb);
           error("%s", buf);
         }
       }

--- a/src/packages/core/call_out.cc
+++ b/src/packages/core/call_out.cc
@@ -557,7 +557,8 @@ void reclaim_call_outs() {
     while (iter != g_callout_handle_map.end()) {
       auto* cop = iter->second;
       if ((cop->ob && (cop->ob->flags & O_DESTRUCTED)) ||
-          (!cop->ob && (cop->function.f->hdr.owner->flags & O_DESTRUCTED))) {
+          (!cop->ob && (!cop->function.f->hdr.owner ||
+                        (cop->function.f->hdr.owner->flags & O_DESTRUCTED)))) {
         free_call(cop);
         iter = g_callout_handle_map.erase(iter);
         i++;

--- a/src/packages/core/call_out.cc
+++ b/src/packages/core/call_out.cc
@@ -606,12 +606,27 @@ inline void int_call_out(bool walltime) {
 
   LPC_INT delay_msecs = 0;
   switch (arg[1].type) {
-    case T_NUMBER:
-      delay_msecs = arg[1].u.number * 1000;
+    case T_NUMBER: {
+      // seconds * 1000 can overflow int64 (UB / UBSan abort); saturate.
+      LPC_INT secs = arg[1].u.number;
+      if (secs > INT64_MAX / 1000) {
+        delay_msecs = INT64_MAX;
+      } else {
+        delay_msecs = secs * 1000;
+      }
       break;
-    case T_REAL:
-      delay_msecs = floor(arg[1].u.real * 1000.0);
+    }
+    case T_REAL: {
+      double ms = floor(arg[1].u.real * 1000.0);
+      if (ms >= (double)INT64_MAX) {
+        delay_msecs = INT64_MAX;
+      } else if (ms <= 0.0) {
+        delay_msecs = 0;
+      } else {
+        delay_msecs = (LPC_INT)ms;
+      }
       break;
+    }
   }
   if (delay_msecs < 0) {
     delay_msecs = 0;

--- a/src/packages/core/ed.cc
+++ b/src/packages/core/ed.cc
@@ -658,6 +658,12 @@ static int prntln(char* str, char* outstr, int vflg, int lineno) {
     *line++ = '$';
   }
 #endif
+  // A tab or control-code expansion in the final iteration can push `line`
+  // a few bytes past ED_MAXLINE within the slack of start[ED_MAXLINE + 100];
+  // clamp before copying into the caller's ED_MAXLINE-sized outstr.
+  if (line - start > ED_MAXLINE - 1) {
+    line = start + ED_MAXLINE - 1;
+  }
   *line = EOS;
 
   strcpy(outstr, start);
@@ -863,13 +869,15 @@ static char* getfn(int writeflg) {
   if (*inptr == NL) {
     P_NOFNAME = TRUE;
     file[0] = '/';
-    strcpy(file + 1, P_FNAME);
+    strncpy(file + 1, P_FNAME, MAXFNAME - 2);
+    file[MAXFNAME - 1] = '\0';
   } else {
     P_NOFNAME = FALSE;
     Skip_White_Space;
 
     cp = file;
-    while (*inptr && *inptr != NL && *inptr != SP && *inptr != HT) {
+    while (*inptr && *inptr != NL && *inptr != SP && *inptr != HT &&
+           cp < file + MAXFNAME - 1) {
       *cp++ = *inptr++;
     }
     *cp = '\0';
@@ -1045,7 +1053,9 @@ static int getrhs(char* sub) {
     return (EDERR);
   }
   while (*inptr != delim && *inptr != NL) {
-    if (sub > outmax) {
+    // Reserve room for the worst-case per-iteration write (the ESCAPE
+    // fall-through and octal cases write two bytes) and the trailing NUL.
+    if (sub >= outmax - 2) {
       return EDERR;
     }
     if (*inptr == ESCAPE) {
@@ -1253,7 +1263,9 @@ static regexp* optpat() {
     return P_OLDPAT;
   }
   cp = str;
-  while (*inptr != delim && *inptr != NL && *inptr != EOS && cp < str + MAXPAT - 1) {
+  // -2 (not -1): the escape branch below writes two bytes per iteration, and
+  // room must remain for the trailing EOS.
+  while (*inptr != delim && *inptr != NL && *inptr != EOS && cp < str + MAXPAT - 2) {
     if (*inptr == ESCAPE && inptr[1] != NL) {
       *cp++ = *inptr++;
     }

--- a/src/packages/core/ed.cc
+++ b/src/packages/core/ed.cc
@@ -869,8 +869,12 @@ static char* getfn(int writeflg) {
   if (*inptr == NL) {
     P_NOFNAME = TRUE;
     file[0] = '/';
-    strncpy(file + 1, P_FNAME, MAXFNAME - 2);
-    file[MAXFNAME - 1] = '\0';
+    size_t fn_len = strlen(P_FNAME);
+    if (fn_len > MAXFNAME - 2) {
+      fn_len = MAXFNAME - 2;
+    }
+    memcpy(file + 1, P_FNAME, fn_len);
+    file[1 + fn_len] = '\0';
   } else {
     P_NOFNAME = FALSE;
     Skip_White_Space;

--- a/src/packages/core/efuns_main.cc
+++ b/src/packages/core/efuns_main.cc
@@ -2069,9 +2069,19 @@ void f_replace_string() {
     if (plen > 1) {
       while (src < flimit) {
         if ((skip = skip_table[static_cast<unsigned char>(src[probe])])) {
+          // This fast-path copy is not covered by the dlen-based guards below;
+          // bound it against the output buffer and count it in dlen so a later
+          // match's expansion guard sees the true written length.
+          if (dst2 + skip > dst1 + max_string_length) {
+            pop_n_elems(st_num_arg);
+            push_svalue(&const0u);
+            FREE_MSTR(dst1);
+            return;
+          }
           for (climit = dst2 + skip; dst2 < climit; *dst2++ = *src++) {
             ;
           }
+          dlen += skip;
 
         } else if (memcmp(src, pattern, plen) == 0) {
           cur++;

--- a/src/packages/core/file.cc
+++ b/src/packages/core/file.cc
@@ -458,6 +458,14 @@ char* read_file(const char* file, int start, int lines) {
     ptr_end = (char*)ptr_start + read_file_max_size;
   }
 
+  // The forward line search can post-increment ptr_end one past the last byte
+  // read (to the_buff + total_bytes_read + 1) when it runs off the end without
+  // finding enough newlines. Clamp to the terminator slot so the '\0' below
+  // stays inside the 2*max+1 byte buffer instead of writing one past it.
+  if (ptr_end > the_buff + total_bytes_read) {
+    ptr_end = (char*)the_buff + total_bytes_read;
+  }
+
   *ptr_end = '\0';
 
   bool const found_crlf = strchr(ptr_start, '\r') != nullptr;

--- a/src/packages/core/file.cc
+++ b/src/packages/core/file.cc
@@ -242,7 +242,12 @@ array_t* get_dir(const char* path, int flags) {
   rewinddir(dirp);
   endtemp = temppath + strlen(temppath);
 
-  strcat(endtemp++, "/");
+  // Append '/' only if it fits (leaving room for the terminator); the
+  // directory path can be up to MAX_FNAME_SIZE+MAX_PATH_LEN long.
+  if ((size_t)(endtemp - temppath) + 2 <= sizeof(temppath)) {
+    *endtemp++ = '/';
+    *endtemp = '\0';
+  }
 
   for (i = 0, de = readdir(dirp); i < count; de = readdir(dirp)) {
     namelen = strlen(de->d_name);
@@ -258,8 +263,14 @@ array_t* get_dir(const char* path, int flags) {
        * We'll have to .... sigh.... stat() the file to get some add'tl
        * info.
        */
-      strcpy(endtemp, de->d_name);
-      stat(temppath, &st); /* We assume it works. */
+      size_t const avail = sizeof(temppath) - (size_t)(endtemp - temppath);
+      if (namelen < avail) {
+        memcpy(endtemp, de->d_name, namelen + 1);
+        stat(temppath, &st); /* We assume it works. */
+      } else {
+        // Combined path too long to form; can't stat it, report zeroed info.
+        memset(&st, 0, sizeof(st));
+      }
     }
     encode_stat(&v->item[i], flags, de->d_name, &st);
     i++;

--- a/src/packages/core/file.cc
+++ b/src/packages/core/file.cc
@@ -463,7 +463,7 @@ char* read_file(const char* file, int start, int lines) {
   // finding enough newlines. Clamp to the terminator slot so the '\0' below
   // stays inside the 2*max+1 byte buffer instead of writing one past it.
   if (ptr_end > the_buff + total_bytes_read) {
-    ptr_end = (char*)the_buff + total_bytes_read;
+    ptr_end = the_buff + total_bytes_read;  // the_buff is already char*
   }
 
   *ptr_end = '\0';

--- a/src/packages/core/reclaim.cc
+++ b/src/packages/core/reclaim.cc
@@ -46,17 +46,16 @@ static void check_svalue(svalue_t* v) {
       break;
     case T_FUNCTION: {
       svalue_t tmp;
-      program_t* prog;
 
       if (v->u.fp->hdr.owner && (v->u.fp->hdr.owner->flags & O_DESTRUCTED)) {
-        if (v->u.fp->hdr.type == (FP_LOCAL | FP_NOT_BINDABLE)) {
-          prog = v->u.fp->hdr.owner->prog;
-          prog->func_ref--;
-          debug(d_flag, "subtr func ref /%s: now %i\n", prog->filename, prog->func_ref);
-          if (!prog->ref && !prog->func_ref) {
-            deallocate_program(prog);
-          }
-        }
+        // Only release the owner reference; the funptr itself lives on (it is
+        // still held by this variable) and dealloc_funp() will decrement the
+        // program's func_ref against the funptr's stored creation program when
+        // it is finally freed. Decrementing func_ref here too was a double
+        // decrement that underflowed func_ref and leaked the program (and
+        // could deallocate a program the funptr still referenced). FP_FUNCTIONAL
+        // funptrs, which take no special-case here, are already handled
+        // correctly this way.
         free_object(&v->u.fp->hdr.owner, "reclaim_objects");
         v->u.fp->hdr.owner = nullptr;
         cleaned++;

--- a/src/packages/core/reclaim.cc
+++ b/src/packages/core/reclaim.cc
@@ -25,6 +25,7 @@ static void check_svalue(svalue_t* v) {
 
   nested++;
   if (nested > MAX_RECURSION) {
+    nested--;  // keep nested balanced, or reclaim stays disabled for the pass
     return;
   }
   switch (v->type) {

--- a/src/packages/core/sprintf.cc
+++ b/src/packages/core/sprintf.cc
@@ -1325,10 +1325,14 @@ char* string_print_formatted(const char* format_str, int argc, svalue_t* argv) {
           }
           cheat[i] = '\0';
 
+          // The precision clamp above bounds only the fraction digits, not the
+          // integer part or sign, so a large-magnitude value with a big
+          // precision (e.g. sprintf("%.1077f", 1e300)) would overrun the fixed
+          // temp buffer. snprintf truncates instead of overflowing.
           if (carg->type == T_REAL) {
-            sprintf(temp, cheat, carg->u.real);
+            snprintf(temp, sizeof(temp), cheat, carg->u.real);
           } else {
-            sprintf(temp, cheat, carg->u.number);
+            snprintf(temp, sizeof(temp), cheat, carg->u.number);
           }
           {
             int const tmpl = strlen(temp);

--- a/src/packages/core/sprintf.cc
+++ b/src/packages/core/sprintf.cc
@@ -168,6 +168,10 @@ using cst = struct ColumnSlashTable {
   unsigned int remainder; /* extra space needed to fill out to width */
   int pres;               /* precision */
   format_info info;       /* formatting data */
+  char* owned;            /* owned copy of the source string (col/table data
+                             point into it); freed with the cst. Columns/tables
+                             can outlive the transient sprintf_state.clean they
+                             were rendered from, so they must not borrow it. */
   struct ColumnSlashTable* next;
 }; /* Columns Slash Tables */
 
@@ -202,6 +206,14 @@ static void pop_sprintf_state() {
     cst* next = state->csts->next;
     if (!(state->csts->info & INFO_COLS) && state->csts->d.tab) {
       FREE(state->csts->d.tab);
+    }
+    // add_column/add_table free the pad when a column/table fully flushes;
+    // a cst still pending here (e.g. on error unwind) must free it too.
+    if (state->csts->pad) {
+      FREE(state->csts->pad);
+    }
+    if (state->csts->owned) {
+      FREE_MSTR(state->csts->owned);
     }
     FREE(state->csts);
     state->csts = next;
@@ -674,6 +686,9 @@ static int add_column(cst** column, int trailing) {
     if (col->pad) {
       FREE(col->pad);
     }
+    if (col->owned) {
+      FREE_MSTR(col->owned);
+    }
     FREE(col);
     *column = temp;
     return ret;
@@ -729,6 +744,9 @@ static int add_table(cst** table) {
     }
     if (tab_d) {
       FREE(tab_d);
+    }
+    if (tab->owned) {
+      FREE_MSTR(tab->owned);
     }
     FREE(tab);
     *table = temp;
@@ -1099,7 +1117,10 @@ char* string_print_formatted(const char* format_str, int argc, svalue_t* argv) {
               *temp =
                   reinterpret_cast<cst*>(DMALLOC(sizeof(cst), TAG_TEMPORARY, "string_print: 3"));
               (*temp)->next = nullptr;
-              (*temp)->d.col = carg->u.string;
+              // Own a copy: a column can stay pending across iterations while
+              // the arg it came from (sprintf_state.clean for %O) is freed.
+              (*temp)->owned = string_copy(carg->u.string, "string_print: col");
+              (*temp)->d.col = (*temp)->owned;
               (*temp)->pad = make_pad(&pad);
               (*temp)->size = fs;
               (*temp)->pres = (pres) ? pres : fs;
@@ -1117,9 +1138,13 @@ char* string_print_formatted(const char* format_str, int argc, svalue_t* argv) {
               unsigned int n, items_per_column, max_width;
               const char *p1, *p2;
 
-#define TABLE carg->u.string
               (*temp) =
                   reinterpret_cast<cst*>(DMALLOC(sizeof(cst), TAG_TEMPORARY, "string_print: 4"));
+              // Own a copy: table entries point into this buffer, which must
+              // outlive the transient sprintf_state.clean (for %O) they were
+              // rendered from.
+              (*temp)->owned = string_copy(carg->u.string, "string_print: table");
+#define TABLE ((*temp)->owned)
               (*temp)->d.tab = nullptr;
               (*temp)->pad = make_pad(&pad);
               (*temp)->info = finfo;

--- a/src/packages/core/sys.cc
+++ b/src/packages/core/sys.cc
@@ -54,7 +54,11 @@ void f_sys_reload_tls() {
   auto port_index = port_index_display - 1;
 
   DEFER { pop_stack(); };
-  if (port_index < 0 || port_index > sizeof(external_port)) {
+  // external_port is a fixed array; bound by ELEMENT COUNT, not sizeof (which
+  // is the size in bytes and let indices up to ~sizeof(port_def_t)*N through,
+  // for an out-of-bounds read and a wild tls_server_close()/port->ssl write).
+  if (port_index < 0 ||
+      port_index >= (LPC_INT)(sizeof(external_port) / sizeof(external_port[0]))) {
     error("Invalid port index: %d\n", port_index_display);
   }
   auto* port = &external_port[port_index];

--- a/src/packages/core/time.cc
+++ b/src/packages/core/time.cc
@@ -4,6 +4,7 @@
 #include <string>
 #include <iomanip>
 #include <sstream>
+#include <vector>
 
 #ifdef F_PERF_COUNTER_NS
 void f_perf_counter_ns() {
@@ -135,12 +136,15 @@ void f_strftime() {
   }
 
   const auto max_string_length = CONFIG_INT(__MAX_STRING_LENGTH__);
-  char buf[max_string_length];
-  int const size = strftime(buf, sizeof(buf), arg_fmt, res_tm);
+  // Heap, not a stack VLA: __MAX_STRING_LENGTH__ defaults to 1MB and is
+  // admin-configurable up to INT_MAX, so `char buf[max_string_length]` risked
+  // a stack overflow on every call.
+  std::vector<char> buf(max_string_length);
+  size_t const size = strftime(buf.data(), buf.size(), arg_fmt, res_tm);
   buf[size] = '\0';
 
   pop_2_elems();
-  copy_and_push_string(buf);
+  copy_and_push_string(buf.data());
 }
 #endif
 

--- a/src/packages/db/db.cc
+++ b/src/packages/db/db.cc
@@ -664,12 +664,17 @@ static array_t* MySQL_fetch(dbconn_t* c, int row) {
     return &the_null_array;
   }
 
+  // Per-field byte lengths of the current row; field->max_length is the
+  // column-wide maximum across all rows, so using it to size/copy a BLOB
+  // over-reads any row whose value is shorter than that maximum.
+  unsigned long* target_lengths = nullptr;
   if (row > 0) {
     mysql_data_seek(c->mysql.results, row - 1);
     target_row = mysql_fetch_row(c->mysql.results);
     if (!target_row) {
       return &the_null_array;
     }
+    target_lengths = mysql_fetch_lengths(c->mysql.results);
   }
 
   v = allocate_empty_array(num_fields);
@@ -718,9 +723,11 @@ static array_t* MySQL_fetch(dbconn_t* c, int row) {
         case FIELD_TYPE_STRING:
         case FIELD_TYPE_VAR_STRING:
           if (field->flags & BINARY_FLAG) {
+            // Use this row's actual field length, not the column-wide max.
+            unsigned long const blen = target_lengths ? target_lengths[i] : 0;
             v->item[i].type = T_BUFFER;
-            v->item[i].u.buf = allocate_buffer(field->max_length);
-            write_buffer(v->item[i].u.buf, 0, target_row[i], field->max_length);
+            v->item[i].u.buf = allocate_buffer(blen);
+            write_buffer(v->item[i].u.buf, 0, target_row[i], blen);
           } else {
             v->item[i].type = T_STRING;
             if (target_row[i]) {

--- a/src/packages/develop/checkmemory.cc
+++ b/src/packages/develop/checkmemory.cc
@@ -680,8 +680,9 @@ void check_all_blocks(int flag) {
     auto* dfm = CONFIG_STR(__DEFAULT_FAIL_MESSAGE__);
     if (dfm != nullptr && strlen(dfm) > 0) {
       char buf[8192];
-      strcpy(buf, dfm);
-      strcat(buf, "\n");
+      // dfm is the admin-configured __DEFAULT_FAIL_MESSAGE__; bound the copy so
+      // an over-long message can't overflow this fixed buffer.
+      snprintf(buf, sizeof(buf), "%s\n", dfm);
       const char* target = findstring(buf);
       if (target) {
         EXTRA_REF(BLOCK(target))++;

--- a/src/packages/dwlib/dwlib.cc
+++ b/src/packages/dwlib/dwlib.cc
@@ -832,7 +832,10 @@ void f_replace_dollars() {
           currentnew += len;
           currentold += len;
           currentold += COUNTED_STRLEN(one);
-          if (currentnew + COUNTED_STRLEN(one) - newstr > max_string_length) {
+          // Check against the replacement length actually written below
+          // ('two'), not the matched pattern ('one'): a replacement longer
+          // than its pattern would otherwise overrun newstr.
+          if (currentnew + COUNTED_STRLEN(two) - newstr > max_string_length) {
             FREE_MSTR(newstr);
             error("string too long");
           }

--- a/src/packages/external/external.cc
+++ b/src/packages/external/external.cc
@@ -124,6 +124,13 @@ int external_start(int which, svalue_t* args, svalue_t* arg1, svalue_t* arg2, sv
   ret = posix_spawn(&pid, newargs[0], &file_actions, nullptr, newargs.data(), newenviron);
   if (ret) {
     debug(external_start, "external_start: posix_spawn() error: %s\n", strerror(ret));
+    // The socket slot above is fully provisioned (fd, callbacks, event
+    // listeners, STATE_DATA_XFER). Tear it down so we don't leak the event
+    // listeners / callback strings and leave a dangling half-open efun socket
+    // pointing at sv[0]. socket_close() closes lpc_socks[fd].fd (== sv[0]);
+    // clear sv[0] afterwards so the DEFER doesn't double-close it.
+    socket_close(fd, SC_FORCE | SC_FINAL_CLOSE);
+    sv[0] = -1;
     return EESOCKET;
   }
 

--- a/src/packages/ffi/ffi.cc
+++ b/src/packages/ffi/ffi.cc
@@ -632,11 +632,14 @@ void f_ffi_address() {
 #ifdef F_FFI_READ
 void f_ffi_read() {
   int code = sp->u.number;
-  int offset = (sp - 1)->u.number;
+  LPC_INT offset = (sp - 1)->u.number;
   buffer_t* buf = (sp - 2)->u.buf;
   int sz = type_size(code);
-  if (offset < 0 || offset + sz > static_cast<int>(buf->size)) {
-    error("ffi_read: offset %d (size %d) out of range for buffer of %u.\n", offset, sz, buf->size);
+  // Range-check in a non-truncating, non-overflowing form: a huge offset must
+  // not truncate to int or wrap past the check into an out-of-bounds memcpy.
+  if (offset < 0 || static_cast<size_t>(offset) + static_cast<size_t>(sz) > buf->size) {
+    error("ffi_read: offset %" LPC_INT_FMTSTR_P " (size %d) out of range for buffer of %u.\n",
+          offset, sz, buf->size);
   }
   void* at = &buf->item[offset];
   FfiArgSlot tmp;
@@ -686,11 +689,12 @@ void f_ffi_read() {
 void f_ffi_write() {
   svalue_t* val = sp;
   int code = (sp - 1)->u.number;
-  int offset = (sp - 2)->u.number;
+  LPC_INT offset = (sp - 2)->u.number;
   buffer_t* buf = (sp - 3)->u.buf;
   int sz = type_size(code);
-  if (offset < 0 || offset + sz > static_cast<int>(buf->size)) {
-    error("ffi_write: offset %d (size %d) out of range for buffer of %u.\n", offset, sz, buf->size);
+  if (offset < 0 || static_cast<size_t>(offset) + static_cast<size_t>(sz) > buf->size) {
+    error("ffi_write: offset %" LPC_INT_FMTSTR_P " (size %d) out of range for buffer of %u.\n",
+          offset, sz, buf->size);
   }
   FfiArgSlot tmp;
   lpc_to_slot(code, val, &tmp);

--- a/src/packages/math/math.cc
+++ b/src/packages/math/math.cc
@@ -176,7 +176,10 @@ void f_round() { sp->u.real = round(sp->u.real); }
    of speed, norm() has less cases.
 */
 static LPC_FLOAT norm(array_t* a) {
-  LPC_INT len = sp->u.arr->size;
+  // Length must come from the array we actually index (a), not sp->u.arr:
+  // f_angle() calls norm((sp-1)->u.arr), a different array, so using sp's size
+  // would read past `a` if the two ever differed in length.
+  LPC_INT len = a->size;
   LPC_FLOAT total = 0.0;
 
   while (len-- > 0) {

--- a/src/packages/matrix/matrix.cc
+++ b/src/packages/matrix/matrix.cc
@@ -47,6 +47,9 @@ void f_translate() {
    * get arguments from stack.
    */
   matrix = (sp - 3)->u.arr;
+  if (matrix->size < 16) {
+    error("matrix transform requires a 16-element array.\n");
+  }
   x = (sp - 2)->u.real;
   y = (sp - 1)->u.real;
   z = sp->u.real;
@@ -92,6 +95,9 @@ void f_scale() {
    * get arguments from stack.
    */
   matrix = (sp - 3)->u.arr;
+  if (matrix->size < 16) {
+    error("matrix transform requires a 16-element array.\n");
+  }
   x = (sp - 2)->u.real;
   y = (sp - 1)->u.real;
   z = sp->u.real;
@@ -130,6 +136,9 @@ void f_rotate_x() {
    * get arguments from stack.
    */
   matrix = (sp - 1)->u.arr;
+  if (matrix->size < 16) {
+    error("matrix transform requires a 16-element array.\n");
+  }
   angle = (sp--)->u.real;
   /*
    * convert vec matrix to float matrix.
@@ -165,6 +174,9 @@ void f_rotate_y() {
    * get arguments from stack.
    */
   matrix = (sp - 1)->u.arr;
+  if (matrix->size < 16) {
+    error("matrix transform requires a 16-element array.\n");
+  }
   angle = (sp--)->u.real;
   /*
    * convert vec matrix to float matrix.
@@ -200,6 +212,9 @@ void f_rotate_z() {
    * get arguments from stack.
    */
   matrix = (sp - 1)->u.arr;
+  if (matrix->size < 16) {
+    error("matrix transform requires a 16-element array.\n");
+  }
   angle = (sp--)->u.real;
   /*
    * convert vec matrix to float matrix.
@@ -240,6 +255,9 @@ void f_lookat_rotate() {
    * get arguments from stack.
    */
   matrix = (sp - 3)->u.arr;
+  if (matrix->size < 16) {
+    error("matrix transform requires a 16-element array.\n");
+  }
   x = (sp - 2)->u.real;
   y = (sp - 1)->u.real;
   z = sp->u.real;
@@ -279,6 +297,9 @@ void f_lookat_rotate2(void) {
    * get arguments from stack.
    */
   matrix = (sp - 6)->u.arr;
+  if (matrix->size < 16) {
+    error("matrix transform requires a 16-element array.\n");
+  }
   ex = (sp - 5)->u.real;
   ey = (sp - 4)->u.real;
   ez = (sp - 3)->u.real;

--- a/src/packages/mudlib_stats/mudlib_stats.cc
+++ b/src/packages/mudlib_stats/mudlib_stats.cc
@@ -342,7 +342,13 @@ static const char* author_for_file(const char* file) {
   if (ret == nullptr || ret == (svalue_t*)-1 || ret->type != T_STRING) {
     return nullptr;
   }
-  strcpy(buff, ret->u.string);
+  // The master apply may return an arbitrary-length string; bound the copy.
+  size_t n = SVALUE_STRLEN(ret);
+  if (n >= sizeof(buff)) {
+    n = sizeof(buff) - 1;
+  }
+  memcpy(buff, ret->u.string, n);
+  buff[n] = '\0';
   return buff;
 }
 
@@ -429,7 +435,13 @@ static const char* domain_for_file(const char* file) {
   if (ret == nullptr || ret == (svalue_t*)-1 || ret->type != T_STRING) {
     return nullptr;
   }
-  strcpy(buff, ret->u.string);
+  // The master apply may return an arbitrary-length string; bound the copy.
+  size_t n = SVALUE_STRLEN(ret);
+  if (n >= sizeof(buff)) {
+    n = sizeof(buff) - 1;
+  }
+  memcpy(buff, ret->u.string, n);
+  buff[n] = '\0';
   return buff;
 }
 
@@ -483,7 +495,7 @@ static void restore_stat_list(const char* file, mudlib_stats_t** list) {
       }
       f = fopen(file, "r");
     } else {
-      sprintf(fname, "%s/%s", CONFIG_STR(__LOG_DIR__), file);
+      snprintf(fname, sizeof(fname_buf), "%s/%s", CONFIG_STR(__LOG_DIR__), file);
       if (fname[0] == '/') {
         fname++;
       }
@@ -497,9 +509,16 @@ static void restore_stat_list(const char* file, mudlib_stats_t** list) {
     debug_message("*Warning: unable to open stat file %s for reading.\n", file);
     return;
   }
-  while (fscanf(f, "%s", fname) != EOF) {
+  // The stat-file names are arbitrary-length mudlib strings; bound the scan
+  // to the remaining buffer space so a long name cannot overflow fname_buf.
+  char scan_fmt[16];
+  snprintf(scan_fmt, sizeof(scan_fmt), "%%%ds",
+           (int)(sizeof(fname_buf) - (size_t)(fname - fname_buf) - 1));
+  while (fscanf(f, scan_fmt, fname) == 1) {
     entry = add_stat_entry(fname, list);
-    fscanf(f, "%d %d\n", &entry->moves, &entry->heart_beats);
+    if (fscanf(f, "%d %d\n", &entry->moves, &entry->heart_beats) != 2) {
+      break;
+    }
   }
   fclose(f);
 }

--- a/src/packages/ops/ops.cc
+++ b/src/packages/ops/ops.cc
@@ -48,7 +48,13 @@ void f_div_eq() {
       if (!sp->u.number) {
         error("Division by 0nn\n");
       }
-      sp->u.number = argp->u.number /= sp->u.number;
+      if (sp->u.number == -1) {
+        // x / -1 == -x; direct division traps (SIGFPE) for INT_MIN.
+        argp->u.number = (LPC_INT)(0ULL - (uint64_t)argp->u.number);
+      } else {
+        argp->u.number /= sp->u.number;
+      }
+      sp->u.number = argp->u.number;
       sp->subtype = 0;
       break;
     }
@@ -381,7 +387,12 @@ void f_mod_eq() {
   if (sp->u.number == 0) {
     error("Modulo by 0\n");
   }
-  sp->u.number = argp->u.number %= sp->u.number;
+  if (sp->u.number == -1) {
+    argp->u.number = 0;  // x % -1 == 0; direct computation traps for INT_MIN.
+  } else {
+    argp->u.number %= sp->u.number;
+  }
+  sp->u.number = argp->u.number;
   sp->subtype = 0;
 }
 

--- a/src/packages/ops/parse.cc
+++ b/src/packages/ops/parse.cc
@@ -1060,6 +1060,12 @@ static svalue_t* living_parse(array_t* obarr, array_t* warr, int* cix_in, int* f
   *fail = 0;
 
   for (obix = 0; obix < obarr->size; obix++) {
+    // The array may hold non-objects (a caller-supplied 0, or a destructed
+    // object that check_for_destr turned into the number 0); skip them
+    // instead of dereferencing u.ob.
+    if (obarr->item[obix].type != T_OBJECT) {
+      continue;
+    }
     if (obarr->item[obix].u.ob->flags & O_ENABLE_COMMANDS) {
       assign_svalue_no_free(&live->item[tix++], &obarr->item[obix]);
     }

--- a/src/packages/parser/parser.cc
+++ b/src/packages/parser/parser.cc
@@ -78,6 +78,16 @@ static int found_level = 0;
 static mapping_t* parse_nicks = nullptr;
 static array_t* parse_env = nullptr;
 
+// A parse holds a raw pointer (parse_vn) into a verb node for its whole
+// duration, but the applies it runs (can_/direct_/do_) may destruct the
+// handler object or call parse_remove(), which frees that object's verb
+// nodes synchronously -- a use-after-free under the active parse. While a
+// parse is in progress, node frees are deferred onto this list and flushed
+// when the last active parse unwinds (in free_parse_globals). Depth (not a
+// bool) because an apply can re-enter parse_sentence().
+static int parse_active_depth = 0;
+static verb_node_t* deferred_verb_nodes = nullptr;
+
 static int direct_object, indirect_object;
 
 static parser_error_t current_error_info;
@@ -616,6 +626,18 @@ void f_parse_refresh() {
 }
 
 /* called from free_object() */
+// Free a verb node, or defer it if a parse is in progress (parse_vn may still
+// reference it). Callers must have already unlinked the node from its hash
+// chain, so reusing its `next` field for the deferred list is safe.
+static void free_verb_node(verb_node_t* vn) {
+  if (parse_active_depth > 0) {
+    vn->next = deferred_verb_nodes;
+    deferred_verb_nodes = vn;
+  } else {
+    FREE(vn);
+  }
+}
+
 void parse_free(parse_info_t* pinfo) {
   int i;
 
@@ -628,7 +650,7 @@ void parse_free(parse_info_t* pinfo) {
           if ((*vn)->handler == pinfo->ob) {
             old = *vn;
             *vn = (*vn)->next;
-            FREE(old);
+            free_verb_node(old);
           } else {
             vn = &((*vn)->next);
           }
@@ -691,6 +713,7 @@ static void clear_result(parse_result_t* pr) {
   for (i = 0; i < 4; i++) {
     pr->res[i].func = nullptr;
     pr->res[i].args = nullptr;
+    pr->res[i].num = 0;
   }
 }
 
@@ -714,6 +737,16 @@ static void free_parse_globals() {
       free_object(&loaded_objects[i], "free_parse_globals");
     }
     objects_loaded = 0;
+  }
+
+  // End of one active parse: when the outermost one unwinds, it is finally
+  // safe to free any verb nodes that were destructed/removed mid-parse.
+  if (parse_active_depth > 0 && --parse_active_depth == 0) {
+    while (deferred_verb_nodes) {
+      verb_node_t* n = deferred_verb_nodes;
+      deferred_verb_nodes = n->next;
+      FREE(n);
+    }
   }
 }
 
@@ -2844,6 +2877,14 @@ static void we_are_finished(parse_state_t* state) {
     best_result = (parse_result_t*)DMALLOC(sizeof(parse_result_t), TAG_PARSER, "we_are_finished");
     clear_result(best_result);
     if (parse_vn->handler->flags & O_DESTRUCTED) {
+      // The handler destructed itself during check_functions(). We already
+      // committed best_match above and freed any prior result, so there is
+      // nothing valid to fall back to: tear down the half-built result and
+      // clear best_match so f_parse_sentence does not call do_the_call() with
+      // best_result->ob == NULL (a NULL deref). (#1014 sibling)
+      free_parse_result(best_result);
+      best_result = nullptr;
+      best_match = 0;
       DEBUG_DEC;
       return;
     }
@@ -3358,6 +3399,7 @@ void f_parse_sentence() {
   STACK_INC;
   sp->type = T_ERROR_HANDLER;
   sp->u.error_handler = free_parse_globals;
+  parse_active_depth++; /* paired with the decrement in free_parse_globals */
 
   parse_user = current_object;
   pi = current_object->pinfo;
@@ -3408,6 +3450,7 @@ void f_parse_my_rules() {
   STACK_INC;
   sp->type = T_ERROR_HANDLER;
   sp->u.error_handler = free_parse_globals;
+  parse_active_depth++; /* paired with the decrement in free_parse_globals */
 
   parse_user = (sp - 2)->u.ob;
   pi = parse_user->pinfo;
@@ -3472,7 +3515,7 @@ void f_parse_remove() {
         if ((*vn)->handler == current_object) {
           old = *vn;
           *vn = (*vn)->next;
-          FREE(old);
+          free_verb_node(old);
         } else {
           vn = &((*vn)->next);
         }

--- a/src/packages/pcre/pcre.cc
+++ b/src/packages/pcre/pcre.cc
@@ -921,8 +921,6 @@ static array_t* pcre_get_substrings(pcre_t* run, bool include_names) {
 }
 
 static char* pcre_get_replace(pcre_t* run, array_t* replacements) {
-  const auto max_string_length = CONFIG_INT(__MAX_STRING_LENGTH__);
-
   unsigned int ret_pos = 0, i;
   size_t ret_sz;
   char* ret;
@@ -946,46 +944,67 @@ static char* pcre_get_replace(pcre_t* run, array_t* replacements) {
   ret = new_string((ret_sz), "pcre get replace");
   // printf("ret_sz:%d\n", ret_sz);
 
-  /* Copy start of subject up until first match */
-  if (run->rc > 1) {
-    strncpy(ret, run->subject, run->ovector[2]);
-    ret_pos = run->ovector[2];
-  } else {
+  if (run->rc <= 1) {
     strncpy(ret, run->subject, ret_sz);
+    *(ret + ret_sz) = '\0';
+    return ret;
+  }
+
+  // Copy the subject, replacing each SELECTED capture group with its
+  // replacement. The selection MUST match the size loop above exactly
+  // (a group is selected only when it starts at/after the end of the last
+  // selected group -- i.e. non-nested/non-overlapping); otherwise the copied
+  // length diverges from ret_sz and overflows ret. Every write is also
+  // clamped to the remaining space as defense in depth.
+  prev = run->ovector[2];  // reuse: gate -- next selected group must start >= this
+  int last_end = run->ovector[2];
+  ret_pos = 0;
+
+  // Copy the subject prefix up to the first potential group start.
+  {
+    size_t n = (size_t)run->ovector[2];
+    if (n > ret_sz - ret_pos) n = ret_sz - ret_pos;
+    strncpy(ret + ret_pos, run->subject, n);
+    ret_pos += n;
   }
 
   for (i = 1; i <= (run->rc - 1); i++) {
-    unsigned int end, len_nxt;
-    const char* rep;
-    size_t rep_sz;
+    int gstart = run->ovector[2 * i];
+    int gend = run->ovector[2 * i + 1];
 
-    end = run->ovector[2 * i + 1];
-
-    if (i == (run->rc - 1)) {
-      len_nxt = run->s_length - end;
-    } else {
-      len_nxt = run->ovector[2 * i + 2] - end;
+    if (gstart < prev) {
+      continue;  // nested/overlapping group -- skipped by the size loop too
     }
 
-    if (len_nxt > max_string_length) {
-      continue;  // nested ()s
+    const char* rep = replacements->item[i - 1].u.string;
+    size_t rep_sz = SVALUE_STRLEN(&replacements->item[i - 1]);
+
+    // Gap of subject text between the previous selected group and this one.
+    if (gstart > last_end) {
+      size_t gap = (size_t)(gstart - last_end);
+      if (gap > ret_sz - ret_pos) gap = ret_sz - ret_pos;
+      strncpy(ret + ret_pos, run->subject + last_end, gap);
+      ret_pos += gap;
     }
 
-    rep = replacements->item[i - 1].u.string;
-    rep_sz = SVALUE_STRLEN(&replacements->item[i - 1]);
-
-    /* Copy first substring into return variable */
+    // The replacement for this group.
+    if (rep_sz > ret_sz - ret_pos) rep_sz = ret_sz - ret_pos;
     strncpy(ret + ret_pos, rep, rep_sz);
-
-    /* increment position in return variable by replacement size */
     ret_pos += rep_sz;
 
-    strncpy(ret + ret_pos, run->subject + end, len_nxt);
-
-    ret_pos += len_nxt;
+    last_end = gend;
+    prev = gend;
   }
 
-  *(ret + ret_sz) = '\0';
+  // Copy the trailing subject text after the last selected group.
+  if ((size_t)last_end < run->s_length) {
+    size_t tail = run->s_length - (size_t)last_end;
+    if (tail > ret_sz - ret_pos) tail = ret_sz - ret_pos;
+    strncpy(ret + ret_pos, run->subject + last_end, tail);
+    ret_pos += tail;
+  }
+
+  *(ret + ret_pos) = '\0';
 
   return ret;
 }

--- a/src/packages/pcre/pcre.cc
+++ b/src/packages/pcre/pcre.cc
@@ -945,7 +945,7 @@ static char* pcre_get_replace(pcre_t* run, array_t* replacements) {
   // printf("ret_sz:%d\n", ret_sz);
 
   if (run->rc <= 1) {
-    strncpy(ret, run->subject, ret_sz);
+    memcpy(ret, run->subject, ret_sz);
     *(ret + ret_sz) = '\0';
     return ret;
   }
@@ -964,7 +964,7 @@ static char* pcre_get_replace(pcre_t* run, array_t* replacements) {
   {
     size_t n = (size_t)run->ovector[2];
     if (n > ret_sz - ret_pos) n = ret_sz - ret_pos;
-    strncpy(ret + ret_pos, run->subject, n);
+    memcpy(ret + ret_pos, run->subject, n);
     ret_pos += n;
   }
 
@@ -983,13 +983,13 @@ static char* pcre_get_replace(pcre_t* run, array_t* replacements) {
     if (gstart > last_end) {
       size_t gap = (size_t)(gstart - last_end);
       if (gap > ret_sz - ret_pos) gap = ret_sz - ret_pos;
-      strncpy(ret + ret_pos, run->subject + last_end, gap);
+      memcpy(ret + ret_pos, run->subject + last_end, gap);
       ret_pos += gap;
     }
 
     // The replacement for this group.
     if (rep_sz > ret_sz - ret_pos) rep_sz = ret_sz - ret_pos;
-    strncpy(ret + ret_pos, rep, rep_sz);
+    memcpy(ret + ret_pos, rep, rep_sz);
     ret_pos += rep_sz;
 
     last_end = gend;
@@ -1000,7 +1000,7 @@ static char* pcre_get_replace(pcre_t* run, array_t* replacements) {
   if ((size_t)last_end < run->s_length) {
     size_t tail = run->s_length - (size_t)last_end;
     if (tail > ret_sz - ret_pos) tail = ret_sz - ret_pos;
-    strncpy(ret + ret_pos, run->subject + last_end, tail);
+    memcpy(ret + ret_pos, run->subject + last_end, tail);
     ret_pos += tail;
   }
 

--- a/src/packages/sockets/socket_efuns.cc
+++ b/src/packages/sockets/socket_efuns.cc
@@ -49,10 +49,8 @@ static void call_callback(int fd, int what, int num_arg);
 
 namespace {
 
-/* flags for socket_close */
-#define SC_FORCE 1u
-#define SC_DO_CALLBACK 2u
-#define SC_FINAL_CLOSE 4u
+/* SC_FORCE / SC_DO_CALLBACK / SC_FINAL_CLOSE flags for socket_close() live in
+ * socket_efuns.h so other packages (e.g. external) can tear down sockets. */
 
 const char* error_strings[ERROR_STRINGS] = {"Problem creating socket",
                                             "Problem with setsockopt",

--- a/src/packages/sockets/socket_efuns.cc
+++ b/src/packages/sockets/socket_efuns.cc
@@ -732,10 +732,13 @@ int socket_accept(int fd, svalue_t* read_callback, svalue_t* write_callback) {
     return EENONBLOCK;
   }
 
-  if (evutil_make_socket_closeonexec(fd) == -1) {
+  // Set close-on-exec on the ACCEPTED socket, not the listener's LPC index.
+  // Passing `fd` (the lpc_socks[] index) misses accept_fd -- so the accepted
+  // connection would leak into exec'd children -- and the error path closed
+  // an unrelated low OS descriptor equal to that index.
+  if (evutil_make_socket_closeonexec(accept_fd) == -1) {
     debug(sockets, "socket_accept: make_socket_closeonexec error: %s.\n",
-          evutil_socket_error_to_string(evutil_socket_geterror(fd)));
-    evutil_closesocket(fd);
+          evutil_socket_error_to_string(evutil_socket_geterror(accept_fd)));
     evutil_closesocket(accept_fd);
     return EESETSOCKOPT;
   }

--- a/src/packages/sockets/socket_efuns.cc
+++ b/src/packages/sockets/socket_efuns.cc
@@ -188,7 +188,12 @@ static bool lpcaddr_to_sockaddr(const char* name, struct sockaddr* addr, ev_sock
   memset(host, 0, sizeof(host));
   memset(service, 0, sizeof(service));
 
-  memcpy(host, name, cp - name);
+  size_t const hlen = cp - name;
+  if (hlen >= sizeof(host)) {
+    debug(sockets, "lpcaddr_to_sockaddr: host too long: %s", name);
+    return false;
+  }
+  memcpy(host, name, hlen);  // host is zero-initialized above, so NUL-terminated
   strncpy(service, cp + 1, sizeof(service) - 1);
 
   struct addrinfo hints = {0}, *res;

--- a/src/packages/sockets/socket_efuns.h
+++ b/src/packages/sockets/socket_efuns.h
@@ -105,6 +105,10 @@ int socket_listen(int, svalue_t*);
 int socket_accept(int, svalue_t*, svalue_t*);
 int socket_connect(int, const char*, svalue_t*, svalue_t*);
 int socket_write(int, svalue_t*, const char*);
+/* flags for socket_close() */
+#define SC_FORCE 1u
+#define SC_DO_CALLBACK 2u
+#define SC_FINAL_CLOSE 4u
 int socket_close(int, int);
 int socket_release(int, object_t*, svalue_t*);
 int socket_acquire(int, svalue_t*, svalue_t*, svalue_t*);

--- a/src/vm/internal/apply.cc
+++ b/src/vm/internal/apply.cc
@@ -89,7 +89,9 @@ void check_co_args2(unsigned short* types, int num_arg, const char* name, const 
           smart_log("driver", 0, buf, 1);
         }
       } else {
-        error(buf);
+        // buf is built from object-derived text (name/ob_name); never use it
+        // as a printf format (a '%' in a path/name would be a crash).
+        error("%s", buf);
       }
     }
   } while (i < num_arg);
@@ -116,12 +118,16 @@ void check_co_args(int num_arg, const program_t* prog, function_t* fun, int find
           smart_log("driver", 0, buf, 1);
         }
       } else {
-        error(buf);
+        error("%s", buf);
       }
     }
     int num_arg_check = std::min((unsigned char)num_arg, fun->num_arg);
+    // Pass num_arg_check as the loop bound: argument_types holds only
+    // fun->num_arg slots, so bounding the walk by the (possibly larger)
+    // passed num_arg would over-read the array. num_arg stays as sparg so
+    // stack indexing (sp - argc) still lines up with the pushed arguments.
     if (num_arg_check && prog->type_start && prog->type_start[findex] != INDEX_START_NONE)
-      check_co_args2(&prog->argument_types[prog->type_start[findex]], num_arg, fun->funcname,
+      check_co_args2(&prog->argument_types[prog->type_start[findex]], num_arg_check, fun->funcname,
                      prog->filename, num_arg);
   }
 }

--- a/src/vm/internal/base/array.cc
+++ b/src/vm/internal/base/array.cc
@@ -125,6 +125,11 @@ array_t* allocate_array2(int n, svalue_t* svp) {
 
   if (svp->type == T_FUNCTION) {
     ret = allocate_array(n);
+    // The callback runs arbitrary LPC and may error()/longjmp out of the
+    // loop. Keep ret on the VM stack so the unwind reclaims it (along with
+    // any refcounted values already stored) instead of leaking it; detach it
+    // without freeing on the normal path. (mirrors allocate_mapping2/map_array)
+    push_refed_array(ret);
 
     for (i = 0; i < n; i++) {
       svalue_t* r;
@@ -134,6 +139,7 @@ array_t* allocate_array2(int n, svalue_t* svp) {
       ret->item[i] = *r;
       r->type = T_NUMBER;
     }
+    sp--; /* detach ret from the stack; caller owns the reference */
   } else {
     ret = allocate_empty_array(n);
 

--- a/src/vm/internal/base/buffer.cc
+++ b/src/vm/internal/base/buffer.cc
@@ -44,20 +44,24 @@ buffer_t* allocate_buffer(int size) {
 }
 
 int write_buffer(buffer_t* buf, int start, const char* str, int theLength) {
-  int size;
+  unsigned int size = buf->size;
 
-  size = buf->size;
   if (start < 0) {
-    start = size + start;
+    start = (int)size + start;
     if (start < 0) {
       return 0;
     }
   }
+  if (theLength < 0) {
+    return 0;
+  }
   /*
    * can't write past the end of the buffer since we can't reallocate the
-   * buffer here (no easy way to propagate back the changes to the caller
+   * buffer here (no easy way to propagate back the changes to the caller).
+   * Compute the bound in unsigned arithmetic so a huge start can't overflow
+   * signed int past the check and drive an out-of-bounds memcpy.
    */
-  if ((start + theLength) > size) {
+  if ((unsigned int)start > size || (unsigned int)theLength > size - (unsigned int)start) {
     return 0;
   }
   memcpy(buf->item + start, str, theLength);

--- a/src/vm/internal/base/interpret.cc
+++ b/src/vm/internal/base/interpret.cc
@@ -976,7 +976,7 @@ void copy_lvalue_range(svalue_t* from) {
           memcpy(b->item, old_item, ind1);
           new_item += ind1;
         }
-        memcpy(new_item, from->u.buf, fsize);
+        memcpy(new_item, from->u.buf->item, fsize);
         new_item += fsize;
 
         if ((size -= ind2) >= 1) {
@@ -1132,7 +1132,7 @@ void assign_lvalue_range(svalue_t* from) {
           memcpy(b->item, old_item, ind1);
           new_item += ind1;
         }
-        memcpy(new_item, from->u.buf, fsize);
+        memcpy(new_item, from->u.buf->item, fsize);
         new_item += fsize;
 
         if ((size -= ind2) >= 1) {

--- a/src/vm/internal/base/interpret.cc
+++ b/src/vm/internal/base/interpret.cc
@@ -3314,7 +3314,12 @@ void eval_instruction(char* p) {
             if (!(sp--)->u.number) {
               error("Division by zero\n");
             }
-            sp->u.number /= (sp + 1)->u.number;
+            if ((sp + 1)->u.number == -1) {
+              // x / -1 == -x; direct division traps (SIGFPE) for INT_MIN.
+              sp->u.number = (LPC_INT)(0ULL - (uint64_t)sp->u.number);
+            } else {
+              sp->u.number /= (sp + 1)->u.number;
+            }
             break;
           }
 
@@ -3695,7 +3700,11 @@ void eval_instruction(char* p) {
         if ((sp--)->u.number == 0) {
           error("Modulus by zero.\n");
         }
-        sp->u.number %= (sp + 1)->u.number;
+        if ((sp + 1)->u.number == -1) {
+          sp->u.number = 0;  // x % -1 == 0; direct computation traps for INT_MIN.
+        } else {
+          sp->u.number %= (sp + 1)->u.number;
+        }
       } break;
       case F_MOD_EQ:
         f_mod_eq();

--- a/src/vm/internal/base/mapping.cc
+++ b/src/vm/internal/base/mapping.cc
@@ -1154,6 +1154,9 @@ mapping_t* compose_mapping(mapping_t* m1, mapping_t* m2, unsigned short flag) {
             m1->unfilled++;
           }
           deleted++;
+          // free_node only releases the value (values+1); the caller must
+          // release the key (values[0]) -- as free_mapping does -- or it leaks.
+          free_svalue(elt->values, "compose_mapping");
           free_node(m1, elt);
         } else {
           prev = &(elt->next);

--- a/src/vm/internal/base/object.cc
+++ b/src/vm/internal/base/object.cc
@@ -66,6 +66,19 @@ int valid_hide(object_t* obj) {
 int save_svalue_depth = 0, max_depth;
 int* sizes = nullptr;
 
+/* Reset the transient scratch state used while sizing a restore string.
+ * restore_svalue() frees this on its normal return, but a nested restore that
+ * longjmps out via error() (OOM / mapping-too-large) skips that cleanup, which
+ * would leak `sizes` and leave save_svalue_depth dirty so that the *next*
+ * restore reads a stale sizes[] entry. Call this before any such error(). */
+static void reset_restore_scratch() {
+  save_svalue_depth = max_depth = 0;
+  if (sizes) {
+    FREE((char*)sizes);
+    sizes = nullptr;
+  }
+}
+
 int svalue_save_size(svalue_t* v) {
   switch (v->type) {
     case T_STRING: {
@@ -243,6 +256,14 @@ static int restore_internal_size(const char** str, int is_mapping, int depth) {
   const char* cp = *str;
   int size = 0;
   char c, delim, toggle = 0;
+
+  // Bound recursion the same way the save path does (too_deep_save_error).
+  // Without this, a maliciously deep-nested save string (e.g. "({({({...")
+  // recurses until the C stack overflows. Returning 0 fails the size pre-pass
+  // so restore_size() reports an error before the actual restore recurses.
+  if (depth > MAX_SAVE_SVALUE_DEPTH) {
+    return 0;
+  }
 
   delim = is_mapping ? ':' : ',';
   while ((c = *cp++)) {
@@ -650,7 +671,10 @@ static int restore_mapping(char** str, svalue_t* sv) {
   if (save_svalue_depth) {
     size = sizes[save_svalue_depth - 1];
   } else if ((size = restore_size((const char**)str, 1)) < 0) {
-    return 0;
+    // A malformed / too-deeply-nested mapping must be reported as an error like
+    // restore_array/restore_class do; returning 0 here signalled "success" yet
+    // left the caller's svalue uninitialized.
+    return ROB_MAPPING_ERROR;
   }
 
   if (!size) {
@@ -830,6 +854,7 @@ static int restore_mapping(char** str, svalue_t* sv) {
         free_mapping(m);
         free_svalue(&key, "restore_mapping: out of memory");
         free_svalue(&value, "restore_mapping: out of memory");
+        reset_restore_scratch();  // error() below skips restore_svalue's cleanup
         error("Out of memory\n");
       }
     }
@@ -839,6 +864,7 @@ static int restore_mapping(char** str, svalue_t* sv) {
       free_mapping(m);
       free_svalue(&key, "restore_mapping: mapping too large");
       free_svalue(&value, "restore_mapping: mapping too large");
+      reset_restore_scratch();  // mapping_too_large() error()s past the cleanup
       mapping_too_large();
     }
 

--- a/src/vm/internal/simulate.cc
+++ b/src/vm/internal/simulate.cc
@@ -880,9 +880,14 @@ int recompile_object(object_t* target) {
     _setmode(f, _O_BINARY);
 #endif
     save_command_giver(command_giver);
-    new_prog = compile_file_fd(f, obname.c_str());
+    {
+      // compile_file_fd may error() and unwind past this frame; guard the fd
+      // exactly as load_object() does, or a failed recompile leaks it (and
+      // this loop can open a fresh fd each round).
+      DEFER { close(f); };
+      new_prog = compile_file_fd(f, obname.c_str());
+    }
     restore_command_giver();
-    close(f);
     update_compile_av(total_lines);
     total_lines = 0;
 

--- a/src/vm/internal/trace.cc
+++ b/src/vm/internal/trace.cc
@@ -43,7 +43,9 @@ void dump_trace_line(const char* fname, const char* pname, const char* const obn
   p = strput(p, end, "() at ");
   p = strput(p, end, where);
   p = strput(p, end, "\n");
-  debug_message(line);
+  // line embeds object/program filenames and function names, which can
+  // contain '%'; never use it as the printf format.
+  debug_message("%s", line);
 }
 
 }  // namespace

--- a/testsuite/clone/bad_macro_params.lpc
+++ b/testsuite/clone/bad_macro_params.lpc
@@ -1,0 +1,2 @@
+#define F(@) x
+int probe() { return 1; }

--- a/testsuite/clone/reclaim_fp_helper.lpc
+++ b/testsuite/clone/reclaim_fp_helper.lpc
@@ -1,2 +1,4 @@
 // Helper for single/tests/crasher/reclaim_funptr_owner.lpc
-function make_fp() { return function() { return 42; }; }
+// Returns an FP_LOCAL funptr owned by this clone.
+int target() { return 42; }
+function make_fp() { return (: target :); }

--- a/testsuite/clone/reclaim_fp_helper.lpc
+++ b/testsuite/clone/reclaim_fp_helper.lpc
@@ -1,0 +1,2 @@
+// Helper for single/tests/crasher/reclaim_funptr_owner.lpc
+function make_fp() { return function() { return 42; }; }

--- a/testsuite/single/tests/compiler/bad_macro_params.lpc
+++ b/testsuite/single/tests/compiler/bad_macro_params.lpc
@@ -1,0 +1,7 @@
+// A malformed function-like macro parameter list (a stray non-identifier in
+// the parameters) used to spin the preprocessor's parameter loop forever,
+// hanging the compiler. It must now report a compile error instead.
+void do_tests() {
+    string err = catch(load_object("/clone/bad_macro_params"));
+    ASSERT_NE(0, err);
+}

--- a/testsuite/single/tests/compiler/long_local_name.lpc
+++ b/testsuite/single/tests/compiler/long_local_name.lpc
@@ -1,0 +1,29 @@
+// Regression: a local variable name longer than the compiler's internal
+// 4096-byte name-block used to overflow the heap in alloc_local_name()
+// (it always allocated fixed 4096-byte blocks and copied the whole name in).
+// Compiling such a name must now succeed without corrupting the heap; under
+// ASan the old code aborted here.
+void do_tests() {
+    string longname = "";
+    string src;
+    object ob;
+    int i;
+
+    for (i = 0; i < 5000; i++) {
+        longname += "a";
+    }
+
+    src = "int test_var;\nint f() { int " + longname + "; " + longname + " = 7; return " +
+          longname + "; }\n";
+
+    rm("/gen_long_local.c");
+    write_file("/gen_long_local.c", src);
+
+    ob = load_object("/gen_long_local");
+    ASSERT2(objectp(ob), "object with a 5000-char local name should compile");
+    if (objectp(ob)) {
+        ASSERT_EQ(7, ob->f());
+        destruct(ob);
+    }
+    rm("/gen_long_local.c");
+}

--- a/testsuite/single/tests/crasher/living_parse_nonobject.lpc
+++ b/testsuite/single/tests/crasher/living_parse_nonobject.lpc
@@ -1,0 +1,15 @@
+// living_parse() (parse_command %l) dereferenced obarr elements as objects
+// without checking their type. A non-object in the oblist (a caller-supplied
+// 0, or a destructed object turned into 0) caused a NULL/wild deref. It must
+// skip non-objects instead.
+
+void do_tests() {
+#ifdef __PACKAGE_OPS__
+    object target;
+
+    // oblist contains a non-object (0); must not crash.
+    ASSERT_EQ(0, catch(parse_command("get all", ({ 0 }), "'get' %l", target)));
+    ASSERT_EQ(0, catch(parse_command("get all", ({ 0, this_object() }), "'get' %l", target)));
+#endif
+    ASSERT(1);
+}

--- a/testsuite/single/tests/crasher/parser_handler_destruct.lpc
+++ b/testsuite/single/tests/crasher/parser_handler_destruct.lpc
@@ -1,0 +1,39 @@
+// A verb handler that destructs itself from its direct_* apply while
+// returning success left we_are_finished() with best_match set but
+// best_result->ob == NULL, so f_parse_sentence -> do_the_call() dereferenced
+// NULL. Must not crash.
+//
+// The clone registers its OWN verb rule (so it IS parse_vn->handler) and is
+// the object matched by the sentence, so its direct_ apply destructs the
+// handler at the swap point.
+
+string* parse_command_id_list() {
+  return ({ "bag" });
+}
+
+void create() {
+  parse_init();
+  if (clonep()) {
+    parse_add_rule("look", "WRD OBJ");   // handler == this clone
+    move_object(__FILE__);
+  }
+}
+
+int can_look_wrd_obj() { return 1; }
+
+int direct_look_wrd_obj() {
+  destruct(this_object());   // destruct the handler, then report success
+  return 1;
+}
+
+int do_look_wrd_obj() { return 0; }
+
+void do_tests() {
+#ifndef __PACKAGE_PARSER__
+  write("no package parser, skipped.\n");
+#else
+  clone_object(__FILE__);
+  catch(parse_sentence("look in bag", 2, all_inventory()));
+#endif
+  ASSERT(1);
+}

--- a/testsuite/single/tests/crasher/reclaim_funptr_owner.lpc
+++ b/testsuite/single/tests/crasher/reclaim_funptr_owner.lpc
@@ -1,0 +1,20 @@
+// reclaim_call_outs() dereferenced a funptr call_out's hdr.owner without a
+// null check. reclaim_objects() nulls the owner of a funptr whose owning
+// object was destructed; a call_out scheduled with that funptr then crashed
+// the next reclaim. Must not crash.
+function saved_fp;
+
+void do_tests() {
+    object helper = clone_object("/clone/reclaim_fp_helper");
+    saved_fp = helper->make_fp();      // funptr owned by helper
+    ASSERT(functionp(saved_fp));
+
+    destruct(helper);
+    reclaim_objects();                 // nulls saved_fp->hdr.owner
+
+    call_out(saved_fp, 1);             // schedule with orphaned funptr
+    reclaim_objects();                 // walks the callout; must not deref null
+
+    saved_fp = 0;
+    ASSERT(1);
+}

--- a/testsuite/single/tests/crasher/replaceable_empty.lpc
+++ b/testsuite/single/tests/crasher/replaceable_empty.lpc
@@ -1,0 +1,14 @@
+// replaceable(ob, ({})) with an empty ignore array left the ignore table
+// pointer NULL before the unconditional ignore[0]/ignore[1] writes -> crash.
+
+int my_dummy() { return 1; }
+
+void do_tests() {
+#ifdef __PACKAGE_CONTRIB__
+    // Empty ignore array must not crash; create/__INIT are always ignored so
+    // an object with only create()/a plain function is still replaceable.
+    ASSERT_EQ(0, catch(replaceable(this_object(), ({}))));
+    ASSERT_EQ(0, catch(replaceable(this_object(), ({ "my_dummy" }))));
+#endif
+    ASSERT(1);
+}

--- a/testsuite/single/tests/crasher/socket_long_host.lpc
+++ b/testsuite/single/tests/crasher/socket_long_host.lpc
@@ -1,0 +1,21 @@
+#ifdef __PACKAGE_SOCKETS__
+#include <socket.h>
+#include <socket_err.h>
+void rcb(int fd) { }
+void wcb(int fd) { }
+#endif
+
+void do_tests() {
+#ifdef __PACKAGE_SOCKETS__
+    // A host portion longer than NI_MAXHOST used to be memcpy'd into a fixed
+    // stack buffer in lpcaddr_to_sockaddr, overflowing it. It must be rejected
+    // cleanly instead of crashing.
+    int fd = socket_create(STREAM, "rcb", "wcb");
+    if (fd >= 0) {
+        string longhost = sprintf("%'a'2000s", "") + " 80";
+        ASSERT(socket_connect(fd, longhost, "rcb", "wcb") < 0);
+        socket_close(fd);
+    }
+#endif
+    ASSERT(1);
+}

--- a/testsuite/single/tests/crasher/terminal_colour_error_replace.lpc
+++ b/testsuite/single/tests/crasher/terminal_colour_error_replace.lpc
@@ -1,0 +1,17 @@
+// terminal_colour() leaked its parts/lens/savestr buffers if the
+// terminal_colour_replace apply error()ed (longjmp past the frees). The efun
+// now uses safe_apply, so an erroring replace is caught and treated as no
+// replacement -- no leak (the per-file leak gate would catch a regression).
+
+string terminal_colour_replace(string s) {
+    error("boom from terminal_colour_replace");
+}
+
+void do_tests() {
+#ifdef __PACKAGE_CONTRIB__
+    mapping codes = ([ "RED" : "<r>", "RESET" : "<0>" ]);
+    // The replace apply errors on every part; must not leak or propagate.
+    ASSERT_EQ(0, catch(terminal_colour("%^RED%^hello world%^RESET%^", codes)));
+#endif
+    ASSERT(1);
+}

--- a/testsuite/single/tests/efuns/allocate.lpc
+++ b/testsuite/single/tests/efuns/allocate.lpc
@@ -5,4 +5,14 @@ void do_tests() {
     }
     ASSERT(allocate(0) == ({}));
     ASSERT(catch(allocate(-10)));
+
+    // allocate(n, function) applies the function per element.
+    ASSERT_EQ(({ 0, 1, 2, 3 }), allocate(4, (: $1 :)));
+
+    // If the per-element function errors mid-loop, the partially built array
+    // must not leak (checkmemory / the per-file leak gate catches it).
+    ASSERT(catch(allocate(5, function(int i) {
+        if (i == 2) error("boom");
+        return i;
+    })));
 }

--- a/testsuite/single/tests/efuns/pcre_replace.lpc
+++ b/testsuite/single/tests/efuns/pcre_replace.lpc
@@ -5,5 +5,17 @@ void do_tests() {
     ASSERT_EQ("X1-Y2-", pcre_replace("a1-b2-", "([a-z])[0-9]-([a-z])[0-9]-", ({ "X", "Y" })));
     // Group count and replacement count must agree.
     ASSERT(catch(pcre_replace("a1", "[a-z][0-9]", ({ "X", "Y" }))));
+
+    // Nested capture groups: the size pass and copy pass used divergent group
+    // selection, overrunning the output buffer. Only the non-nested (outer)
+    // group is selected, matching the allocation.
+    ASSERT_EQ("X", pcre_replace("a", "((a))", ({ "X", "YYYY" })));
+    ASSERT_EQ("Xc", pcre_replace("abc", "((ab))", ({ "X", "Y" })));
+
+    // A replacement much longer than its match must not overflow.
+    ASSERT_EQ("[LONGREPLACEMENT]", pcre_replace("[x]", "(x)", ({ "LONGREPLACEMENT" })));
+
+    // Text outside groups is preserved around a single group.
+    ASSERT_EQ("aXc", pcre_replace("abc", "(b)", ({ "X" })));
 }
 #endif

--- a/testsuite/single/tests/efuns/restore_variable.lpc
+++ b/testsuite/single/tests/efuns/restore_variable.lpc
@@ -40,4 +40,20 @@ void do_tests() {
 	IS("([1:" + x + ",])", ([1:y ]));
 	IS("([" + x + ":" + x + ",])", ([ y: y ]));
     }
+
+    // Deeply-nested crafted input must be rejected, not overflow the C stack.
+    // The restore sizing pass caps recursion at the same depth the save side
+    // does, so an attacker-supplied string far deeper than that errors cleanly.
+    {
+	string deep_arr = "0";
+	string deep_map = "0";
+	for (i = 0; i < 400; i++) {
+	    deep_arr = "({" + deep_arr + ",})";
+	    deep_map = "([0:" + deep_map + ",])";
+	}
+	ASSERT2(catch(restore_variable(deep_arr)),
+		"Deeply-nested array should be rejected, not crash");
+	ASSERT2(catch(restore_variable(deep_map)),
+		"Deeply-nested mapping should be rejected, not crash");
+    }
 }

--- a/testsuite/single/tests/efuns/sprintf.lpc
+++ b/testsuite/single/tests/efuns/sprintf.lpc
@@ -317,4 +317,13 @@ TEXT;
     ASSERT_EQ("123", sprintf("%d", 123.0));
     ASSERT_EQ("123", sprintf("%d", 123.123)); // truncates
     ASSERT_EQ("123.000000", sprintf("%f", 123));
+
+    // Huge user-controlled precision must not overflow the internal print
+    // buffer (it is clamped/truncated, not written past the end). Before the
+    // fix these overran a fixed static buffer. We only assert they run and
+    // produce a plausibly-long string without crashing.
+    ASSERT(strlen(sprintf("%.1077f", 0.0)) > 1000);
+    ASSERT(strlen(sprintf("%.2000f", 1.0e300)) > 1000);
+    ASSERT(strlen(sprintf("%.5000f", -1.0)) > 1000);
+    ASSERT(strlen(sprintf("%.5000d", -1)) > 0);
 }

--- a/testsuite/single/tests/efuns/sprintf_column_object.lpc
+++ b/testsuite/single/tests/efuns/sprintf_column_object.lpc
@@ -1,0 +1,26 @@
+// Column/table sprintf on a %O (or other rendered) argument used to borrow
+// the transient sprintf_state.clean buffer, which is freed each iteration --
+// a use-after-free when the column stays pending across iterations. The cst
+// now owns a copy. Exercise column and table modes with rendered arguments.
+
+void do_tests() {
+    string r;
+
+    // Column mode with an array %O: the rendered string is long enough to
+    // wrap across several column emissions.
+    r = sprintf("%-=20O", ({ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 }));
+    ASSERT(stringp(r));
+    ASSERT(strlen(r) > 0);
+
+    // Table mode with a rendered argument.
+    r = sprintf("%-=40O", ({ "alpha", "beta", "gamma", "delta", "epsilon" }));
+    ASSERT(stringp(r));
+
+    // Two column specs from %O in one format: the first column must survive
+    // while the second %O reuses the clean buffer.
+    r = sprintf("%-=15O%-=15O", ({ 1, 2, 3, 4, 5 }), ({ 6, 7, 8, 9, 10 }));
+    ASSERT(stringp(r));
+
+    // Plain-string column still works.
+    ASSERT(stringp(sprintf("%-=10s", "a fairly long string that wraps")));
+}

--- a/testsuite/single/tests/efuns/strsrch_reverse_egc.lpc
+++ b/testsuite/single/tests/efuns/strsrch_reverse_egc.lpc
@@ -1,0 +1,23 @@
+// Reverse strsrch (from-end) with a multi-char needle whose only occurrence
+// is at offset 0 but is not grapheme-aligned (a combining mark follows). The
+// reverse scan used to decrement pos below 0 to npos and re-find offset 0
+// forever, hanging the driver. Must terminate and report no match.
+
+void do_tests() {
+    // haystack = "ab" + U+0301 (combining acute, attaches to b) + "c".
+    // Clusters: "a"(0), "b\u0301"(1..3), "c"(4). Needle "ab" ends at offset 2,
+    // which is mid-cluster, so no grapheme-aligned match exists.
+    string haystack = "ab́c";
+
+    // Reverse search: must return -1 (no boundary-aligned match), not hang.
+    // This is the regression: the reverse scan used to decrement pos below 0
+    // to npos and re-find offset 0 forever.
+    ASSERT_EQ(-1, strsrch(haystack, "ab", -1));
+
+    // A genuine boundary-aligned reverse match still works (last occurrence).
+    ASSERT_EQ(0, strsrch("abc", "a", -1));
+    ASSERT_EQ(5, strsrch("abcabc", "c", -1));
+    ASSERT_EQ(3, strsrch("abcabc", "ab", -1));
+    // A reverse multi-char needle that never matches terminates with -1.
+    ASSERT_EQ(-1, strsrch("abcabc", "xy", -1));
+}

--- a/testsuite/single/tests/efuns/sys_reload_tls.lpc
+++ b/testsuite/single/tests/efuns/sys_reload_tls.lpc
@@ -10,6 +10,13 @@ void do_tests_real() {
 
   // valid tls
   ASSERT_EQ(0, sys_reload_tls(4));
+
+  // Regression: the index bound used sizeof(external_port) (the array's size in
+  // BYTES) instead of its element count (5), letting indices in the gap slip
+  // through to an out-of-bounds read and a wild tls_server_close()/->ssl write.
+  // Index 8 lands in that old gap; it and a negative index must error cleanly.
+  ASSERT_NE(0, catch(sys_reload_tls(8)));
+  ASSERT_NE(0, catch(sys_reload_tls(-1)));
 }
 void after_boot() {
   mixed err;

--- a/testsuite/single/tests/efuns/write_buffer_bounds.lpc
+++ b/testsuite/single/tests/efuns/write_buffer_bounds.lpc
@@ -1,0 +1,22 @@
+// write_buffer() computed (start + theLength) in signed int; a huge start
+// overflowed past the bounds check and drove an out-of-bounds memcpy. It must
+// reject out-of-range positions and only write in-bounds.
+
+void do_tests() {
+    buffer b = allocate_buffer(4);
+
+    // Valid write.
+    ASSERT_EQ(1, write_buffer(b, 0, "abcd"));
+    ASSERT_EQ("abcd", read_buffer(b, 0, 4));
+
+    // Huge positive start must be rejected (no signed overflow past the check).
+    ASSERT_EQ(0, write_buffer(b, 2147483647, "xy"));
+    // Start past the end.
+    ASSERT_EQ(0, write_buffer(b, 4, "z"));
+    ASSERT_EQ(0, write_buffer(b, 3, "zz"));   // would run one past
+    // Huge negative start (start = size + start stays negative).
+    ASSERT_EQ(0, write_buffer(b, -2147483647, "z"));
+
+    // Buffer contents unchanged by the rejected writes.
+    ASSERT_EQ("abcd", read_buffer(b, 0, 4));
+}

--- a/testsuite/single/tests/operators/buffer_range_assign.lpc
+++ b/testsuite/single/tests/operators/buffer_range_assign.lpc
@@ -1,0 +1,45 @@
+// Buffer range assignment with a size-changing rhs took the reallocation
+// branch of assign_lvalue_range/copy_lvalue_range, which copied from the
+// buffer_t header (ref/size fields) instead of its payload (->item),
+// corrupting the assigned bytes. Regression pin for that fix.
+
+void do_tests() {
+    buffer a, b;
+
+    // Grow: replace a 1-byte range with a 3-byte buffer (reallocation branch).
+    a = allocate_buffer(4);
+    a[0] = 'a'; a[1] = 'b'; a[2] = 'c'; a[3] = 'd';
+    b = allocate_buffer(3);
+    b[0] = 'X'; b[1] = 'Y'; b[2] = 'Z';
+
+    a[1..1] = b;
+    // a is now { 'a', 'X', 'Y', 'Z', 'c', 'd' }
+    ASSERT_EQ(6, sizeof(a));
+    ASSERT_EQ('a', a[0]);
+    ASSERT_EQ('X', a[1]);
+    ASSERT_EQ('Y', a[2]);
+    ASSERT_EQ('Z', a[3]);
+    ASSERT_EQ('c', a[4]);
+    ASSERT_EQ('d', a[5]);
+
+    // Shrink: replace a 3-byte range with a 1-byte buffer.
+    a = allocate_buffer(4);
+    a[0] = 'a'; a[1] = 'b'; a[2] = 'c'; a[3] = 'd';
+    b = allocate_buffer(1);
+    b[0] = 'Q';
+
+    a[1..3] = b;
+    // a is now { 'a', 'Q' }
+    ASSERT_EQ(2, sizeof(a));
+    ASSERT_EQ('a', a[0]);
+    ASSERT_EQ('Q', a[1]);
+
+    // Equal-size fast path (unchanged) still works.
+    a = allocate_buffer(3);
+    a[0] = 1; a[1] = 2; a[2] = 3;
+    b = allocate_buffer(1);
+    b[0] = 9;
+    a[1..1] = b;
+    ASSERT_EQ(3, sizeof(a));
+    ASSERT_EQ(9, a[1]);
+}


### PR DESCRIPTION
Four rounds of a subsystem-by-subsystem audit of the driver. Each finding was verified against the code and reproduced or reasoned through; most ship with a regression test that fails (crash / ASan / wrong output / leak) on the unfixed binary. Validated on Debug + ASan/UBSan (randomized suite passes) and RelWithDebInfo, 312/312 GTest units on both.

## Round 1 — core subsystems (13 fixes)

- **vm/interpret**: buffer range assignment copied from the `buffer_t` header instead of `-&gt;item` (corruption).
- **vm/simulate**: `recompile_object` leaked the source fd when the compile error()'d.
- **parser**: a verb handler that destructs itself mid-parse freed the verb node the parse still held (`parse_vn` UAF) and left a NULL `best_result-&gt;ob` (NULL deref).
- **files**: `read_file` wrote the terminator one byte past its buffer.
- **vm/array**: `allocate(n, fn)` leaked the array if the initializer error()'d.
- **sprintf**: huge user precision overran a static buffer (`%.1077f`).
- **strutils**: reverse `strsrch`/EGC search infinite-looped with no grapheme-aligned match.
- **telnet**: ZMP argument array off-by-one overflow (+ uninitialized element 0).
- **call_out**: `reclaim_call_outs` dereferenced a null funptr owner.
- **contrib**: `query_replaced_program()` read a bogus stack slot as an object.
- **sockets**: `socket_accept` set close-on-exec on the listener index, not the accepted fd.
- **reclaim**: double-decremented `func_ref` for FP_LOCAL funptrs (program leak).

## Round 2 — previously-uncovered areas + cross-cutting hunts (20 fixes)

**Memory corruption / OOB writes**
- **ed**: four static-buffer overflows in the line editor (`getfn`, `getrhs`, `optpat`, `prntln`).
- **vm/buffer**: `write_buffer` signed-overflow in `start + theLength` bypassed the bounds check.
- **dwlib**: `replace_dollars` bounds-checked the pattern length but copied the (longer) replacement.
- **sockets**: `lpcaddr_to_sockaddr` memcpy'd an unbounded LPC host string into a fixed `NI_MAXHOST` buffer.
- **pcre**: `pcre_replace` sized and copied with divergent group-selection logic → heap overflow.

**Crashes (NULL / wild-pointer / OOB read / hang / UAF)**
- **ops/parse**: `living_parse` (parse_command `%l`) dereferenced non-object oblist entries.
- **contrib**: `replaceable(ob, ({}))` dereferenced a NULL table.
- **vm/apply**: call-other type check over-read `argument_types`; built `error()` formats from object paths.
- **lexer**: a malformed function-like `#define` parameter list spun forever, hanging the compiler.
- **sprintf**: column/table mode on a `%O` argument borrowed the transient `clean` buffer → UAF.
- **port**: `random_number`/`secure_random_number(0)` → `uniform_int_distribution(0,-1)` UB.
- **stralloc**: an absurd configured hash-table size overflowed the power-of-two round-up loop → boot hang.

**Leaks**
- **sprintf**: `pop_sprintf_state` leaked a pending cst's pad on error unwind.
- **compress**: `uncompress` leaked `output_data` on the inflate-error path.
- **contrib**: `terminal_colour` leaked `parts`/`lens`/`savestr` if the replace apply error()'d.

**Minor / debug-only**
- **disassembler**: switch-table `minval` walked with a hardcoded 4 instead of `sizeof(LPC_INT)`.

## Round 3 — deeper pass, two-lens verification (18 fixes)

- **vm/object (restore)**: no recursion cap in the restore size pre-pass (crafted deep-nested string → C stack overflow); `restore_mapping` returned success on a size failure (uninitialized svalue); OOM/too-large `error()` paths leaked `sizes` and corrupted the next restore.
- **ffi**: `ffi_read`/`ffi_write` checked `offset` as `int`, truncating/wrapping past the check into an OOB memcpy.
- **contrib**: `repeat_string` `len*repeat` overflow → undersized alloc + heap overflow.
- **core**: `replace_string` untracked skip-table fast-path copy; `add_action` unbounded verb sprintf; `get_dir` unbounded path copy; `call_out` seconds*1000 int64 overflow.
- **matrix**: `translate`/`scale`/`rotate_*`/`lookat_*` indexed `[0..15]` with no size check.
- **mudlib_stats**: unbounded author/domain copies and restore sprintf/fscanf.
- **vm/compiler**: `INT_MIN / -1` and `INT_MIN % -1` (UB / SIGFPE) guarded at all six sites.
- **comm**: `input_to()` to a `#`-prefixed apply left an uninitialized svalue on the VM stack + leaked the sentence.
- **net**: `get_user_data` could pass a negative read size from a malicious MUD length prefix.
- **vm/mapping**: `compose_mapping` leaked deleted entries' keys.
- **reclaim / trace / compiler**: recursion-counter balance; two more tainted-format-string sites.

## Round 4 — audit of the remaining uncovered subsystems (10 fixes)

Fanned out over the subsystems rounds 1–3 hadn't touched (crypto, sha1, db, math, trim, uids, develop, async, jsbridge, net websocket/dns, remaining vm/core/compiler files).

**The flaky CI failure ("Bad ref count for object ..." on gcc Debug) is fixed here.**
- **async (CI flake)**: `async_mark_request()` tracked in-flight requests through a single `current_work` pointer, but `do_stuff()` spawns a fresh worker thread whenever `reqs` is momentarily empty while an earlier worker is still in a slow `w->func()`. With 2+ concurrent workers each overwriting `current_work`, the debug memory checker under-counted the others' refs → the intermittent "Bad ref count". Now tracks all in-flight works in a set.
- **async**: `getdirthread` grew its buffer by `sizeof(dirent*)` (~8 bytes) per entry but wrote a whole ~280-byte `struct dirent` → heap overflow past ~54 directory entries.
- **async**: `add_read`/`add_write`/`add_getdir` leaked the ref-bumped callback funptr when the path was denied.
- **compiler/lexer**: `alloc_local_name` overran its fixed 4096-byte block for a local name longer than 4096 chars (compile-time, attacker-supplied source). *(regression test)*
- **core/sys**: `sys_reload_tls` bounded the port index with `sizeof(external_port)` (bytes) instead of the 5-element count → OOB read + wild write. *(regression test)*
- **net/telnet**: LINEMODE subnegotiation read `buf[1]` with only `buf[0]` guaranteed → OOB read reflected to a remote client.
- **db (MySQL)**: BLOB fetch sized/copied with the column-wide `max_length` instead of the row's actual `mysql_fetch_lengths()` → heap over-read / info leak.
- **core/time**: `f_strftime` used a stack VLA of `__MAX_STRING_LENGTH__` (1MB default) → stack-overflow risk; now heap.
- **develop/checkmemory**: unbounded strcpy of `__DEFAULT_FAIL_MESSAGE__` into a fixed buffer (debug build).
- **math/norm**: took the loop length from `sp` but indexed a different parameter array.

## Validation

- Debug + ASan/UBSan (clang): full LPC testsuite passed (randomized order, plus a 20× async stress loop with zero ref-count anomalies), 312/312 GTest units. New/updated tests confirmed to fail on the unfixed binary.
- RelWithDebInfo (clang): full LPC testsuite passed, 312/312 GTest units.
- Rebased onto current master and re-validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lv2Gw2AWqtyN3nNEgob1He