### PR TITLE
make_options_defs: terminate "Generate Success!" with a newline

### DIFF
--- a/src/tools/make_options_defs.cc
+++ b/src/tools/make_options_defs.cc
@@ -52,6 +52,6 @@ int main(int argc, char** argv) {
   }
   file << TPL_FOOTER;
 
-  std::cout << "Generate Success!";
+  std::cout << "Generate Success!" << std::endl;
   return 0;
 }


### PR DESCRIPTION
`make_options_defs` printed `Generate Success!` without a trailing newline, so the next build-step line got glued directly onto it in the generator output:

```
Generate Success![ 49%] Generating efuns.autogen.cc, efuns.autogen.h
```

Append `std::endl` so the message ends its own line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)