### PR TITLE
Fix stat() flag argument corruption in directory/glob paths

### DIFF
--- a/src/packages/core/efuns_main.cc
+++ b/src/packages/core/efuns_main.cc
@@ -2551,7 +2551,11 @@ void f_stat() {
   array_t* v;
   object_t* ob;
 
-  path = check_valid_path((--sp)->u.string, current_object, "stat", 0);
+  // Capture the flag before check_valid_path(): the valid_read apply it
+  // runs pushes its arguments right where the flag sits (issue #1271).
+  LPC_INT const flag = (sp--)->u.number;
+
+  path = check_valid_path(sp->u.string, current_object, "stat", 0);
   if (!path) {
     free_string_svalue(sp);
     *sp = const0;
@@ -2587,7 +2591,7 @@ void f_stat() {
       return;
     }
   }
-  v = get_dir(sp->u.string, (sp + 1)->u.number);
+  v = get_dir(sp->u.string, flag);
   free_string_svalue(sp);
   if (v) {
     put_array(v);

--- a/testsuite/single/tests/efuns/stat.lpc
+++ b/testsuite/single/tests/efuns/stat.lpc
@@ -1,0 +1,48 @@
+// Issue #1271: f_stat() read its flag argument via (sp + 1)->u.number
+// *after* calling check_valid_path(), which runs the valid_read master
+// apply -- that apply pushes its own arguments into exactly the stack
+// slot the flag was still sitting in, so the flag was clobbered before
+// f_stat() ever read it. The upshot: stat(path, flag) silently behaved
+// as if flag was whatever garbage the apply left behind, instead of what
+// the caller passed, for any directory or glob path (regular files have
+// their own code path and were unaffected).
+//
+// stat()'s directory/glob branch simply forwards to get_dir() with the
+// (correctly read) flag, so the two must agree exactly for the same
+// path + flag.
+void do_tests() {
+    // Directory, every flag shape.
+    ASSERT_EQ(get_dir("/std", 0), stat("/std", 0));
+    ASSERT_EQ(get_dir("/std", 1), stat("/std", 1));
+    ASSERT_EQ(get_dir("/std", -1), stat("/std", -1));
+
+    // Trailing slash must not change the outcome either way.
+    ASSERT_EQ(get_dir("/std/", -1), stat("/std/", -1));
+
+    // Glob pattern.
+    ASSERT_EQ(get_dir("/std/*.lpc", -1), stat("/std/*.lpc", -1));
+
+    // Default flag (0) when omitted.
+    ASSERT_EQ(get_dir("/std", 0), stat("/std"));
+
+    // The -1 shape carries per-entry ({name, size-or-dirflag, mtime}).
+    mixed *info = stat("/std", -1);
+    ASSERT(pointerp(info));
+    ASSERT(sizeof(info) > 0);
+    foreach (mixed entry in info) {
+        ASSERT(pointerp(entry));
+        ASSERT_EQ(3, sizeof(entry));
+        ASSERT(stringp(entry[0]));
+    }
+
+    // Regular files keep using their own dedicated code path regardless
+    // of flag (size/mtime/load-time/ctime), unaffected by this bug.
+    string str = "stat test file for issue 1271";
+    string fname = "/stat_test_file";
+    rm(fname);
+    write_file(fname, str);
+    mixed *finfo = stat(fname, -1);
+    ASSERT(pointerp(finfo));
+    ASSERT_EQ(strlen(str), finfo[0]);
+    rm(fname);
+}


### PR DESCRIPTION
## Summary
Fixed a bug in `f_stat()` where the flag argument was being corrupted when stat() was called on directories or glob patterns. The flag was read from the stack *after* `check_valid_path()` executed, which runs the `valid_read` master apply that overwrites the stack slot containing the flag.

## Changes
- **Capture flag before validation**: Read the flag argument from the stack before calling `check_valid_path()` to prevent it from being clobbered by the master apply's stack operations
- **Use captured flag value**: Pass the captured flag to `get_dir()` instead of re-reading from the corrupted stack location
- **Added comprehensive test suite**: New test file validates that `stat()` and `get_dir()` produce identical results for directories, glob patterns, and various flag values (-1, 0, 1)

## Implementation Details
The fix involves a minimal change to the stack handling order:
1. Read and store the flag argument first: `LPC_INT const flag = (sp--)->u.number;`
2. Then call `check_valid_path()` on the path argument
3. Pass the pre-captured flag to `get_dir()` instead of attempting to read it from the stack afterward

This ensures the flag value remains intact regardless of what the `valid_read` apply does with the stack. Regular file stat operations were unaffected by this bug as they use a separate code path.

https://claude.ai/code/session_018LFGApX88co12VgFULx1VZ