### PR TITLE
object: fix restore of wide collections regressed by the deep-nesting guard

### DIFF
--- a/src/vm/internal/base/object.cc
+++ b/src/vm/internal/base/object.cc
@@ -252,16 +252,21 @@ void save_svalue(svalue_t* v, char** buf) {
   }
 }
 
-static int restore_internal_size(const char** str, int is_mapping, int depth) {
+static int restore_internal_size(const char** str, int is_mapping, int depth, int nest) {
   const char* cp = *str;
   int size = 0;
   char c, delim, toggle = 0;
 
-  // Bound recursion the same way the save path does (too_deep_save_error).
-  // Without this, a maliciously deep-nested save string (e.g. "({({({...")
-  // recurses until the C stack overflows. Returning 0 fails the size pre-pass
-  // so restore_size() reports an error before the actual restore recurses.
-  if (depth > MAX_SAVE_SVALUE_DEPTH) {
+  // Bound *recursion* depth the same way the save path does (too_deep_save_error),
+  // so a maliciously deep-nested save string (e.g. "({({({...") cannot recurse
+  // until the C stack overflows. This must track true nesting depth (`nest`), NOT
+  // `depth`: `depth` is save_svalue_depth, a monotonic index into sizes[] that
+  // counts every container across the whole structure in DFS order and is only
+  // reset at the outermost close. Bounding `depth` wrongly rejected valid
+  // wide-but-shallow data (e.g. a mapping of a few hundred classes) as "too deep"
+  // once the cumulative container count crossed the cap. Returning 0 fails the
+  // size pre-pass so restore_size() reports an error before the restore recurses.
+  if (nest > MAX_SAVE_SVALUE_DEPTH) {
     return 0;
   }
 
@@ -284,17 +289,17 @@ static int restore_internal_size(const char** str, int is_mapping, int depth) {
       case '(': {
         if (*cp == '{') {
           *str = ++cp;
-          if (!restore_internal_size(str, 0, save_svalue_depth++)) {
+          if (!restore_internal_size(str, 0, save_svalue_depth++, nest + 1)) {
             return 0;
           }
         } else if (*cp == '[') {
           *str = ++cp;
-          if (!restore_internal_size(str, 1, save_svalue_depth++)) {
+          if (!restore_internal_size(str, 1, save_svalue_depth++, nest + 1)) {
             return 0;
           }
         } else if (*cp == '/') {
           *str = ++cp;
-          if (!restore_internal_size(str, 0, save_svalue_depth++)) {
+          if (!restore_internal_size(str, 0, save_svalue_depth++, nest + 1)) {
             return 0;
           }
         } else {
@@ -406,17 +411,17 @@ static int restore_size(const char** str, int is_mapping) {
       case '(': {
         if (*cp == '{') {
           *str = ++cp;
-          if (!restore_internal_size(str, 0, save_svalue_depth++)) {
+          if (!restore_internal_size(str, 0, save_svalue_depth++, 1)) {
             return -1;
           }
         } else if (*cp == '[') {
           *str = ++cp;
-          if (!restore_internal_size(str, 1, save_svalue_depth++)) {
+          if (!restore_internal_size(str, 1, save_svalue_depth++, 1)) {
             return -1;
           }
         } else if (*cp == '/') {
           *str = ++cp;
-          if (!restore_internal_size(str, 0, save_svalue_depth++)) {
+          if (!restore_internal_size(str, 0, save_svalue_depth++, 1)) {
             return -1;
           }
         } else {

--- a/testsuite/single/tests/efuns/restore_variable.lpc
+++ b/testsuite/single/tests/efuns/restore_variable.lpc
@@ -56,4 +56,29 @@ void do_tests() {
 	ASSERT2(catch(restore_variable(deep_map)),
 		"Deeply-nested mapping should be rejected, not crash");
     }
+
+    // A wide-but-shallow collection must restore cleanly. The size pre-pass
+    // caches element counts in sizes[], keyed on a counter that climbs with the
+    // total container count across the whole structure -- not the nesting depth.
+    // Bounding recursion on that counter used to reject large flat collections:
+    // a mapping of a few hundred one-element arrays is only two levels deep, but
+    // its cumulative container count crossed the cap and it failed with "Illegal
+    // mapping format". Each element here is a nested container (scalars do not
+    // advance the counter), so this exercises the regression directly.
+    {
+	string wide_map = "";
+	string wide_arr = "";
+	mapping rm;
+	mixed *ra;
+	for (i = 0; i < 500; i++) {
+	    wide_map += i + ":({" + i + ",}),";
+	    wide_arr += "({" + i + ",}),";
+	}
+	rm = restore_variable("([" + wide_map + "])");
+	ASSERT_EQ(500, sizeof(rm));
+	ASSERT_EQ(7, rm[7][0]);
+	ra = restore_variable("({" + wide_arr + "})");
+	ASSERT_EQ(500, sizeof(ra));
+	ASSERT_EQ(499, ra[499][0]);
+    }
 }


### PR DESCRIPTION
### What

`restore_object()` / `restore_variable()` reject any sufficiently **wide**
saved collection with `Illegal mapping format`, even though the data is valid
and round-tripped cleanly out of `save_object()`.

### Repro

```lpc
// a mapping of ~30+ one-element arrays -- only two levels deep -- fails:
string s = "([";
for (int i = 0; i < 40; i++) s += i + ":({" + i + ",}),";
s += "])";
restore_variable(s);   // error: Illegal mapping format
```

Real-world trigger: a coordinate daemon persisting 2000+ rooms as a mapping of
small classes (`{string short, string* exits, string* done, int* coords}`).
It saves fine, then won't reload — `restore_object(): Illegal mapping format
while restoring __rooms`.

### Root cause

ac1981f6 hardened restore against deep nesting by capping recursion in the
size pre-pass, but it capped `depth` — which is `save_svalue_depth`, a
**monotonic index into `sizes[]`** bumped once per container across the whole
structure in DFS order (reset only at the outermost close). That counter
tracks *total container count*, not nesting depth, so the cap fires on width:
anything past `MAX_SAVE_SVALUE_DEPTH` containers total fails the pre-pass,
which the same commit turned into `ROB_MAPPING_ERROR`. A 2000-room mapping is
only 3 levels deep but has thousands of containers, so it trips at ~room 25.

### Fix

Thread a separate `nest` argument through `restore_internal_size()` that
tracks *true* recursion depth, and bound on that instead. `depth` keeps its
only real job: indexing `sizes[]`. The C-stack-overflow protection the guard
was added for is preserved — a genuinely deep string still fails the pre-pass
cleanly — while wide-but-shallow data restores again.

### Tests

Extends `testsuite/single/tests/efuns/restore_variable.lpc` with a wide
(500-element) mapping and array of nested containers — unrestorable before,
passing after. Full LPC suite is green (`Checks succeeded.`). The existing
deep-rejection cases still pass, confirming the guard's intent is intact.
