### PR TITLE
Add missing trailing newline to trace_start() error messages

### DIFF
--- a/src/packages/core/trace.cc
+++ b/src/packages/core/trace.cc
@@ -14,13 +14,13 @@ void f_trace_start() {
 
   auto duration_secs = sp->u.number;
   if (duration_secs < 0 || duration_secs > 5 * 60) {
-    error("Invalid duration specified.");
+    error("Invalid duration specified.\n");
   }
 
   const auto* realfile = check_valid_path((sp - 1)->u.string, current_object, "trace_start", 1);
 
   if (!realfile) {
-    error("Permission denied for trace file: %s", (sp - 1)->u.string);
+    error("Permission denied for trace file: %s\n", (sp - 1)->u.string);
   }
 
   // Used later in the block.


### PR DESCRIPTION
Update `src/packages/core/trace.cc` to follow project convention of `error(...)` messages sending a trailing `\n` character.