### PR TITLE
Fix three Coverity defects: lexer buffer overrun, dangling filename pointer, infinite loop

### DIFF
--- a/src/compiler/internal/lexer_utils.cc
+++ b/src/compiler/internal/lexer_utils.cc
@@ -1407,7 +1407,18 @@ typedef struct lname_linked_buf_s {
   char block[4096];
 } lname_linked_buf_t;
 
+// A name that cannot fit in a whole block (identifiers are only capped at
+// YYLMAX ~64KB) gets its own allocation here instead of being overlaid onto
+// lname_linked_buf_t::block -- that struct's block is a fixed 4096-byte
+// array, so writing more than 4096 bytes into it is a real overrun even
+// when the backing DMALLOC is sized larger. This header has no trailing
+// array; the name data is the `len` bytes placed immediately after it.
+typedef struct lname_big_buf_s {
+  struct lname_big_buf_s* next;
+} lname_big_buf_t;
+
 lname_linked_buf_t* lnamebuf = nullptr;
+static lname_big_buf_t* lname_big_list = nullptr;
 
 int lb_index = 4096;
 
@@ -1415,20 +1426,14 @@ static char* alloc_local_name(const char* name) {
   size_t len = strlen(name) + 1;
   char* res;
 
-  // A name that cannot fit in a whole block gets its own exactly-sized
-  // allocation, then we force the next request to start a fresh normal block.
-  // Previously the code only ever allocated fixed 4096-byte blocks and copied
-  // `len` bytes in unconditionally, so a >4096-char local variable/parameter
-  // name (identifiers are only capped at YYLMAX ~64KB) overran the heap block.
   if (len > sizeof(lnamebuf->block)) {
-    auto* new_buf = reinterpret_cast<lname_linked_buf_t*>(DMALLOC(
-        sizeof(lname_linked_buf_t) - sizeof(lnamebuf->block) + len, TAG_COMPILER,
-        "alloc_local_name"));
-    new_buf->next = lnamebuf;
-    lnamebuf = new_buf;
-    lb_index = sizeof(new_buf->block);  // next alloc must open a fresh block
-    memcpy(new_buf->block, name, len);
-    return new_buf->block;
+    auto* big = reinterpret_cast<lname_big_buf_t*>(
+        DMALLOC(sizeof(lname_big_buf_t) + len, TAG_COMPILER, "alloc_local_name"));
+    big->next = lname_big_list;
+    lname_big_list = big;
+    res = reinterpret_cast<char*>(big + 1);
+    memcpy(res, name, len);
+    return res;
   }
 
   if (lb_index + len > sizeof(lnamebuf->block)) {
@@ -1457,6 +1462,7 @@ ident_hash_elem_list_t* ihe_list = nullptr;
 void free_unused_identifiers() {
   ident_hash_elem_list_t *ihel, *next;
   lname_linked_buf_t *lnb, *lnbn;
+  lname_big_buf_t *lbb, *lbbn;
   int i;
 
   /* clean up dirty idents */
@@ -1499,6 +1505,14 @@ void free_unused_identifiers() {
   }
   lnamebuf = nullptr;
   lb_index = 4096;
+
+  lbb = lname_big_list;
+  while (lbb) {
+    lbbn = lbb->next;
+    FREE(lbb);
+    lbb = lbbn;
+  }
+  lname_big_list = nullptr;
 }
 
 static ident_hash_elem_t* quick_alloc_ident_entry() {

--- a/src/vm/internal/base/object.cc
+++ b/src/vm/internal/base/object.cc
@@ -1,6 +1,7 @@
 #include "base/std.h"
 
 #include <chrono>
+#include <climits>  // for INT_MAX
 #include <ctype.h>  // for isdigit
 #include <cstdio>   // for std::remove
 #include <math.h>   // for pow
@@ -252,6 +253,37 @@ void save_svalue(svalue_t* v, char** buf) {
   }
 }
 
+// Grow the global `sizes` scratch array (see reset_restore_scratch()) so it
+// can hold sizes[depth]. `depth` is a monotonic per-container counter over
+// the WHOLE structure being sized (see restore_internal_size()'s `depth` vs
+// `nest` comment) and, unlike `nest`, is not bounded by MAX_SAVE_SVALUE_DEPTH
+// -- a pathologically wide (not deep) save-string can drive it arbitrarily
+// high. Doubling `max_depth` without a bound would eventually overflow a
+// signed int to <= 0 and loop forever; bail out and let the caller fail the
+// size pre-pass cleanly instead.
+static bool grow_restore_sizes(int depth) {
+  if (!sizes) {
+    max_depth = 128;
+    while (max_depth <= depth) {
+      if (max_depth > INT_MAX / 2) {
+        return false;
+      }
+      max_depth <<= 1;
+    }
+    sizes = reinterpret_cast<int*>(
+        DCALLOC(max_depth, sizeof(int), TAG_TEMPORARY, "restore_internal_size"));
+  } else if (depth >= max_depth) {
+    while (max_depth <= depth) {
+      if (max_depth > INT_MAX / 2) {
+        return false;
+      }
+      max_depth <<= 1;
+    }
+    sizes = RESIZE(sizes, max_depth, int, TAG_TEMPORARY, "restore_internal_size");
+  }
+  return true;
+}
+
 static int restore_internal_size(const char** str, int is_mapping, int depth, int nest) {
   const char* cp = *str;
   int size = 0;
@@ -317,18 +349,8 @@ static int restore_internal_size(const char** str, int is_mapping, int depth, in
       case ']': {
         if (*cp++ == ')' && is_mapping) {
           *str = cp;
-          if (!sizes) {
-            max_depth = 128;
-            while (max_depth <= depth) {
-              max_depth <<= 1;
-            }
-            sizes = reinterpret_cast<int*>(
-                DCALLOC(max_depth, sizeof(int), TAG_TEMPORARY, "restore_internal_size"));
-          } else if (depth >= max_depth) {
-            while ((max_depth <<= 1) <= depth) {
-              ;
-            }
-            sizes = RESIZE(sizes, max_depth, int, TAG_TEMPORARY, "restore_internal_size");
+          if (!grow_restore_sizes(depth)) {
+            return 0;
           }
           sizes[depth] = size;
           return 1;
@@ -341,18 +363,8 @@ static int restore_internal_size(const char** str, int is_mapping, int depth, in
       case '}': {
         if (*cp++ == ')' && !is_mapping) {
           *str = cp;
-          if (!sizes) {
-            max_depth = 128;
-            while (max_depth <= depth) {
-              max_depth <<= 1;
-            }
-            sizes = reinterpret_cast<int*>(
-                DCALLOC(max_depth, sizeof(int), TAG_TEMPORARY, "restore_internal_size"));
-          } else if (depth >= max_depth) {
-            while ((max_depth <<= 1) <= depth) {
-              ;
-            }
-            sizes = RESIZE(sizes, max_depth, int, TAG_TEMPORARY, "restore_internal_size");
+          if (!grow_restore_sizes(depth)) {
+            return 0;
           }
           sizes[depth] = size;
           return 1;

--- a/src/vm/internal/simulate.cc
+++ b/src/vm/internal/simulate.cc
@@ -885,7 +885,12 @@ int recompile_object(object_t* target) {
       // exactly as load_object() does, or a failed recompile leaks it (and
       // this loop can open a fresh fd each round).
       DEFER { close(f); };
-      new_prog = compile_file_fd(f, obname.c_str());
+      // Pass old_prog's own (ref-counted, stable for this whole call)
+      // filename rather than obname.c_str() -- the compiler stashes the
+      // pointer it's given in g_compile.filename for the duration of the
+      // compile, so it must not be the address of a local std::string's
+      // internal buffer.
+      new_prog = compile_file_fd(f, old_prog->filename);
     }
     restore_command_giver();
     update_compile_av(total_lines);


### PR DESCRIPTION
- lexer_utils.cc (CID 1663877, OVERRUN): alloc_local_name() overlaid
  oversized (>4096 byte) local-variable names onto lname_linked_buf_t's
  fixed 4096-byte block array. The backing allocation was sized correctly,
  but writing past the array's declared bound is a real overrun. Give
  oversized names their own header-only allocation (lname_big_buf_t) with
  no trailing fixed-size array, tracked and freed via a separate list.

- simulate.cc (CID 1663876, WRAPPER_ESCAPE): recompile_object() passed
  obname.c_str() into compile_file_fd(), which stashes the pointer in
  g_compile.filename for the duration of the compile. Pass old_prog's own
  ref-counted filename instead, which is guaranteed to outlive the call
  and isn't the internal buffer of a local std::string.

- object.cc (CID 1663878, INFINITE_LOOP): restore_internal_size()'s sizes[]
  growth loop doubled max_depth with no overflow guard. `depth` counts
  every container across the whole structure (unlike `nest`, it is not
  bounded by MAX_SAVE_SVALUE_DEPTH), so a wide-enough save-string can drive
  it high enough that doubling overflows max_depth to <= 0, at which point
  the loop never terminates. Factored the duplicated growth logic into
  grow_restore_sizes() and bail out cleanly (fail the size pre-pass) instead
  of overflowing.

Validated with a full RelWithDebInfo build and a Debug+ASan/UBSan build
running the LPC testsuite (including the debug ref-count checker) twice.