### PR TITLE
lpcshell: report runtime errors, and predefine __LPCSHELL__

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -162,3 +162,16 @@ set_tests_properties(lpcshell-errors PROPERTIES
         FAIL_REGULAR_EXPRESSION "syntax error;n=0;n=2"
         TIMEOUT 120
         LABELS "lpcshell")
+
+# lpcshell predefines __LPCSHELL__ so a mudlib can tell it is being compiled
+# for the shell rather than a live driver. It has to be visible by the time
+# the MASTER compiles -- early enough to branch on in epilog() -- which is
+# why it cannot be a master::flag() call; see single/master.lpc's epilog(),
+# which prints this marker under the guard.
+add_test(NAME lpcshell-predefine
+        COMMAND $<TARGET_FILE:lpcshell> etc/config.test lpcshell/eval.lpcs
+        WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}/testsuite")
+set_tests_properties(lpcshell-predefine PROPERTIES
+        PASS_REGULAR_EXPRESSION "LPCSHELL_PREDEFINED"
+        TIMEOUT 120
+        LABELS "lpcshell")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -129,3 +129,36 @@ set_tests_properties(testsuite PROPERTIES
         FAIL_REGULAR_EXPRESSION "\\[  FAILED  \\]"
         TIMEOUT 600
         LABELS "testsuite")
+
+# lpcshell drives the REPL binary itself in script mode against the same
+# mudlib: the wrapping it is being tested for (deciding whether typed text
+# is an expression or a statement, and reporting what happened) lives in
+# C++ in main_lpcshell.cc, so the LPC testsuite above cannot reach it.
+# `ctest -L lpcshell` runs just these.
+#
+# Both assert on OUTPUT rather than exit status -- lpcshell-errors evaluates
+# deliberately-failing statements and so exits nonzero by design, and CMake
+# ignores the exit code once PASS_REGULAR_EXPRESSION is set.
+add_test(NAME lpcshell-eval
+        COMMAND $<TARGET_FILE:lpcshell> etc/config.test lpcshell/eval.lpcs
+        WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}/testsuite")
+set_tests_properties(lpcshell-eval PROPERTIES
+        PASS_REGULAR_EXPRESSION "EVAL_OK"
+        FAIL_REGULAR_EXPRESSION "EVAL_BAD;syntax error"
+        TIMEOUT 120
+        LABELS "lpcshell")
+
+# The regression guard. A bare expression that error()s must report the
+# real message and must NOT be retried in statement form: the retry would
+# re-run whatever side effects the expression already had (asserted via
+# n=1 -- n=2 means it ran twice) and report a bogus "syntax error,
+# unexpected '}'" against the generated wrapper's closing brace, burying
+# the real error entirely.
+add_test(NAME lpcshell-errors
+        COMMAND $<TARGET_FILE:lpcshell> etc/config.test lpcshell/errors.lpcs
+        WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}/testsuite")
+set_tests_properties(lpcshell-errors PROPERTIES
+        PASS_REGULAR_EXPRESSION "error: boom"
+        FAIL_REGULAR_EXPRESSION "syntax error;n=0;n=2"
+        TIMEOUT 120
+        LABELS "lpcshell")

--- a/src/main_lpcshell.cc
+++ b/src/main_lpcshell.cc
@@ -14,8 +14,21 @@
 //     unchanged, at the cost of not sharing a persistent symbol table
 //     across statements (that would need real compiler surgery -- see the
 //     plan's open Phase 3 item). A bare expression like `1 + 1` is tried
-//     first (auto-printed, like Python); if that fails to parse, the same
+//     first (auto-printed, like Python); if that fails to PARSE, the same
 //     text is retried wrapped as a statement body instead (no auto-print).
+//     A trial that parsed and then errored at RUNTIME is never retried:
+//     the text is a valid expression, so the statement form would only
+//     re-run whatever side effects it already had and then report a bogus
+//     syntax error (a bare expression has no terminating ';' as a
+//     statement) on top of the real one.
+//
+//   - Every attempt's body is wrapped in an LPC-level catch(), so a runtime
+//     error arrives as a VALUE rather than unwinding out of the apply. It
+//     cannot be recovered any other way: error() hands the text to the
+//     mudlib's error_handler apply and then throws the generic "error
+//     handler error" (see simulate.cc), so against a mudlib that routes its
+//     errors somewhere other than stdout the REPL is left with nothing to
+//     report.
 //
 //   - Variable VALUES persist across statements via the existing
 //     save_variable()/restore_variable() efuns, called from LPC source
@@ -186,15 +199,43 @@ bool MatchSingleDeclaration(const std::string& stmt, std::string* name, std::str
   return true;
 }
 
+// Renders whatever catch() handed back. A standard error is a string with a
+// leading '*' (and usually a trailing newline) -- strip both. throw() can
+// hand back any non-zero value, though, so fall back to %O for the rest.
+std::string FormatCaughtError(svalue_t* err) {
+  if (err->type == T_STRING) {
+    std::string s = err->u.string;
+    if (!s.empty() && s[0] == '*') s.erase(0, 1);
+    while (!s.empty() && (s.back() == '\n' || s.back() == '\r')) s.pop_back();
+    return s;
+  }
+  char* formatted = string_print_formatted("%O", 1, err);
+  if (!formatted) return "runtime error";
+  std::string s = formatted;
+  FREE_MSTR(formatted);
+  return s;
+}
+
 // ---------------------------------------------------------------------------
 // Compile-and-run one attempt. Returns the applied function's result via
 // `*result` (only meaningful when `want_result` is true and this returns
-// true) and updates `session`'s saved variable values on success. Throws
-// nothing -- LPC-level errors are caught and reported via return false.
+// kOk) and updates `session`'s saved variable values on success. Throws
+// nothing -- LPC-level errors come back as kRuntimeError with the message
+// in `*error_message`.
+//
+// Distinguishing "didn't compile" from "compiled but errored" is what lets
+// Eval() decide whether retrying in another form is meaningful or merely
+// destructive; see the caller.
 // ---------------------------------------------------------------------------
 
-bool RunAttempt(Session* session, const std::string& body_src, bool want_result,
-                std::string* printed_result, std::string* error_message) {
+enum class Attempt {
+  kOk,            // compiled, ran, and returned cleanly
+  kCompileError,  // never ran: the text does not compile in this form
+  kRuntimeError,  // compiled and ran, but error()ed -- *error_message is set
+};
+
+Attempt RunAttempt(Session* session, const std::string& body_src, bool want_result,
+                   std::string* printed_result, std::string* error_message) {
   std::string name = "/lpcshell#" + std::to_string(session->counter++);
 
   // __lpcshell_snapshot() is defined FIRST and __lpcshell_eval() (which
@@ -204,8 +245,16 @@ bool RunAttempt(Session* session, const std::string& body_src, bool want_result,
   // textually follows it in the same compile unit (a bogus "unexpected
   // '}'" pointing at the next function's signature). Putting the
   // user's code last means there's nothing after it left to corrupt.
+  //
+  // body_src assigns the caught error to __lpcshell_error and (expression
+  // form only) the value to __lpcshell_value; __lpcshell_outcome() reads
+  // both back out. They are globals rather than __lpcshell_eval()'s return
+  // value so that a user-typed `return ...;` still returns from
+  // __lpcshell_eval() harmlessly, exactly as it did before.
   std::string src = session->Preamble();
+  src += "mixed __lpcshell_value, __lpcshell_error;\n";
   src += "mixed *__lpcshell_snapshot() {\n  return " + session->SnapshotExpr() + ";\n}\n";
+  src += "mixed *__lpcshell_outcome() {\n  return ({ __lpcshell_error, __lpcshell_value });\n}\n";
   src += "mixed __lpcshell_eval() {\n";
   src += session->RestoreStatements();
   src += body_src;
@@ -228,25 +277,38 @@ bool RunAttempt(Session* session, const std::string& body_src, bool want_result,
     restore_context(&econ);
     pop_context(&econ);
     *error_message = e ? e : "compile error";
-    return false;
+    return Attempt::kCompileError;
   }
   compiler_diags_quiet = false;
   pop_context(&econ);
 
   if (!ob) {
     *error_message = "compile error";
-    return false;
+    return Attempt::kCompileError;
   }
 
   current_object = ob;
   save_context(&econ);
+  Attempt outcome = Attempt::kOk;
   try {
-    svalue_t* ret = apply("__lpcshell_eval", ob, 0, ORIGIN_DRIVER);
-    if (want_result && ret) {
-      char* formatted = string_print_formatted("%O", 1, ret);
-      if (formatted) {
-        *printed_result = formatted;
-        FREE_MSTR(formatted);
+    apply("__lpcshell_eval", ob, 0, ORIGIN_DRIVER);
+
+    // The body's catch() already contained any error, so this reads back a
+    // plain value; only an uncatchable error (eval cost, too-deep
+    // recursion) reaches the handler below.
+    svalue_t* out = apply("__lpcshell_outcome", ob, 0, ORIGIN_DRIVER);
+    if (out && out->type == T_ARRAY && out->u.arr->size == 2) {
+      svalue_t* err = &out->u.arr->item[0];
+      svalue_t* val = &out->u.arr->item[1];
+      if (err->type != T_NUMBER || err->u.number != 0) {
+        outcome = Attempt::kRuntimeError;
+        *error_message = FormatCaughtError(err);
+      } else if (want_result) {
+        char* formatted = string_print_formatted("%O", 1, val);
+        if (formatted) {
+          *printed_result = formatted;
+          FREE_MSTR(formatted);
+        }
       }
     }
 
@@ -267,12 +329,12 @@ bool RunAttempt(Session* session, const std::string& body_src, bool want_result,
     pop_context(&econ);
     if (!(ob->flags & O_DESTRUCTED)) destruct_object(ob);
     *error_message = e ? e : "runtime error";
-    return false;
+    return Attempt::kRuntimeError;
   }
   pop_context(&econ);
 
   if (!(ob->flags & O_DESTRUCTED)) destruct_object(ob);
-  return true;
+  return outcome;
 }
 
 // Strips one trailing ';' (and surrounding whitespace) if present, so a
@@ -282,6 +344,19 @@ std::string StripTrailingSemicolon(std::string s) {
   size_t end = s.find_last_not_of(" \t\r\n");
   if (end != std::string::npos && s[end] == ';') {
     s.erase(end);
+  }
+  return s;
+}
+
+// The mirror image, for the statement form: `write("a"); write("b")` is a
+// perfectly good statement sequence that the user simply didn't terminate,
+// and without this it would land inside the generated block unterminated
+// and report a syntax error against the block's own closing brace. A body
+// already ending in ';' or '}' (`if (x) { ... }`) needs nothing.
+std::string EnsureTrailingSemicolon(std::string s) {
+  size_t end = s.find_last_not_of(" \t\r\n");
+  if (end != std::string::npos && s[end] != ';' && s[end] != '}') {
+    s.insert(end + 1, ";");
   }
   return s;
 }
@@ -313,40 +388,64 @@ bool Eval(Session* session, std::string stmt) {
   bool try_expression_first = !std::regex_search(stmt, statement_leader);
 
   if (try_expression_first) {
-    std::string expr_body = "return (" + StripTrailingSemicolon(stmt) + ");";
-    if (RunAttempt(session, expr_body, /*want_result=*/true, &result, &error_message)) {
-      std::cout << result << "\n";
-      return true;
+    // The user's text goes on its OWN line, so a diagnostic against it
+    // quotes the line the user actually typed at the column they typed it,
+    // rather than the generated wrapper. (It also keeps a trailing `//`
+    // comment in the input from swallowing the wrapper's closing tokens.)
+    std::string expr_body =
+        "__lpcshell_error = catch(__lpcshell_value = (\n" + StripTrailingSemicolon(stmt) + "\n));";
+    switch (RunAttempt(session, expr_body, /*want_result=*/true, &result, &error_message)) {
+      case Attempt::kOk:
+        std::cout << result << "\n";
+        return true;
+      case Attempt::kRuntimeError:
+        // It parsed and it ran -- the text IS an expression, it just
+        // errored. Retrying it as a statement would re-execute whatever
+        // side effects it already had and bury the real error under a
+        // bogus one, so report it and stop here.
+        std::cout << "error: " << error_message << "\n";
+        return false;
+      case Attempt::kCompileError:
+        // Not an expression at all. Fall through and retry as a statement.
+        // The trial's diagnostics stay unprinted (compiles run with
+        // compiler_diags_quiet, and the retry's own compile clears
+        // compiler_diags), so the doomed trial never reaches the user.
+        break;
     }
-    // Trial failed silently (compiles run with compiler_diags_quiet); the
-    // statement-form retry below clears compiler_diags via its own
-    // compile, so the doomed trial's errors never reach the user.
   }
 
   // Fall back to statement form (e.g. `if (x) write(...)`, assignments,
   // loops -- anything that isn't itself an expression).
-  if (RunAttempt(session, stmt, /*want_result=*/false, &result, &error_message)) {
-    // Success may still have produced warnings worth showing.
-    for (const auto& d : compiler_diags) {
-      if (d.is_warning) std::cout << render_diagnostic(d, isatty(1)) << "\n";
-    }
-    return true;
+  std::string stmt_body = "__lpcshell_error = catch {\n" + EnsureTrailingSemicolon(stmt) + "\n};";
+  switch (RunAttempt(session, stmt_body, /*want_result=*/false, &result, &error_message)) {
+    case Attempt::kOk:
+      // Success may still have produced warnings worth showing.
+      for (const auto& d : compiler_diags) {
+        if (d.is_warning) std::cout << render_diagnostic(d, isatty(1)) << "\n";
+      }
+      return true;
+    case Attempt::kRuntimeError:
+      std::cout << "error: " << error_message << "\n";
+      return false;
+    case Attempt::kCompileError:
+      break;
   }
 
-  // Both attempts failed. Render the FINAL attempt's structured
-  // diagnostics ourselves, clang-style with the full include/macro
-  // provenance chains (compiler_diags holds exactly the last compile's
-  // records -- each compile clears the previous one's). error_message
-  // itself stays unprinted: error()'s C++-exception unwinding path always
-  // throws the generic "error handler error", not the diagnostic text.
+  // The text compiles in neither form, so it is a genuine syntax/semantic
+  // error. Render the FINAL attempt's structured diagnostics ourselves,
+  // clang-style with the full include/macro provenance chains
+  // (compiler_diags holds exactly the last compile's records -- each
+  // compile clears the previous one's). Runtime failures never reach here:
+  // both switches above report and return on kRuntimeError.
   bool printed = false;
   for (const auto& d : compiler_diags) {
     std::cout << render_diagnostic(d, isatty(1)) << "\n";
     printed = true;
   }
   if (!printed) {
-    // No compile diagnostics: the failure was at runtime (the driver's
-    // own error logging already reported it to the console).
+    // A compile that failed without recording a diagnostic would otherwise
+    // fail mutely; error_message is all there is to go on.
+    std::cout << "error: " << error_message << "\n";
   }
   return false;
 }

--- a/src/main_lpcshell.cc
+++ b/src/main_lpcshell.cc
@@ -65,6 +65,7 @@
 #include <vector>
 
 #include "compiler/internal/compiler.h"
+#include "compiler/internal/lexer_utils.h"
 #include "mainlib.h"
 #include "vm/vm.h"
 #include "vm/internal/apply.h"
@@ -475,6 +476,21 @@ int main(int argc, char** argv) try {
 
   auto config = get_argument(0, argc, argv);
   init_main(config);
+
+  // Let the mudlib tell it is being compiled for the shell rather than for
+  // a live driver, so it can skip whatever only makes sense with players
+  // attached (boot chatter, port-bound daemons, ...).
+  //
+  // This has to be a PREDEFINE rather than a master::flag() call: the
+  // master does not exist until vm_start() loads it, and vm_start() runs
+  // preload_objects() -> master::epilog() in the same breath, so there is
+  // no window in between from which to apply to it. A predefine registered
+  // here is in place when vm_start() compiles the master -- add_predefines()
+  // (vm.cc, called from vm_start) only ever adds to the table, never clears
+  // it, so this survives. Defined to 1 so both `#ifdef __LPCSHELL__` and
+  // `#if __LPCSHELL__` work.
+  add_predefine("__LPCSHELL__", -1, "1");
+
   vm_start();
   current_object = master_ob;
 

--- a/testsuite/lpcshell/errors.lpcs
+++ b/testsuite/lpcshell/errors.lpcs
@@ -1,0 +1,6 @@
+error("boom")
+"AFTER_ERROR"
+int n;
+n = 0;
+(n = n + 1, error("bang"));
+"n=" + n

--- a/testsuite/lpcshell/eval.lpcs
+++ b/testsuite/lpcshell/eval.lpcs
@@ -1,0 +1,7 @@
+1 + 1
+int x = 5;
+x = x * 2;
+write("a\n"); write("b\n")
+1 + 1 // a trailing comment must not swallow the generated wrapper
+if(x == 10) write("ten\n");
+x == 10 ? "EVAL_OK" : "EVAL_BAD"

--- a/testsuite/single/master.lpc
+++ b/testsuite/single/master.lpc
@@ -190,6 +190,16 @@ string* epilog(int)
 {
   string *items;
 
+#ifdef __LPCSHELL__
+  // Proves lpcshell's __LPCSHELL__ predefine is already in place when the
+  // MASTER is compiled -- i.e. early enough for a mudlib to branch on it
+  // here, in epilog(), which is the whole point of it being a predefine.
+  // master::flag() cannot carry this signal: the driver only calls flag()
+  // after vm_start(), by which time epilog() has already run. Compiles to
+  // nothing under the real driver.
+  debug_message("LPCSHELL_PREDEFINED\n");
+#endif
+
   items = update_file(CONFIG_DIR + "/preload");
   return items;
 }


### PR DESCRIPTION
Two independent lpcshell fixes, one commit each.

## 1. Runtime errors were reported as a bogus syntax error

Any statement that parsed but then `error()`ed printed only this, and never the real message:

```
> mud_config("MUD.name")
/lpcshell#1:6:1: error: syntax error, unexpected '}'
    6 | }
      | ^
```

Two faults combined:

- **`RunAttempt()` returned a bare `bool`**, so `Eval()` could not distinguish *"did not compile"* from *"compiled, ran, and `error()`ed"*, and retried the latter in statement form. That retry is wrong twice over: it **re-executes side effects the expression already had**, and a bare expression has no terminating `;` as a statement, so it dies on the generated closing brace — and that bogus diagnostic is the only one the user sees.
- **The real message was unrecoverable.** `error()` hands the text to the mudlib's `error_handler` apply and then throws the generic `"error handler error"` (simulate.cc), so against a mudlib that routes errors anywhere other than stdout there was nothing left to report.

Fix: `RunAttempt()` returns `kOk`/`kCompileError`/`kRuntimeError` and a trial that reached runtime is never retried; each body is wrapped in an LPC-level `catch()` so the error arrives as a value with its real text, independent of the mudlib.

```
-  ]SIDE  ]SIDE           side effects ran twice, real error never shown
+  ]SIDE  error: bang     ran once, reported
```

The user's text is also now emitted on its **own line** in the generated source, so diagnostics quote what was actually typed at the right column instead of the wrapper. That incidentally fixes two more papercuts: a trailing `//` comment no longer swallows the wrapper's closing tokens (`1 + 1 // foo` used to be a syntax error), and an unterminated sequence like `write("a"); write("b")` now runs.

## 2. `__LPCSHELL__` predefine

A mudlib usually wants to do less under the REPL than under a live driver, but has no way to tell which is compiling it.

`master::flag()` can't carry that signal: the driver only calls `flag()` **after** `vm_start()` (mainlib.cc), and `vm_start()` runs `preload_objects()` → `master::epilog()` in the same breath (vm.cc) — so `epilog()` has already run by the time `flag()` fires, and there's no window in between to apply to (the master doesn't exist until `vm_start()` loads it).

A predefine registered before `vm_start()` is in place when the master compiles, which is early enough to branch on in `epilog()`:

```c
#ifdef __LPCSHELL__
  // no preload chatter when there's nobody to read it
#endif
```

## Tests

Three ctest entries (`ctest -L lpcshell`) driving the binary in script mode — the LPC testsuite can't reach this code, which is C++. The two error-reporting tests **fail against the unpatched binary**; `lpcshell-errors` asserts `n=1`, where `n=0` is the old lost-side-effect behaviour and `n=2` would be a double-execution regression.

The predefine test proves visibility at *master*-compile time via a marker in `single/master.lpc`'s `epilog()`. It compiles to nothing under the real driver — and the marker's **absence** from a normal driver run is itself part of the test.

Full `ctest` green (4/4), existing LPC testsuite unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GVj9t8GPkUiZYLJUyiRehD