### PR TITLE
core: don't fire lazy resets from the clean_up sweep

### DIFF
--- a/src/backend.cc
+++ b/src/backend.cc
@@ -231,6 +231,13 @@ void look_for_objects_to_swap() {
         if (ready_for_clean_up && (ob->flags & O_WILL_CLEAN_UP)) {
           int const save_reset_state = ob->flags & O_RESET_STATE;
 
+          /*
+           * Set O_RESET_STATE during the apply so LAZY_RESETS' try_reset()
+           * doesn't fire an overdue reset() on an object that may be about to
+           * destruct; the pending reset fires on the next real touch instead.
+           */
+          ob->flags |= O_RESET_STATE;
+
           debug(d_flag, "clean up /%s\n", ob->obname);
 
           /*
@@ -256,7 +263,7 @@ void look_for_objects_to_swap() {
           if (!svp || (svp->type == T_NUMBER && svp->u.number == 0)) {
             ob->flags &= ~O_WILL_CLEAN_UP;
           }
-          ob->flags |= save_reset_state;
+          ob->flags = (ob->flags & ~O_RESET_STATE) | save_reset_state;
         }
       }
       last_good_ob = ob;


### PR DESCRIPTION
With `LAZY_RESETS` enabled, `apply_low()` calls `try_reset()` before every apply. The periodic `look_for_objects_to_swap()` sweep applies `clean_up()` to objects that have been untouched for `TIME_TO_CLEAN_UP`. But untouched is exactly what makes a lazy reset overdue: by the time an object has sat idle for `TIME_TO_CLEAN_UP` (which meets or exceeds `TIME_TO_RESET`), its reset timer expired long ago and is still waiting for a touch. The sweep's own `clean_up()` apply becomes that touch.

**Result:** the sweep batch-fires `reset()` on each idle object moments before `clean_up()` destructs it. On content-heavy mudlibs this clones monsters/equipment into rooms that are immediately destroyed, producing a synchronous stall on every 5-minute sweep and defeating the entire point of `LAZY_RESETS`.

**Fix:** set `O_RESET_STATE` around the `clean_up` apply so `try_reset()` skips it, and restore the saved state with a mask afterwards. Pending resets stay pending and fire on the next genuine touch (`call_other` or `move_object`), so objects a player actually reaches are still reset on arrival.


**Testing:**
I noticed this on our production MUD now that I have a metrics system and charts to display them.

The three charts being displayed are:
1. `room.reset` - the number of room resets per minute over the past hour
2. `system.rooms.blueprints` - the number of room blueprints, sampled every minute
3. `lag.hb_gap_max` - worst heart_beat-to-heart_beat gap per sample window; our interval is 2,500ms, so ~2,500-2,600 is healthy

<img width="640" height="675" alt="merentha_prime_before" src="https://github.com/user-attachments/assets/f807064f-dfaf-456e-aa19-3006dc082919" />

This chart is showing a clear pattern that on a 5 minute interval, large amounts of rooms are resetting and occasionally causing a spike in our heart_beat lag, despite having `LAZY_RESETS` enabled and most players idle. I was also able to confirm in our metrics that large amounts of monsters, armour, weapon, and objects were being created as well but have excluded them from this chart for simplicity.

<img width="640" height="675" alt="merentha_builders_before" src="https://github.com/user-attachments/assets/bdcdd8e9-7909-41b9-9c1b-0ddb1422c8d3" />

On our test port with no active players, I started the driver and loaded ~4,500 rooms (this caused the heart_beat lag to spike, ignore the initial spike). After the `TIME_TO_CLEAN_UP` (30 minutes) and the next `look_for_objects_to_swap()` (5 minutes later), there is a spike of basically every room resetting. ~4,000 out of ~4,500 rooms cleaned up, and we had a noticeable heart_beat lag jump.

<img width="640" height="675" alt="merentha_builders_after" src="https://github.com/user-attachments/assets/096fbfee-f7d1-4616-97ab-f39f869c3fcd" />

Applying this patch and replicating the above scenario again on our test port with no active players, I was able to confirm that the amount of rooms being reset on the `TIME_TO_CLEAN` + `look_for_objects_to_swap()` event was significantly reduced. Out of ~3,850 loaded rooms, ~3,450 of them cleaned up and only ~1,100 of them reset, as opposed to the previous scenario where nearly every room reset.