### PR TITLE
Fix #1267: codegen recursion cap rejects large objects

### DIFF
--- a/src/compiler/internal/compiler.cc
+++ b/src/compiler/internal/compiler.cc
@@ -2781,6 +2781,20 @@ static program_t* epilog(void) {
 
   current_tree = TREE_MAIN;
 
+  if (num_parse_error > 0) {
+    /* i_generate_node() can raise errors after the check at the top of
+       this function already passed -- e.g. a pathologically deep
+       expression tripping its recursion-depth cap, or the pre-existing
+       branch-limit-exceeded checks. Bail out the same way the
+       top-of-function check does rather than handing back a program
+       built from a codegen pass that stopped partway through. */
+    clean_parser();
+    end_new_file();
+    free_string(current_file);
+    current_file = nullptr;
+    return nullptr;
+  }
+
   generate_final_program(0);
   UPDATE_PROGRAM_SIZE;
 

--- a/src/compiler/internal/generate.cc
+++ b/src/compiler/internal/generate.cc
@@ -3,6 +3,7 @@
 #include "generate.h"
 
 #include <cstdio>
+#include <vector>
 
 #include "include/function.h"  // for F_SIMUL etc , FIXME
 #include "efuns.autogen.h"
@@ -50,10 +51,32 @@ static void optimize_lvalue_list(parse_node_t* expr) {
 #define OPTIMIZER_IN_COND 2 /* switch or if or ?: */
 static int optimizer_state = 0;
 
+namespace {
+// Mirrors the guard in icode.cc's i_generate_node(): a left-nested chain
+// of binary/unary/ternary operators builds a parse tree as deep as the
+// input, with no bound from the grammar/parser. The NODE_TWO_VALUES case
+// below walks its own chain (one node per top-level definition/statement)
+// iteratively rather than recursing, so this cap bounds genuine
+// expression nesting only -- never an object's definition or statement
+// count (github.com/fluffos/fluffos/issues/1267).
+//
+// Unlike i_generate_node(), going over is not a compile error: skipping
+// optimization of a subtree still leaves correct (just less tight)
+// bytecode, so this only warns and gives up on that subtree.
+int g_optimize_depth = 0;
+constexpr int kMaxOptimizeDepth = 500;
+}  // namespace
+
 static parse_node_t* optimize(parse_node_t* expr) {
   if (!expr) {
     return nullptr;
   }
+  if (++g_optimize_depth > kMaxOptimizeDepth) {
+    --g_optimize_depth;
+    yywarn("Expression nested too deeply to fully optimize.");
+    return expr;
+  }
+  DEFER { --g_optimize_depth; };
 
   switch (expr->kind) {
     case NODE_TERNARY_OP:
@@ -138,10 +161,26 @@ static parse_node_t* optimize(parse_node_t* expr) {
     case NODE_CALL:
       optimize_expr_list(expr->r.expr);
       break;
-    case NODE_TWO_VALUES:
-      OPT(expr->l.expr);
-      OPT(expr->r.expr);
+    case NODE_TWO_VALUES: {
+      // Same chain, same reason to flatten it, as icode.cc's
+      // i_generate_node() (see there). optimize() never replaces a
+      // NODE_TWO_VALUES node's identity, so a stack of *slots* (rather
+      // than values), with each leaf's optimized replacement written
+      // back into its own slot, is equivalent to the recursive form.
+      std::vector<parse_node_t**> work{&expr->r.expr, &expr->l.expr};
+      while (!work.empty()) {
+        parse_node_t** slot = work.back();
+        work.pop_back();
+        parse_node_t* node = *slot;
+        if (node && node->kind == NODE_TWO_VALUES) {
+          work.push_back(&node->r.expr);
+          work.push_back(&node->l.expr);
+        } else {
+          OPT(*slot);
+        }
+      }
       break;
+    }
     case NODE_CONTROL_JUMP:
     case NODE_PARAMETER:
     case NODE_PARAMETER_LVALUE:

--- a/src/compiler/internal/icode.cc
+++ b/src/compiler/internal/icode.cc
@@ -6,6 +6,7 @@
 #include "icode.h"
 
 #include <cstdio>  // for printf
+#include <vector>
 
 #include "include/function.h"
 #include "efuns.autogen.h"
@@ -357,10 +358,31 @@ static int try_to_push(int kind, int value) {
   return 0;
 }
 
+namespace {
+// A left-nested chain of binary/unary/ternary operators (e.g. tens of
+// thousands of '+' terms) builds a parse tree of matching depth with no
+// bound from the grammar/parser -- walking it here recurses just as deep.
+// Cap it so pathological input errors cleanly instead of overflowing the
+// C stack (mirrors MAX_INCLUDE_DEPTH's role for #include nesting).
+// NODE_TWO_VALUES chains (top-level definitions, statement lists) are
+// walked iteratively below instead of recursed, so they never count
+// against this -- the cap only ever bounds genuine expression nesting
+// (github.com/fluffos/fluffos/issues/1267).
+int g_generate_node_depth = 0;
+constexpr int kMaxGenerateNodeDepth = 500;
+}  // namespace
+
 void i_generate_node(parse_node_t* expr) {
   if (!expr) {
     return;
   }
+
+  if (++g_generate_node_depth > kMaxGenerateNodeDepth) {
+    --g_generate_node_depth;
+    yyerror("Expression nested too deeply.");
+    return;
+  }
+  DEFER { --g_generate_node_depth; };
 
   if (expr->line && expr->line != line_being_generated) {
     switch_to_line(expr->line);
@@ -535,10 +557,30 @@ void i_generate_node(parse_node_t* expr) {
       ins_byte(expr->v.number);
       ins_short(expr->l.number);
       break;
-    case NODE_TWO_VALUES:
-      i_generate_node(expr->l.expr);
-      i_generate_node(expr->r.expr);
+    case NODE_TWO_VALUES: {
+      // rule_program_append() chains one node per top-level definition
+      // via l.expr; the statements: rule chains one per statement via
+      // r.expr. Neither is safe to recurse: l.expr isn't a tail call
+      // (r.expr's own work follows it), and r.expr only looks
+      // tail-callable -- the depth-guard's DEFER above still has to run
+      // after it returns, which defeats that. Flatten with an explicit
+      // stack instead, in whichever direction the chain nests;
+      // i_generate_node() is still called (and still depth-capped) per
+      // leaf, so a genuinely deep expression inside one
+      // definition/statement is still caught.
+      std::vector<parse_node_t*> work{expr->r.expr, expr->l.expr};
+      while (!work.empty()) {
+        parse_node_t* node = work.back();
+        work.pop_back();
+        if (node && node->kind == NODE_TWO_VALUES) {
+          work.push_back(node->r.expr);
+          work.push_back(node->l.expr);
+        } else {
+          i_generate_node(node);
+        }
+      }
       break;
+    }
     case NODE_CONTROL_JUMP: {
       int kind = expr->v.number;
       end_pushes();

--- a/testsuite/single/tests/compiler/deep_definition_chain.lpc
+++ b/testsuite/single/tests/compiler/deep_definition_chain.lpc
@@ -1,0 +1,36 @@
+// https://github.com/fluffos/fluffos/issues/1267
+//
+// rule_program_append() (grammar_rules.cc) chains one NODE_TWO_VALUES per
+// top-level definition via l.expr, so i_generate_node() and optimize()
+// used to recurse one C stack frame per definition when walking it -- the
+// depth cap added for deep_expr_recursion.lpc's pathological expression
+// trees counted this the exact same way, so any object with more
+// top-level definitions than the cap failed to compile. That's an
+// ordinary source-size quantity, not pathological input: real
+// simul_efuns/daemons routinely define hundreds of functions. The walkers
+// now flatten this particular chain iteratively instead of recursing it,
+// so a large object must compile regardless of its definition count.
+void do_tests() {
+    string src;
+    object ob;
+    int i;
+
+    src = "";
+    for (i = 0; i < 5000; i++) {
+        src += "int f" + i + "() { return " + i + "; }\n";
+    }
+
+    rm("/gen_deep_defs.c");
+    write_file("/gen_deep_defs.c", src);
+
+    ob = load_object("/gen_deep_defs");
+    ASSERT2(objectp(ob), "object with 5000 top-level functions should compile");
+    if (objectp(ob)) {
+        ASSERT_EQ(0, ob->f0());
+        ASSERT_EQ(2500, ob->f2500());
+        ASSERT_EQ(4999, ob->f4999());
+        destruct(ob);
+    }
+
+    rm("/gen_deep_defs.c");
+}

--- a/testsuite/single/tests/compiler/deep_expr_recursion.lpc
+++ b/testsuite/single/tests/compiler/deep_expr_recursion.lpc
@@ -1,0 +1,29 @@
+// A left-nested chain of binary operators (e.g. tens of thousands of
+// '+' terms) builds a parse tree as deep as the input -- LALR parsing
+// itself stays shallow (each '+' reduces immediately), but the
+// optimizer (optimize(), generate.cc) and code generator
+// (i_generate_node(), icode.cc) then walk that tree with plain
+// recursion and no depth cap, overflowing the C stack at compile time.
+// A single seed variable (not a literal) prevents constant-folding
+// from collapsing the chain before it reaches the walkers.
+void do_tests() {
+    string src, expr;
+    int i;
+
+    expr = "x";
+    for (i = 0; i < 50000; i++) {
+        expr += "+x";
+    }
+    src = "int x; int f() { x = 1; return " + expr + "; }\n";
+
+    rm("/gen_deep_expr.c");
+    write_file("/gen_deep_expr.c", src);
+
+    // Surviving this compile is the regression signal -- whether the
+    // compile is accepted or cleanly rejected past the new depth cap,
+    // it must not crash the driver.
+    catch(load_object("/gen_deep_expr"));
+    ASSERT(1);
+
+    rm("/gen_deep_expr.c");
+}

--- a/testsuite/single/tests/compiler/deep_statement_chain.lpc
+++ b/testsuite/single/tests/compiler/deep_statement_chain.lpc
@@ -1,0 +1,33 @@
+// https://github.com/fluffos/fluffos/issues/1267
+//
+// The statements: grammar rule (rule_block_statements_stmt(), in
+// grammar_rules_decls.cc) chains one NODE_TWO_VALUES per statement via
+// r.expr, so a function body with a lot of sequential statements builds
+// a parse tree exactly as deep as its statement count -- the same
+// underlying node kind as deep_definition_chain.lpc's top-level
+// definitions, just nested the other direction. i_generate_node() and
+// optimize() must walk it without recursing one C stack frame per
+// statement.
+void do_tests() {
+    string src;
+    object ob;
+    int i;
+
+    src = "int x;\nint f() {\n    x = 0;\n";
+    for (i = 0; i < 5000; i++) {
+        src += "    x = x + 1;\n";
+    }
+    src += "    return x;\n}\n";
+
+    rm("/gen_deep_stmts.c");
+    write_file("/gen_deep_stmts.c", src);
+
+    ob = load_object("/gen_deep_stmts");
+    ASSERT2(objectp(ob), "function with 5000 sequential statements should compile");
+    if (objectp(ob)) {
+        ASSERT_EQ(5000, ob->f());
+        destruct(ob);
+    }
+
+    rm("/gen_deep_stmts.c");
+}


### PR DESCRIPTION
Fixes #1267.

## Problem

The 500-deep recursion cap added in 117cbc1 (`optimize()` / `i_generate_node()`) counts **every** `NODE_TWO_VALUES` level. But that node kind forms two ordinary source-size chains, not just expression trees:

- `rule_program_append()` chains one `NODE_TWO_VALUES` per **top-level definition** (via `l.expr`)
- the `statements:` grammar rule chains one per **statement** (via `r.expr`)

Walking those recursively made codegen depth scale with an object's definition/statement count, so the cap rejected perfectly ordinary objects. As reported in #1267, a `simul_efun` aggregating >500 functions stopped compiling and the driver couldn't boot — `error: Expression nested too deeply` on completely normal code. (117cbc1 was reverted on master in a89bb37e; this PR reintroduces the protection in a size-independent form.)

## Fix

Walk both `NODE_TWO_VALUES` chains with an **explicit work stack** instead of recursing, in whichever direction each nests. `i_generate_node()`/`optimize()` are still called (and still depth-capped) per leaf, so a genuinely deep *expression* inside one definition/statement is still caught — but an object's size never counts against the cap. The cap stays at 117cbc1's ASan-verified-safe **500**, now purely a backstop for pathological expression trees (e.g. tens of thousands of chained `+`).

Two follow-on fixes to the cap's own behavior:

1. **`epilog()` shipped a corrupt-but-loadable object.** It only checked `num_parse_error` once, *before* codegen ran, so tripping `i_generate_node()`'s cap set the error but still emitted and returned a truncated program. Now re-checks after `generate()` and bails out, mirroring the existing "Program too large" path. This also hardens the pre-existing branch-limit-exceeded errors, which had the identical late-error bug.
2. **`optimize()`'s cap now warns instead of erroring.** Skipping optimization of a subtree leaves correct (just less tight) bytecode, so it uses `yywarn()` and gives up on that subtree rather than failing the compile.

## Verification

Built lpcc from **117cbc1** (previous cap) and from **this change**, ran identical inputs:

| Case | Previous cap (117cbc1) | This PR |
|---|---|---|
| 5000 top-level functions | ❌ `Expression nested too deeply` | ✅ compiles clean |
| 5000 sequential statements | ❌ `Expression nested too deeply` | ✅ compiles clean |
| 50 000-term `+` expression | error, but loads a **truncated** object | ✅ cleanly rejected, load fails |

## Tests

- `deep_expr_recursion.lpc` — pathological expression; must not crash the driver, now cleanly rejected past the cap.
- `deep_definition_chain.lpc` — 5000 top-level functions; must compile (the #1267 repro).
- `deep_statement_chain.lpc` — 5000 sequential statements; must compile (same node kind, other nesting direction).

🤖 Generated with [Claude Code](https://claude.com/claude-code)