### PR TITLE
ci: cut a release from a pushed v* tag too

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,10 @@ on:
     # when master has no new commits since the latest release tag
     # (see the check-changes job).
     - cron: '0 9 1 * *'
+  push:
+    # Pushing a version tag also cuts a release for that tag.
+    tags:
+      - 'v*'
 
 env:
   REGISTRY: ghcr.io
@@ -42,9 +46,10 @@ jobs:
         run: |
           git fetch --tags
 
-          # Manual dispatch always releases
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            echo "Manual dispatch: releasing"
+          # Manual dispatch and tag pushes always release; only the
+          # monthly schedule is gated on changes
+          if [ "${{ github.event_name }}" != "schedule" ]; then
+            echo "${{ github.event_name }} event: releasing"
             echo "should_release=true" >> $GITHUB_OUTPUT
             exit 0
           fi
@@ -83,6 +88,13 @@ jobs:
       - name: Generate Version
         id: generate
         run: |
+          # A pushed tag IS the version
+          if [ "${{ github.event_name }}" = "push" ]; then
+            echo "Using pushed tag: ${GITHUB_REF_NAME}"
+            echo "version=${GITHUB_REF_NAME}" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
           # Get current date in YYYY.MMDD format
           DATE_VERSION=$(date -u '+%Y.%m%d')
 
@@ -121,6 +133,8 @@ jobs:
           fetch-depth: 0
 
       - name: Create Git Tag
+        # A pushed tag already exists; only scheduled/dispatched runs tag
+        if: github.event_name != 'push'
         run: |
           VERSION="${{ needs.generate-version.outputs.version }}"
           git config user.name "github-actions[bot]"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -133,7 +133,7 @@ FluffOS uses GitHub Actions for CI on pull requests and pushes to `master`.
 * **Docker CI** (`.github/workflows/docker-publish.yml`):
   - Builds a Docker image and pushes to `ghcr.io` on tagged releases and master merges.
 * **Releases** (`.github/workflows/release.yml`):
-  - Runs on a monthly schedule (09:00 UTC on the 1st) and via manual `workflow_dispatch`. A `check-changes` gate skips the scheduled run when master has no commits since the latest release tag; manual dispatch always releases. Versions are date-based (`vYYYY.MMDD.N`), release notes are auto-generated from merged PRs, and the build matrix ships Linux/Windows binaries plus `fluffos-<version>-wasm.zip`.
+  - Runs on a monthly schedule (09:00 UTC on the 1st), via manual `workflow_dispatch`, or by pushing a `v*` tag. A `check-changes` gate skips the scheduled run when master has no commits since the latest release tag; dispatch and tag pushes always release. Versions are date-based (`vYYYY.MMDD.N`, taken from the tag when one was pushed), release notes are auto-generated from merged PRs, and the build matrix ships Linux/Windows binaries plus `fluffos-<version>-wasm.zip`.
 
 ---
 


### PR DESCRIPTION
## Summary

Follow-up to #1253: pushing a `v*` tag now runs the release pipeline for exactly that tag — the version comes from the tag name, the workflow's own tag-creation step is skipped, and the changes gate treats tag pushes (like manual dispatch) as an explicit release request. Only the monthly schedule stays gated on new commits.

This gives maintainers (and tooling without `actions: write`, like this session) a way to cut a release by pushing a tag, in addition to the Actions UI dispatch and the monthly schedule.

## Test plan
- [x] YAML validated
- [ ] Exercised immediately after merge by pushing today's `v2026.0712.0` tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Skf9CfHwAngWorDNDzPKWp

---
_Generated by [Claude Code](https://claude.ai/code/session_01Skf9CfHwAngWorDNDzPKWp)_