### PR TITLE
ci: monthly auto-release when master has changes since the last tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,11 @@ on:
         required: false
         type: boolean
         default: false
+  schedule:
+    # Monthly auto-release: 09:00 UTC on the 1st. Skipped automatically
+    # when master has no new commits since the latest release tag
+    # (see the check-changes job).
+    - cron: '0 9 1 * *'
 
 env:
   REGISTRY: ghcr.io
@@ -22,8 +27,51 @@ permissions:
   packages: write
 
 jobs:
+  check-changes:
+    name: Check for Changes Since Last Release
+    runs-on: ubuntu-latest
+    outputs:
+      should_release: ${{ steps.check.outputs.should_release }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check for changes
+        id: check
+        run: |
+          git fetch --tags
+
+          # Manual dispatch always releases
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "Manual dispatch: releasing"
+            echo "should_release=true" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          # Most recent release tag by creation date (tag formats have
+          # varied over the years, so date order beats version sort)
+          LAST_TAG=$(git tag -l 'v*' --sort=-creatordate | head -n 1)
+
+          if [ -z "$LAST_TAG" ]; then
+            echo "No release tag found: releasing"
+            echo "should_release=true" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          COUNT=$(git rev-list --count "$LAST_TAG"..HEAD)
+          echo "$COUNT commit(s) since $LAST_TAG"
+          if [ "$COUNT" -gt 0 ]; then
+            echo "should_release=true" >> $GITHUB_OUTPUT
+          else
+            echo "No changes since $LAST_TAG: skipping release"
+            echo "should_release=false" >> $GITHUB_OUTPUT
+          fi
+
   generate-version:
     name: Generate Version Number
+    needs: check-changes
+    if: needs.check-changes.outputs.should_release == 'true'
     runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.generate.outputs.version }}
@@ -92,7 +140,7 @@ jobs:
               tag_name: version,
               name: `FluffOS ${version}`,
               generate_release_notes: true,
-              prerelease: ${{ inputs.prerelease }},
+              prerelease: ${{ inputs.prerelease || false }},
               draft: false
             });
             core.setOutput('upload_url', release.data.upload_url);

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -132,6 +132,8 @@ FluffOS uses GitHub Actions for CI on pull requests and pushes to `master`.
   - **Flow** (native platforms): Install dependencies → CMake configure → Build → GTest unit tests → LPC testsuite.
 * **Docker CI** (`.github/workflows/docker-publish.yml`):
   - Builds a Docker image and pushes to `ghcr.io` on tagged releases and master merges.
+* **Releases** (`.github/workflows/release.yml`):
+  - Runs on a monthly schedule (09:00 UTC on the 1st) and via manual `workflow_dispatch`. A `check-changes` gate skips the scheduled run when master has no commits since the latest release tag; manual dispatch always releases. Versions are date-based (`vYYYY.MMDD.N`), release notes are auto-generated from merged PRs, and the build matrix ships Linux/Windows binaries plus `fluffos-<version>-wasm.zip`.
 
 ---
 


### PR DESCRIPTION
## Summary

- `release.yml` gains a **monthly schedule** (09:00 UTC on the 1st) alongside the existing manual `workflow_dispatch`
- A new **`check-changes` gate job** compares master against the most recent release tag (by creation date, since tag formats have varied over the years) and skips the whole release pipeline when there are no new commits; manual dispatch always releases
- The `prerelease` flag now defaults to `false` so scheduled runs don't interpolate an empty value into the `createRelease` script (which would be a JS syntax error)
- Release cadence documented in AGENTS.md §6

Versioning (`vYYYY.MMDD.N`), auto-generated release notes, and the Linux/Windows/WASM build matrix are unchanged.

## Test plan
- [x] YAML validated
- [x] Gate logic verified against the repo's tag history (`v2025.1205.0` is the latest tag by creatordate; commits exist since → would release)
- [ ] Dispatching a release after merge exercises the manual path end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Skf9CfHwAngWorDNDzPKWp

---
_Generated by [Claude Code](https://claude.ai/code/session_01Skf9CfHwAngWorDNDzPKWp)_