### PR TITLE
docs: document call_out handle validity and mid-compile valid_read be…

### DIFF
--- a/docs/apply/master/valid_read.md
+++ b/docs/apply/master/valid_read.md
@@ -13,13 +13,22 @@ title: master / valid_read
 
 ### DESCRIPTION
 
-    Every time a user tries to read a file, thie driver calls valid_read in
+    Every time a user tries to read a file, the driver calls valid_read in
     the master object to check if the read should be  allowed.   The  argu‐
     ments are the filename, the name of the person making the read, and the
     calling function name.  If valid_read returns  non-zero,  the  read  is
     allowed.
 
+    This apply is also consulted in the middle of compiling an object: each
+    #include directive checks the header path with valid_read (with <func>
+    set to "include") before opening it. Returning 0 denies the include and
+    fails that compile. Because the apply runs mid-compile, it must not
+    trigger another compile itself (e.g. by loading an object). A runtime
+    error thrown from valid_read (or anywhere else while a file is being
+    compiled) aborts that compilation cleanly; the driver fully unwinds its
+    compiler state and remains able to load other objects afterwards.
+
 ### SEE ALSO
 
-    valid_write(4)
+    valid_write(4), include_file(4), inherit_program(4)
 

--- a/docs/efun/calls/call_out.md
+++ b/docs/efun/calls/call_out.md
@@ -41,7 +41,10 @@ title: calls / call_out
     above problem.
 
     The return value is an integer representing the handle of the call_out
-    which may be used as an argument to remove_call_out().
+    which may be used as an argument to remove_call_out() or
+    find_call_out(). The handle remains valid until the call_out fires or
+    is removed, regardless of how many newer call_outs are scheduled after
+    it. Handles are always positive; 0 is never a valid handle.
 
 ### SEE ALSO
 

--- a/docs/efun/calls/remove_call_out.md
+++ b/docs/efun/calls/remove_call_out.md
@@ -26,6 +26,11 @@ title: calls / remove_call_out
     called,  or -1  if  there  was  no  valid  call_out  identified  by the
     specified <handle>.
 
+    A handle stays valid until its call out fires or is removed, no matter
+    how many newer call outs have been scheduled since it was created. A
+    <handle> of 0 (typically an uninitialized variable) or a handle that
+    does not identify a pending call out returns -1.
+
     In the third form all pending call outs for the current object will be
     removed. In this case the return value is always 0.
 


### PR DESCRIPTION
…havior

Follow-up to reviewing PRs #1068 and #932, both of whose bugs are already fixed on master:

- #1068 (call_out handles below the allocation counter rejected as invalid) was fixed by #1220 with a regression test in testsuite/single/tests/efuns/remove_call_out.lpc. Document the guaranteed semantics in call_out.md / remove_call_out.md: a handle stays valid until it fires or is removed, regardless of newer call_outs; 0 is never a valid handle.

- #932 (an error thrown from valid_read during #include handling left compile_file's reentrancy guard set, wedging all future loads) is fixed by the compiler front-end rewrite: compile_file's scope guard restores all compiler state and clears the guard on exception unwinding. Document in valid_read.md that the apply runs mid-compile for #include checks, must not trigger another compile, and that a thrown error aborts only that compilation.


Claude-Session: https://claude.ai/code/session_01JRvUnh3x5MYPWPk2MiiUS2