### PR TITLE
Document dual (expr)/{ block } syntax for catch and time_expression

### DIFF
--- a/docs/efun/calls/catch.md
+++ b/docs/efun/calls/catch.md
@@ -5,26 +5,38 @@ title: calls / catch
 
 ### NAME
 
-    catch() - catch an evaluation error
+    catch - catch an evaluation error
 
 ### SYNOPSIS
 
-    mixed catch( mixed expr );
+    mixed catch( expr );
+    mixed catch { statements }
 
 ### DESCRIPTION
 
-    Evaluate  <expr>.  If  there  is no error, 0 is returned. If there is a
-    standard error, a string (with a leading '*') will be returned.
+    catch is a language construct (a compiler keyword), not an ordinary
+    efun.  It accepts two body styles, sharing the same grammar as
+    time_expression:
+
+    - Parenthesized expression form: `catch(expr)` evaluates <expr>.
+    - Block form: `catch { statements }` executes the statement block.
+
+    If there is no error, 0 is returned.  If there is a standard error, a
+    string (with a leading '*') will be returned.  The value of the body
+    expression itself is discarded.
 
     The function throw() can also be used to immediately return any  value,
-    except 0. catch() is not really a function call, but a directive to the
-    compiler.
+    except 0.
+
+    It is a compile-time error to `break` or `continue` out of a catch
+    block.
 
     The catch() is somewhat costly, and should not be used  just  anywhere.
     Rather, use it at places where an error would destroy consistency.
 
 ### EXAMPLE
 
+    ```c
     void example1() {
         object ob ;
         mixed err ;
@@ -48,8 +60,9 @@ title: calls / catch
     }
 
     // ERR: "*Error in loading object '/u/g/gesslar/two'"
+    ```
 
 ### SEE ALSO
 
-    error(3), throw(3), error_handler(4)
+    error(3), throw(3), error_handler(4), time_expression(3)
 

--- a/docs/efun/internals/time_expression.md
+++ b/docs/efun/internals/time_expression.md
@@ -5,21 +5,45 @@ title: internals / time_expression
 
 ### NAME
 
-    time_expression()  -  return the amount of real time that an expression
-    took
+    time_expression - return the amount of real time that an expression
+        or block took to evaluate
 
 ### SYNOPSIS
 
-    int time_expression( mixed expr );
+    int time_expression( expr );
+    int time_expression { statements }
 
 ### DESCRIPTION
 
-    Evaluate <expr>.  The amount of real time that passed during the evalu‐
-    ation  of  <expr>,  in microseconds, is returned.  The precision of the
-    value is not necessarily 1 microsecond; in fact, it  probably  is  much
-    less precise.
+    time_expression is a language construct (a compiler keyword, like
+    catch), not an ordinary efun.  It accepts two body styles, sharing the
+    same grammar as catch:
+
+    - Parenthesized expression form: `time_expression(expr)` evaluates
+      <expr>.
+    - Block form: `time_expression { statements }` executes the statement
+      block.
+
+    In both forms, the amount of real (wall-clock) time that passed during
+    the evaluation of the body, in microseconds, is returned as an int.
+    The value of the body expression itself is discarded.  The precision
+    of the value is not necessarily 1 microsecond; in fact, it probably is
+    much less precise.
+
+    It is a compile-time error to `break` or `continue` out of a
+    time_expression block.
+
+### EXAMPLES
+
+    ```c
+    int usec = time_expression( users() );
+
+    int usec = time_expression {
+        for (int i = 0; i < 1000; i++)
+            do_something();
+    };
+    ```
 
 ### SEE ALSO
 
-    rusage(3), function_profile(3), time(3)
-
+    rusage(3), function_profile(3), time(3), catch(3)

--- a/docs/i18n/zh-CN/docusaurus-plugin-content-docs/current/efun/calls/catch.md
+++ b/docs/i18n/zh-CN/docusaurus-plugin-content-docs/current/efun/calls/catch.md
@@ -5,23 +5,62 @@ title: calls / catch
 
 ### 名称
 
-    catch() - 捕获运行时错误
+    catch - 捕获运行时错误
 
 ### 语法
 
-    mixed catch( mixed expr );
+    mixed catch( expr );
+    mixed catch { statements }
 
 ### 描述
 
-    执行表达式 `expr`，如果没有错误会返回0，如果有标准错误，会返回一个以 `*` 开头的包括错误信息的字符串。
+    catch 是一个语言结构（编译器关键字），而不是普通的外部函数。
+    它接受两种主体写法，与 time_expression 共享同一语法：
 
-    外部函数 throw() 用来马上抛出一个错误并返回非零值，可以和 catch 配合使用。另外 catch() 本质上并不是外部函数而是一个编译器指令。
+    - 括号表达式形式：`catch(expr)` 对 <expr> 求值。
+    - 语句块形式：`catch { statements }` 执行该语句块。
+
+    如果没有错误会返回 0，如果有标准错误，会返回一个以 `*` 开头的
+    包括错误信息的字符串。主体表达式本身的值会被丢弃。
+
+    外部函数 throw() 用来马上抛出一个错误并返回非零值，可以和 catch
+    配合使用。
+
+    在 catch 语句块中使用 `break` 或 `continue` 跳出是编译期错误。
 
     catch() 比较消耗资源，请不要随意使用，建议只用在出错时可能会造成严重问题的地方。
 
+### 示例
+
+    ```c
+    void example1() {
+        object ob ;
+        mixed err ;
+
+        err = catch( ob = load_object("/obj/weapon/sword") ) ;
+        if(err) throw("加载指定文件时出错。") ;
+    }
+
+    void example2() {
+        mixed err = catch {
+            string file, *files = ({
+                "/u/g/gesslar/one",     // 正常文件
+                "/u/g/gesslar/two",     // 有问题的文件
+                "/u/g/gesslar/three",   // 正常文件
+            }) ;
+
+            foreach(file in files) load_object(file) ;
+        } ;
+
+        if(err) printf("ERR: %O", err) ;
+    }
+
+    // ERR: "*Error in loading object '/u/g/gesslar/two'"
+    ```
+
 ### 参考
 
-    error(3), throw(3), error_handler(4)
+    error(3), throw(3), error_handler(4), time_expression(3)
 
 ### 翻译 ###
 

--- a/docs/i18n/zh-CN/docusaurus-plugin-content-docs/current/efun/internals/time_expression.md
+++ b/docs/i18n/zh-CN/docusaurus-plugin-content-docs/current/efun/internals/time_expression.md
@@ -5,16 +5,39 @@ title: internals / time_expression
 
 ### 名称
 
-    time_expression() - return the amount of real time that an expression took
+    time_expression - 返回求值一个表达式或语句块所耗费的真实时间
 
 ### 语法
 
-    int time_expression( mixed expr );
+    int time_expression( expr );
+    int time_expression { statements }
 
 ### 描述
 
-    Evaluate <expr>. The amount of real time that passed during the evaluation of <expr>, in microseconds, is returned. The precision of the value is not necessarily 1 microsecond; in fact, it probably is much less precise.
+    time_expression 是一个语言结构（编译器关键字，类似 catch），
+    而不是普通的 efun。它接受两种主体写法，与 catch 共享同一语法：
+
+    - 括号表达式形式：`time_expression(expr)` 对 <expr> 求值。
+    - 语句块形式：`time_expression { statements }` 执行该语句块。
+
+    两种形式都以 int 返回主体求值期间经过的真实（挂钟）时间，
+    单位为微秒。主体表达式本身的值会被丢弃。返回值的精度不一定
+    是 1 微秒；实际上，精度很可能低得多。
+
+    在 time_expression 语句块中使用 `break` 或 `continue` 跳出
+    是编译期错误。
+
+### 示例
+
+    ```c
+    int usec = time_expression( users() );
+
+    int usec = time_expression {
+        for (int i = 0; i < 1000; i++)
+            do_something();
+    };
+    ```
 
 ### 参考
 
-    rusage(3), function_profile(3), time(3)
+    rusage(3), function_profile(3), time(3), catch(3)


### PR DESCRIPTION
Both are compiler keywords sharing the same expr_or_block grammar production, but the pages showed only the function-call form. Document the parenthesized-expression and block forms, that the body's value is discarded, and the compile-time break/continue restriction; cross- reference the two pages. Update the zh-CN mirrors and port the catch examples to the Chinese page.