### PR TITLE
build: stop autogen churn — pin generator versions, gate copy-back on input hash

### DIFF
--- a/cmake/util.cmake
+++ b/cmake/util.cmake
@@ -1,4 +1,4 @@
-function(process_bison_file FILE_IN FILE_OUT REPO_ROOT ACTION BUILD_ROOT)
+function(process_bison_file FILE_IN FILE_OUT REPO_ROOT ACTION BUILD_ROOT SRC_FILE)
   if (NOT EXISTS "${FILE_IN}")
     message(WARNING "File does not exist: ${FILE_IN}")
     return()
@@ -26,6 +26,20 @@ function(process_bison_file FILE_IN FILE_OUT REPO_ROOT ACTION BUILD_ROOT)
   file(READ "${FILE_IN}" CONTENT)
 
   if (ACTION STREQUAL "NORMALIZE")
+    # When the generator input (.y/.l) is known, gate the copy-back on it:
+    # if the committed file already records the same input hash, the
+    # committed file is up to date with respect to the grammar/lexer
+    # SOURCE, and regeneration differences (bison/flex build variations
+    # between hosts that report the same version) must NOT churn it.
+    if (SRC_FILE AND EXISTS "${SRC_FILE}" AND EXISTS "${FILE_OUT}")
+      file(SHA256 "${SRC_FILE}" SRC_HASH)
+      file(READ "${FILE_OUT}" EXISTING_OUT)
+      string(REGEX MATCH "FluffOS generated-from [^ ]+ sha256=([0-9a-f]+)" _stamp "${EXISTING_OUT}")
+      if ("${CMAKE_MATCH_1}" STREQUAL "${SRC_HASH}")
+        return()
+      endif()
+    endif()
+
     # Replace absolute paths with standard tokens (build root first).
     set(CONTENT_SUB "${CONTENT}")
     if (BUILD_ROOT_NORM)
@@ -38,6 +52,14 @@ function(process_bison_file FILE_IN FILE_OUT REPO_ROOT ACTION BUILD_ROOT)
       "YY_YY_[A-Z0-9_]+_GRAMMAR_AUTOGEN_H_INCLUDED"
       "YY_YY_GRAMMAR_AUTOGEN_H_INCLUDED"
       CONTENT_SUB "${CONTENT_SUB}")
+    # Record which input produced this file so later builds can tell "the
+    # grammar/lexer changed" apart from "a different generator build
+    # produced cosmetically different output".
+    if (SRC_FILE AND EXISTS "${SRC_FILE}")
+      file(SHA256 "${SRC_FILE}" SRC_HASH)
+      get_filename_component(SRC_NAME "${SRC_FILE}" NAME)
+      string(APPEND CONTENT_SUB "/* FluffOS generated-from ${SRC_NAME} sha256=${SRC_HASH} */\n")
+    endif()
   elseif (ACTION STREQUAL "DENORMALIZE")
     # Replace standard tokens with the actual absolute local paths
     set(CONTENT_SUB "${CONTENT}")
@@ -48,15 +70,22 @@ function(process_bison_file FILE_IN FILE_OUT REPO_ROOT ACTION BUILD_ROOT)
   else()
     message(FATAL_ERROR "Invalid ACTION: ${ACTION}. Must be NORMALIZE or DENORMALIZE")
   endif()
-  
-  # Write back if content changed or if we are copying to a different location
-  if (NOT "${CONTENT}" STREQUAL "${CONTENT_SUB}" OR NOT "${FILE_IN}" STREQUAL "${FILE_OUT}")
-    file(WRITE "${FILE_OUT}" "${CONTENT_SUB}")
-    if (ACTION STREQUAL "NORMALIZE")
-      message(STATUS "Normalized and copied ${FILE_IN} -> ${FILE_OUT}")
-    else()
-      message(STATUS "Denormalized and copied ${FILE_IN} -> ${FILE_OUT}")
+
+  # Skip the write when the destination already has identical content --
+  # rewriting identical bytes still bumps the mtime and cascades a
+  # pointless rebuild/relink of everything downstream on the next build.
+  if (EXISTS "${FILE_OUT}")
+    file(READ "${FILE_OUT}" EXISTING_CONTENT)
+    if ("${EXISTING_CONTENT}" STREQUAL "${CONTENT_SUB}")
+      return()
     endif()
+  endif()
+
+  file(WRITE "${FILE_OUT}" "${CONTENT_SUB}")
+  if (ACTION STREQUAL "NORMALIZE")
+    message(STATUS "Normalized and copied ${FILE_IN} -> ${FILE_OUT}")
+  else()
+    message(STATUS "Denormalized and copied ${FILE_IN} -> ${FILE_OUT}")
   endif()
 endfunction()
 
@@ -67,6 +96,9 @@ if (CMAKE_SCRIPT_MODE_FILE)
   if (NOT DEFINED BUILD_ROOT)
     set(BUILD_ROOT "")
   endif()
+  if (NOT DEFINED SRC_FILE)
+    set(SRC_FILE "")
+  endif()
 
-  process_bison_file("${FILE_IN}" "${FILE_OUT}" "${REPO_ROOT}" "${ACTION}" "${BUILD_ROOT}")
+  process_bison_file("${FILE_IN}" "${FILE_OUT}" "${REPO_ROOT}" "${ACTION}" "${BUILD_ROOT}" "${SRC_FILE}")
 endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -451,8 +451,23 @@ add_custom_command(
 endif ()
 
 find_package(BISON 3.8)
-if (${BISON_FOUND})
-  message(STATUS "BISON: ${BISON_VERSION}")
+# The committed generated file pins the generator version that produced it:
+# a host with an OLDER bison must not regenerate (it cannot reproduce the
+# committed output and would churn it on the post-build copy-back); it
+# builds from the committed copy instead. Hosts at or above the pin still
+# regenerate, so CI keeps validating grammar.y against a real toolchain.
+set(FLUFFOS_PINNED_BISON_VERSION "0")
+file(STRINGS "${CMAKE_CURRENT_SOURCE_DIR}/compiler/internal/grammar.autogen.cc"
+     _fluffos_bison_pin_line REGEX "made by GNU Bison" LIMIT_COUNT 1)
+if (_fluffos_bison_pin_line MATCHES "GNU Bison ([0-9]+\\.[0-9]+(\\.[0-9]+)?)")
+  set(FLUFFOS_PINNED_BISON_VERSION "${CMAKE_MATCH_1}")
+endif()
+set(FLUFFOS_BISON_REGEN FALSE)
+if (BISON_FOUND AND NOT BISON_VERSION VERSION_LESS FLUFFOS_PINNED_BISON_VERSION)
+  set(FLUFFOS_BISON_REGEN TRUE)
+endif()
+if (FLUFFOS_BISON_REGEN)
+  message(STATUS "BISON: ${BISON_VERSION} (committed files pinned at ${FLUFFOS_PINNED_BISON_VERSION})")
   BISON_TARGET(Grammar "${CMAKE_CURRENT_SOURCE_DIR}/compiler/internal/grammar.y"
           ${CMAKE_CURRENT_BINARY_DIR}/grammar.autogen.cc
           DEFINES_FILE "${CMAKE_CURRENT_BINARY_DIR}/grammar.autogen.h"
@@ -490,7 +505,11 @@ if (${BISON_FOUND})
     )
   endif()
 else()
-  message(STATUS "BISON: version too low, using pre-generated source.")
+  if (BISON_FOUND)
+    message(STATUS "BISON: ${BISON_VERSION} is older than the pinned ${FLUFFOS_PINNED_BISON_VERSION}, using pre-generated source.")
+  else()
+    message(STATUS "BISON: version too low, using pre-generated source.")
+  endif()
   add_custom_command(
     OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/grammar.autogen.cc"
            "${CMAKE_CURRENT_BINARY_DIR}/grammar.autogen.h"
@@ -507,14 +526,33 @@ endif()
 
 # ── Flex (LPC lexer) ──────────────────────────────────────────────────────
 find_package(FLEX 2.6)
-if (FLEX_FOUND)
-  message(STATUS "FLEX: ${FLEX_VERSION}")
+# Same version-pin scheme as bison above, read from the committed scanner's
+# YY_FLEX_*_VERSION defines.
+set(FLUFFOS_PINNED_FLEX_VERSION "0")
+file(STRINGS "${CMAKE_CURRENT_SOURCE_DIR}/compiler/internal/lexer.autogen.cc"
+     _fluffos_flex_pin_lines REGEX "#define YY_FLEX_(MAJOR|MINOR|SUBMINOR)_VERSION")
+if ("${_fluffos_flex_pin_lines}" MATCHES "MAJOR_VERSION ([0-9]+)")
+  set(_fluffos_flex_pin_major "${CMAKE_MATCH_1}")
+  if ("${_fluffos_flex_pin_lines}" MATCHES "MINOR_VERSION ([0-9]+)")
+    set(_fluffos_flex_pin_minor "${CMAKE_MATCH_1}")
+    if ("${_fluffos_flex_pin_lines}" MATCHES "SUBMINOR_VERSION ([0-9]+)")
+      set(FLUFFOS_PINNED_FLEX_VERSION
+          "${_fluffos_flex_pin_major}.${_fluffos_flex_pin_minor}.${CMAKE_MATCH_1}")
+    endif()
+  endif()
+endif()
+set(FLUFFOS_FLEX_REGEN FALSE)
+if (FLEX_FOUND AND NOT FLEX_VERSION VERSION_LESS FLUFFOS_PINNED_FLEX_VERSION)
+  set(FLUFFOS_FLEX_REGEN TRUE)
+endif()
+if (FLUFFOS_FLEX_REGEN)
+  message(STATUS "FLEX: ${FLEX_VERSION} (committed files pinned at ${FLUFFOS_PINNED_FLEX_VERSION})")
   FLEX_TARGET(LpcLexer
     "${CMAKE_CURRENT_SOURCE_DIR}/compiler/internal/lexer.l"
     "${CMAKE_CURRENT_BINARY_DIR}/lexer.autogen.cc"
     COMPILE_FLAGS "-Ca"
   )
-  if (BISON_FOUND)
+  if (FLUFFOS_BISON_REGEN)
     # Only valid when BISON_TARGET(Grammar) actually ran -- on the
     # bison-too-old path (macOS's stock bison) the Grammar target doesn't
     # exist and newer CMake makes this a hard configure error; the header
@@ -523,7 +561,11 @@ if (FLEX_FOUND)
   endif()
   set(GENERATED_LEXER_FILE "${FLEX_LpcLexer_OUTPUTS}")
 else()
-  message(STATUS "FLEX: not found, using pre-generated source.")
+  if (FLEX_FOUND)
+    message(STATUS "FLEX: ${FLEX_VERSION} is older than the pinned ${FLUFFOS_PINNED_FLEX_VERSION}, using pre-generated source.")
+  else()
+    message(STATUS "FLEX: not found, using pre-generated source.")
+  endif()
   add_custom_command(
     OUTPUT  "${CMAKE_CURRENT_BINARY_DIR}/lexer.autogen.cc"
     COMMAND "${CMAKE_COMMAND}" -D ACTION=DENORMALIZE -D FILE_IN="${CMAKE_CURRENT_SOURCE_DIR}/compiler/internal/lexer.autogen.cc" -D FILE_OUT="${CMAKE_CURRENT_BINARY_DIR}/lexer.autogen.cc" -D REPO_ROOT="${CMAKE_SOURCE_DIR}" -D BUILD_ROOT="${CMAKE_BINARY_DIR}" -P "${CMAKE_SOURCE_DIR}/cmake/util.cmake"
@@ -827,17 +869,21 @@ if (NOT WIN32 AND NOT EMSCRIPTEN)
     RUNTIME DESTINATION bin)
 endif ()
 
-# Update generated grammar files
-if (${BISON_FOUND} AND NOT EMSCRIPTEN)
+# Update generated grammar files. The copy-back is gated twice: only hosts
+# whose generator is at/above the committed pin regenerate at all, and
+# util.cmake skips the write unless the .y/.l INPUT hash changed -- so
+# same-version generators with cosmetically different output (distro
+# patches) can never churn the committed files.
+if (FLUFFOS_BISON_REGEN AND NOT EMSCRIPTEN)
   add_custom_command(TARGET "driver" POST_BUILD
-          COMMAND "${CMAKE_COMMAND}" -D ACTION=NORMALIZE -D FILE_IN="${BISON_Grammar_OUTPUT_SOURCE}" -D FILE_OUT="${CMAKE_CURRENT_SOURCE_DIR}/compiler/internal/grammar.autogen.cc" -D REPO_ROOT="${CMAKE_SOURCE_DIR}" -D BUILD_ROOT="${CMAKE_BINARY_DIR}" -P "${CMAKE_SOURCE_DIR}/cmake/util.cmake"
-          COMMAND "${CMAKE_COMMAND}" -D ACTION=NORMALIZE -D FILE_IN="${BISON_Grammar_OUTPUT_HEADER}" -D FILE_OUT="${CMAKE_CURRENT_SOURCE_DIR}/compiler/internal/grammar.autogen.h" -D REPO_ROOT="${CMAKE_SOURCE_DIR}" -D BUILD_ROOT="${CMAKE_BINARY_DIR}" -P "${CMAKE_SOURCE_DIR}/cmake/util.cmake"
+          COMMAND "${CMAKE_COMMAND}" -D ACTION=NORMALIZE -D FILE_IN="${BISON_Grammar_OUTPUT_SOURCE}" -D FILE_OUT="${CMAKE_CURRENT_SOURCE_DIR}/compiler/internal/grammar.autogen.cc" -D REPO_ROOT="${CMAKE_SOURCE_DIR}" -D BUILD_ROOT="${CMAKE_BINARY_DIR}" -D SRC_FILE="${CMAKE_CURRENT_SOURCE_DIR}/compiler/internal/grammar.y" -P "${CMAKE_SOURCE_DIR}/cmake/util.cmake"
+          COMMAND "${CMAKE_COMMAND}" -D ACTION=NORMALIZE -D FILE_IN="${BISON_Grammar_OUTPUT_HEADER}" -D FILE_OUT="${CMAKE_CURRENT_SOURCE_DIR}/compiler/internal/grammar.autogen.h" -D REPO_ROOT="${CMAKE_SOURCE_DIR}" -D BUILD_ROOT="${CMAKE_BINARY_DIR}" -D SRC_FILE="${CMAKE_CURRENT_SOURCE_DIR}/compiler/internal/grammar.y" -P "${CMAKE_SOURCE_DIR}/cmake/util.cmake"
           COMMENT "Copying and sanitizing generated grammar files")
 endif()
 
-if (FLEX_FOUND AND NOT EMSCRIPTEN)
+if (FLUFFOS_FLEX_REGEN AND NOT EMSCRIPTEN)
   add_custom_command(TARGET "driver" POST_BUILD
-    COMMAND "${CMAKE_COMMAND}" -D ACTION=NORMALIZE -D FILE_IN="${CMAKE_CURRENT_BINARY_DIR}/lexer.autogen.cc" -D FILE_OUT="${CMAKE_CURRENT_SOURCE_DIR}/compiler/internal/lexer.autogen.cc" -D REPO_ROOT="${CMAKE_SOURCE_DIR}" -D BUILD_ROOT="${CMAKE_BINARY_DIR}" -P "${CMAKE_SOURCE_DIR}/cmake/util.cmake"
+    COMMAND "${CMAKE_COMMAND}" -D ACTION=NORMALIZE -D FILE_IN="${CMAKE_CURRENT_BINARY_DIR}/lexer.autogen.cc" -D FILE_OUT="${CMAKE_CURRENT_SOURCE_DIR}/compiler/internal/lexer.autogen.cc" -D REPO_ROOT="${CMAKE_SOURCE_DIR}" -D BUILD_ROOT="${CMAKE_BINARY_DIR}" -D SRC_FILE="${CMAKE_CURRENT_SOURCE_DIR}/compiler/internal/lexer.l" -P "${CMAKE_SOURCE_DIR}/cmake/util.cmake"
     COMMENT "Copying and sanitizing Flex-generated lexer.autogen.cc")
 endif()
 

--- a/src/compiler/internal/grammar.autogen.cc
+++ b/src/compiler/internal/grammar.autogen.cc
@@ -1744,7 +1744,7 @@ int yydebug;
 struct yypstate
   {
     /* Number of syntax errors so far.  */
-    int yynerrs YY_ATTRIBUTE_UNUSED;
+    int yynerrs;
 
     yy_state_fast_t yystate;
     /* Number of tokens to shift before error messages enabled.  */
@@ -4270,3 +4270,4 @@ yypushreturn:
 #undef yyes_capacity
 #line 1159 "$REPO_ROOT$/src/compiler/internal/grammar.y"
 
+/* FluffOS generated-from grammar.y sha256=1e0b0dc0115624b2604b675a147b6ef88d5e9f72cbc76dc9e48b661f1a4eeacc */

--- a/src/compiler/internal/grammar.autogen.h
+++ b/src/compiler/internal/grammar.autogen.h
@@ -191,3 +191,4 @@ void yypstate_delete (yypstate *ps);
 
 
 #endif /* !YY_YY_GRAMMAR_AUTOGEN_H_INCLUDED  */
+/* FluffOS generated-from grammar.y sha256=1e0b0dc0115624b2604b675a147b6ef88d5e9f72cbc76dc9e48b661f1a4eeacc */

--- a/src/compiler/internal/lexer.autogen.cc
+++ b/src/compiler/internal/lexer.autogen.cc
@@ -5629,3 +5629,4 @@ void lpc_lex_reset(void *yyscanner) {
 }
 
 
+/* FluffOS generated-from lexer.l sha256=26827fa5457771c9a0932e4fc33a539ae6ac03f0f36bc6e24a07d5d40d8e29a7 */


### PR DESCRIPTION
## Problem

Every local build regenerated `grammar.autogen.cc/.h` and `lexer.autogen.cc` and copied them back into the source tree, churning git whenever the host's bison/flex emitted cosmetically different output than whatever produced the committed copy. The existing normalization only tokenizes paths and header guards — it can't help when two generators that even *report the same version* differ in emitted code: the committed grammar said "made by GNU Bison 3.8.2" but contained a distro-patched bison's `int yynerrs YY_ATTRIBUTE_UNUSED;`, which vanilla 3.8.2 (every CI image) downgrades on every rebuild.

## Fix (two layers)

1. **Generator version pin** — the pin is read from the committed generated files themselves (`made by GNU Bison X.Y.Z`, `YY_FLEX_*_VERSION`). A host with an **older** generator no longer regenerates at all; it builds from the committed copy via the existing pre-generated path (`BISON: 3.7 is older than the pinned 3.8.2, using pre-generated source.`). Hosts at/above the pin still regenerate, so CI keeps validating `grammar.y`/`lexer.l` against a real toolchain.
2. **Input-hash gate on the copy-back** — the post-build copy-back stamps the committed file with the SHA256 of its *input* (`/* FluffOS generated-from grammar.y sha256=... */`) and is skipped entirely while that hash is unchanged. Same-version-but-differently-patched generators can never churn the committed files again; editing the `.y`/`.l` updates them exactly as before.

Also: the copy-back now skips writing byte-identical content, so it no longer bumps mtimes and cascades pointless relinks on every incremental build.

The three committed autogen files are re-stamped in this commit (one-time churn) as the new pinned baseline: **vanilla bison 3.8.2 / flex 2.6.4**, matching every CI image — so CI itself can never churn them either.

## Verified

- Rebuild with no input change: zero copy-backs, `git status` clean
- `grammar.y` edited: copy-back fires for both grammar files with an updated stamp; reverting the edit resyncs on the next build
- Full gate: clean build, 312/312 GTest, LPC testsuite "Checks succeeded."

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PCUi8QKaFxeTyLXMeVkqn4

---
_Generated by [Claude Code](https://claude.ai/code/session_01PCUi8QKaFxeTyLXMeVkqn4)_