### PR TITLE
trace: stop recursive dump_trace() re-entry from exploding error output

### DIFF
--- a/src/vm/internal/trace.cc
+++ b/src/vm/internal/trace.cc
@@ -8,12 +8,24 @@
 // FIXME: for svalue_to_string
 #include "packages/core/sprintf.h"
 
+#include "thirdparty/scope_guard/scope_guard.hpp"
+
 // Dump a stack trace at current location.
 
 /* The end of a static buffer */
 #define EndOf(x) (x + sizeof(x) / sizeof(x[0]))
 
 namespace {
+
+// Formatting a frame's arguments/locals (below) can itself call error() --
+// e.g. an object whose object_name() apply always throws -- which re-enters
+// dump_trace() while the outer call is still walking the stack. Without a
+// guard, each re-entry re-dumps and thus re-embeds the still-in-progress
+// outer trace's text (itself containing the trace before that, ...), so the
+// output grows combinatorially with recursion depth instead of linearly.
+// Let the inner error just report "trace suppressed" (see error_handler()
+// in simulate.cc) and let the outer, already-in-progress dump continue.
+bool dump_trace_in_progress = false;
 
 void get_trace_details(const program_t* prog, long findex, const char** fname, int* na, int* nl) {
   function_t* cfp = &prog->function_table[findex];
@@ -63,6 +75,11 @@ const char* dump_trace(int how) {
   if (csp < &control_stack[0]) {
     return nullptr;
   }
+  if (dump_trace_in_progress) {
+    return nullptr;
+  }
+  dump_trace_in_progress = true;
+  DEFER { dump_trace_in_progress = false; };
 
   if (how) {
     last_instructions();

--- a/testsuite/single/tests/crasher/750.lpc
+++ b/testsuite/single/tests/crasher/750.lpc
@@ -21,8 +21,12 @@ string object_name() {
 }
 
 void do_tests() {
-  object* obs = objects();
-  foreach(object ob in obs) {
-    write(sprintf("%O: %d\n", ob, refs(ob)));
-  }
+  // Issue #750: name()/object_name() erroring must not crash the driver,
+  // even though the driver's own error/trace printer needs to represent
+  // this same object via %O while it unwinds. this_object() alone is
+  // enough to hit that path -- looping sprintf("%O") over every objects()
+  // in the game (the original report's exact code) only adds output
+  // proportional to however many objects happen to be loaded elsewhere in
+  // a full suite run, without exercising anything extra.
+  write(sprintf("%O: %d\n", this_object(), refs(this_object())));
 }


### PR DESCRIPTION
Running crasher/750.lpc printed ~40,000 lines (1.3MB) of nested error
traces for one test. dump_trace() formats each frame's arguments and
locals via svalue_to_string(), whose %O handling for objects calls the
master's object_name() apply; 750.lpc's object errors inside that apply
(the whole point of the regression test), which lands back in
error_handler() -> dump_trace() while the outer dump is still walking
the same control stack. Each re-entry re-dumped the stack and its text
got embedded into the outer trace's argument rendering, so output grew
combinatorially with the recursion depth (the num_mudlib_error > 10
brake bounds the depth, not the output).

Guard dump_trace() with an in-progress flag (DEFER-reset, so an error()
unwind can't leave it stuck): a nested call now returns immediately and
the inner error is reported by the existing one-line "trace suppressed"
path in error_handler(). One full trace of the original error is still
printed. Isolated run of crasher/750: 40,448 lines -> under 700.

Also trim 750.lpc's do_tests() to sprintf("%O") this_object() only --
that one object is what reproduces issue #750's crash; looping over
every objects() in the game just multiplied the remaining output by
however many objects a full suite run happens to have loaded.

Validated on Debug+ASan (full suite twice, randomized order) and
RelWithDebInfo: 599 files pass, no sanitizer or ref-count reports.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01XEbhcRgWHssME1TQvUomPm