### PR TITLE
docs: LPC style guide + formatter reference; for (;;) spacing fix

### DIFF
--- a/docs/i18n/zh-CN/docusaurus-plugin-content-docs/current.json
+++ b/docs/i18n/zh-CN/docusaurus-plugin-content-docs/current.json
@@ -2706,5 +2706,17 @@
   "sidebar.docs.doc.concepts/general/reference_loops": {
     "message": "Reference Loops",
     "description": "The label for the doc item 'Reference Loops' in sidebar 'docs', linking to the doc concepts/general/reference_loops"
+  },
+  "sidebar.docs.doc.Style Guide": {
+    "message": "代码风格指南",
+    "description": "The label for the doc item 'Style Guide' in sidebar 'docs', linking to the doc lpc/style-guide"
+  },
+  "sidebar.docs.doc.Formatter": {
+    "message": "格式化工具",
+    "description": "The label for the doc item 'Formatter' in sidebar 'docs', linking to the doc lpc/formatter"
+  },
+  "sidebar.docs.doc.stdlib/ffi_util": {
+    "message": "FFI 工具",
+    "description": "The label for the doc item 'FFI Utilities' in sidebar 'docs', linking to the doc stdlib/ffi_util"
   }
 }

--- a/docs/lpc/formatter.md
+++ b/docs/lpc/formatter.md
@@ -1,0 +1,141 @@
+---
+title: formatter
+---
+
+# The LPC formatter
+
+FluffOS ships a dependency-free LPC code formatter in
+`tools/lpc-syntax/` — the same grammar-driven engine that powers the
+VS Code extension's *Format Document* and the testsuite's CI format
+check. It needs only Node.js (≥ 18); there is no `npm install`.
+
+It enforces the layout half of the [LPC style guide](style-guide):
+spacing, indentation, brace placement, and wrapping — while treating
+your line-break decisions, blank lines, and comments as meaningful and
+leaving them where you put them.
+
+## Running it
+
+Over the testsuite corpus (from the repo root):
+
+```bash
+testsuite/format.sh            # format testsuite/**/*.lpc,*.c in place
+testsuite/format.sh --check    # verify only, exit 1 if unformatted (CI)
+```
+
+From your own scripts, on any file set:
+
+```bash
+find lib -name '*.lpc' | node tools/lpc-syntax/bin/format-corpus.mjs           # in place
+find lib -name '*.lpc' | node tools/lpc-syntax/bin/format-corpus.mjs --check  # verify
+```
+
+As a library:
+
+```js
+import { formatLPC } from './tools/lpc-syntax/format.mjs';
+
+const pretty = formatLPC(source);                       // defaults
+const wide = formatLPC(source, { printWidth: 120 });    // default 100
+const four = formatLPC(source, { indentSize: 4 });      // default 2
+```
+
+In VS Code, the extension under `tools/lpc-syntax/vscode/` provides
+*Format Document* and format-on-save with the same engine, configured
+by `lpc.format.printWidth` (default 100) and `lpc.format.indentSize`
+(default 2).
+
+## Options
+
+| Option | Default | Meaning |
+|---|---|---|
+| `printWidth` | `100` | Preferred maximum line length. Matches `ColumnLimit` in `src/.clang-format`, so LPC and the driver's C++ wrap at the same column. |
+| `indentSize` | `2` | Spaces per indent level. Matches the C++ `IndentWidth`. |
+
+## What it normalizes
+
+* Indentation (brace depth, `case` labels, wrapped continuations) and
+  trailing whitespace.
+* Token spacing per the [style guide's spacing table](style-guide#spaces):
+  control-flow vs call parens, operators, casts, unary tightness,
+  literal padding — `({ 1, 2 })`, `([ "a": 1 ])`, `(: f :)` — index
+  and mapping colons, label colons, and the rest.
+* Empty blocks collapse to `{}`.
+* Trailing `//` comments get at least two spaces before them; a wider
+  hand-aligned gap is kept exactly.
+* Preprocessor directives move to column 0.
+* A rendered line longer than `printWidth` is split at its outermost
+  bracket group (call arguments, array/mapping elements), one element
+  per line, recursively as needed.
+
+## What it preserves
+
+The formatter follows the source instead of canonicalizing both ways —
+the opposite of clang-format's full reflow:
+
+* **Your line breaks.** A one-line block stays one line (if it fits);
+  a multi-line call or declaration keeps its layout, including whether
+  the closing `)` / `");` / `});` is glued to the last element or on
+  its own line; a brace-less `if` body on its own line stays there.
+* **Blank lines**, exactly as written — including runs of more than
+  one.
+* **Comments.** Never moved to another line, never re-wrapped, never
+  allowed to force the code before them to wrap. Content is untouched.
+* **Literal content, byte for byte.** Strings, `` ` ``-templates,
+  `@TEXT` heredocs, and char literals are never split, re-indented, or
+  re-spaced internally — a heredoc's body and terminator lines are
+  reproduced verbatim (only its `;` placement on the terminator line
+  follows the source).
+* **Stringized macro arguments.** `#define STR(x) #x` bakes the
+  argument's source spelling into a string at compile time, so the
+  formatter detects stringizing macros (mirroring the driver's own
+  preprocessing rules, including `#`-run parity and `\`-continuations)
+  and freezes the matching call-site arguments verbatim —
+  `STR(1+2)` keeps stringizing to `"1+2"`, never `"1 + 2"`.
+* **CRLF sources stay CRLF.**
+
+One known limitation: an unbracketed, non-string expression
+continuation (`return a +` newline `b;` with no parentheses) collapses
+onto one line — tracking that break for arbitrary expressions would
+need a full expression parser, which the token-driven design
+deliberately avoids. Parenthesize the continuation if the break
+matters.
+
+## Safety guarantees
+
+Every write through `format.sh` / `format-corpus.mjs` is gated; a file
+that would violate any of these is reported, left untouched, and the
+run exits nonzero:
+
+1. **Token-sequence equivalence** — the output re-tokenizes to exactly
+   the input's token kinds and spellings; the formatter cannot change
+   what the compiler sees.
+2. **Literal byte-identity** — every string/template/heredoc/char/
+   comment/directive token's content is byte-identical.
+3. **Idempotency** — formatting the output again reproduces it
+   exactly.
+
+Deliberately malformed fixtures that are not valid text (the two
+raw-byte bad-UTF-8 compiler fixtures under
+`testsuite/single/tests/compiler/fail/`) are excluded by
+`testsuite/format.sh`; anything the tokenizer cannot fully understand
+is refused rather than guessed at.
+
+Beyond the built-in gates, formatter changes are validated against the
+real driver: the whole reformatted testsuite must still pass
+`driver etc/config.test -ftest`. That end-to-end check exists because
+a token-level self-check cannot catch a bug that lives in the
+tokenizer itself — see `tools/lpc-syntax/README.md` for the full
+methodology.
+
+## Relation to the C++ style
+
+The driver's C++ is formatted by clang-format (`src/.clang-format`:
+Google base, 2-space indent, 100 columns). The LPC formatter matches
+it on every language-common rule — indent, column limit, brace
+attachment, keyword/call paren spacing, operator spacing, tight casts,
+indented case labels, two-space trailing comments — and diverges only
+where LPC is genuinely different (`string *arr` array markers, padded
+`({ })` / `([ ])` literals, call-tight `catch(` / `new(`, spaced
+`(: :)` bounds) or where hand-shaped layout carries intent (no line
+reflow). The full comparison lives in `tools/lpc-syntax/README.md`.

--- a/docs/lpc/index.md
+++ b/docs/lpc/index.md
@@ -5,6 +5,8 @@ title: lpc
 
 * [source files & object names](source-files)
 * [compiler diagnostics](diagnostics)
+* [style guide](style-guide)
+* [formatter](formatter)
 ## constructs
 * [for](constructs/for)
 * [function](constructs/function)

--- a/docs/lpc/style-guide.md
+++ b/docs/lpc/style-guide.md
@@ -1,0 +1,236 @@
+---
+title: style guide
+---
+
+# LPC style guide
+
+This is the house style for LPC code in the FluffOS tree (the
+`testsuite/` mudlib and example code), and a sane default for any
+mudlib. It follows the same philosophy as the
+[Google C++ Style Guide](https://google.github.io/styleguide/cppguide.html)
+that the driver's own C++ sources are formatted to (`src/.clang-format`:
+Google base, 2-space indent, 100-column limit), with widely-used
+community C rules (cf. [MaJerle/c-code-style](https://github.com/MaJerle/c-code-style))
+adapted where LPC differs from C.
+
+Two principles come before every specific rule:
+
+1. **Optimize for readers, not writers.** Code is read far more often
+   than it is written; a rule earns its place by making the next read
+   cheaper.
+2. **Imitate the surrounding code.** When editing an existing file,
+   consistency with what is already there beats this document. (This is
+   also the single most important rule of MaJerle's C guide.)
+
+The *layout* rules below are machine-enforced by the
+[LPC formatter](formatter) — run `testsuite/format.sh` and they are
+applied for you; CI rejects unformatted testsuite code. The *naming and
+practice* rules are judgment calls the formatter deliberately does not
+touch.
+
+## Layout (formatter-enforced)
+
+### Indentation and line length
+
+* **2 spaces** per indent level. Never tabs.
+* **100 columns** maximum, matching the driver's C++ `ColumnLimit`.
+  Long statements are wrapped at the outermost bracket group, one
+  element per line. Three things are exempt because splitting them
+  changes program behavior or meaning: string/template/heredoc
+  literals, comments, and a trailing comment's line.
+* Preprocessor directives start at **column 0**, never indented.
+
+### Braces
+
+K&R style everywhere — the opening brace shares the line of its
+declaration or keyword, `else` and a `do`-loop's `while` cuddle the
+closing brace:
+
+```c
+int find(string name) {
+  if (!name) {
+    return -1;
+  } else {
+    return lookup(name);
+  }
+}
+
+do {
+  step();
+} while (more());
+```
+
+* A genuinely empty block collapses to `{}` — `void create() {}`.
+* Braces are *recommended* for every control-flow body, but a
+  single-statement body on its own line may omit them:
+
+```c
+if (!raw)
+  return mask[0];
+```
+
+### Spaces
+
+| Context | Rule | Example |
+|---|---|---|
+| Control-flow keyword before `(` | one space | `if (x)`, `while (x)`, `for (;;)`, `foreach (v in arr)`, `return (x)` |
+| Call before `(` | tight | `write(msg)`, `funcs[0](5, 5)`, `f(a)(b)` |
+| Call-like keywords | tight | `catch(err)`, `new("/obj")` |
+| Inside `( )` | no padding | `f(a, b)`, not `f( a, b )` |
+| Binary operators, assignments | one space each side | `a = b + c * d`, `a >>= 2` |
+| Ternary | spaced | `a ? b : c` |
+| Unary operators | tight to operand | `-a`, `!ok`, `~bits`, `++i`, `i++` |
+| Comma / semicolon | tight before, space after | `f(a, b)`; `for (i = 0; i < n; i++)` |
+| Cast | tight to operand | `(string)x`, `(mixed *)arr`, `return (int)v` |
+| Index | tight | `arr[0]`, `m["key"]`, `s[1..<2]` |
+| `->`, qualified `::` | tight | `ob->query()`, `efun::write()` |
+| Array declaration `*` | binds to the name | `string *names`, `int *fn(mixed *args)` |
+| Array literal | inner padding | `({ 1, 2, 3 })`, empty `({})` |
+| Mapping literal | inner padding, tight key colon | `([ "a": 1, "b": 2 ])`, empty `([])` |
+| Functional literal | spaced bounds | `(: f :)`, `(: $1 + $2 :)` |
+| Default-argument colon | tight before | `void f(int a, string b: (: "x" :))` |
+| Spread | tight after the expression | `f(args...)`, but bare `f(int a, ...)` |
+| Label colons | tight | `case 1:`, `default:`, `private:` |
+| Trailing `//` comment | at least two spaces off the code | `return 1;  // why` |
+
+Two of these are deliberate departures from the C++ config, because the
+constructs mean something different in LPC:
+
+* `string *names` — LPC's `*` is the **array marker**, not a pointer,
+  and mudlib code overwhelmingly binds it to the name (the driver's C++
+  uses `PointerAlignment: Left`, `type* name`).
+* `({ ... })` / `([ ... ])` keep inner padding where C++ brace-init
+  lists are tight — the delimiters are two characters wide and the
+  padding keeps the pairs legible.
+
+### Case labels
+
+`case` and `default` indent one level inside the `switch`, bodies one
+more (Google `IndentCaseLabels`):
+
+```c
+switch (x) {
+  case 1:
+    handle_one();
+    break;
+  case LOW..HIGH:  // LPC range label
+    handle_range();
+    break;
+  default:
+    handle_rest();
+}
+```
+
+### Line breaks follow the source
+
+Unlike clang-format, the formatter does **not** re-decide your line
+breaks; it preserves the shape you wrote (and only splits a line when
+it exceeds the column limit):
+
+* A block you wrote on one line stays on one line if it fits:
+  `void event_ping(object from, int v) { origin = from; value = v + 1; }`
+* A call or declaration you split across lines keeps that layout,
+  including where you put the close — a `");` glued to the last
+  argument stays glued; `});` sticks to the closing brace of a
+  functional or inline block argument.
+* Blank-line runs are preserved exactly; use them to group related
+  statements (and one blank line between functions).
+* A comment never moves to another line, and a trailing comment never
+  causes the code before it to wrap.
+
+Layout carries intent in hand-written test code; the formatter treats
+it as meaningful.
+
+## Naming
+
+Measured against the testsuite corpus, LPC's dominant conventions are
+C-flavored (they differ from Google C++'s `CapitalizedWords`
+deliberately — LPC identifiers are historically lowercase):
+
+| Entity | Convention | Example |
+|---|---|---|
+| Functions, applies, efun overrides | `lower_snake_case` | `query_name()`, `do_tests()` |
+| Local & global variables | `lower_snake_case` | `save_file`, `num_users` |
+| Macros / `#define` constants | `ALL_CAPS_WITH_UNDERSCORES` | `MAX_USERS`, `TUI_ANSI` |
+| Source files | `lower_snake_case.lpc` | `hot_reload.lpc` |
+| Classes | lowercase or `Capitalized` — be consistent per file | `class point`, `class Counter` |
+| Include files | `lower_snake_case.h` | `tests.h` |
+
+* Don't invent Hungarian prefixes or `m_`-style member markers; LPC
+  objects are small enough that plain names with `private` do the job.
+* Name a thing for what it is, not its type: `users`, not
+  `user_array`.
+
+## Visibility and structure
+
+* **`private` by default.** Global variables and helper functions that
+  aren't part of the object's interface should be `private` (the
+  corpus uses `private` over `public` more than 20:1). Reserve
+  `nomask` for security-critical functions that inheritors must not
+  override.
+* Declare locals in the **narrowest scope** that works, and initialize
+  at the point of declaration. FluffOS allows declarations after
+  statements — prefer declaring where the value first exists over a
+  C89-style block of declarations at the top.
+* One declaration per line when the initializers matter; grouping
+  uninitialized same-type locals on one line (`int i, j, n;`) is fine.
+* Prefer `foreach (member in aggregate)` over an indexed `for` loop
+  when you don't need the index.
+* Always give a `switch` a `default:` when it isn't exhaustive by
+  construction.
+* Prefer returning values over writing through `ref` parameters; use
+  `ref` when the caller genuinely needs multiple results mutated in
+  place.
+
+## Comments
+
+* `//` for line comments and trailing notes; `/* ... */` for longer
+  block comments. (Unlike MaJerle's C rule — which bans `//` for C89
+  compatibility — LPC has always had both; use whichever reads best.)
+* Comment the **why**, not the what. A comment that restates the next
+  line is noise; a comment that records a constraint the code can't
+  express is gold.
+* Trailing comments sit at least two spaces off the code. If you align
+  a column of trailing comments by hand, the formatter preserves your
+  alignment.
+
+## Preprocessor practice
+
+These C rules apply to LPC's preprocessor unchanged:
+
+* Parenthesize macro parameters and the whole expansion:
+  `#define SQUARE(x) ((x) * (x))`.
+* Wrap multi-statement macros in `do { ... } while (0)` so they behave
+  as one statement under `if`/`else`.
+* Guard include files with `#ifndef NAME_H` / `#define NAME_H` /
+  `#endif`.
+* Prefer `#if defined(XYZ)` over `#ifdef XYZ` when the condition may
+  grow more terms.
+* Tests and optional-package code guard themselves with the package
+  conditionals: `#ifdef __PACKAGE_ASYNC__`.
+
+One LPC-specific caution: a macro that *stringizes* a parameter
+(`#define STR(x) #x`) bakes the argument's exact source spelling into
+program output — `STR(1+2)` is the string `"1+2"`. The formatter
+detects this and never re-spaces such arguments, but be aware of it
+when writing them by hand.
+
+## Error handling
+
+* `catch(...)` returns the error or `0` — always check or consciously
+  discard it. Use `error("message")` (not raw `throw`) to raise.
+* Never build a format string from untrusted input; pass it as an
+  argument instead: `printf("%s", player_text)`.
+
+## Enforcement
+
+```bash
+testsuite/format.sh            # format the corpus in place
+testsuite/format.sh --check    # verify only; CI runs this
+```
+
+The formatter refuses to write any file whose output isn't
+token-equivalent to the input, literal-byte-identical, and idempotent,
+so running it is always safe. See the [formatter documentation](formatter)
+for options, editor integration, and exactly what it does and does not
+change.

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -30,6 +30,8 @@ const sidebars: SidebarsConfig = {
       items: [
         { type: 'doc', id: 'lpc/source-files', label: 'Source Files & Object Names' },
         { type: 'doc', id: 'lpc/diagnostics', label: 'Compiler Diagnostics' },
+        { type: 'doc', id: 'lpc/style-guide', label: 'Style Guide' },
+        { type: 'doc', id: 'lpc/formatter', label: 'Formatter' },
         {
           type: 'category',
           label: 'Types',

--- a/tools/lpc-syntax/format.mjs
+++ b/tools/lpc-syntax/format.mjs
@@ -1423,11 +1423,19 @@ function renderLine(toks, mappingContext = false, pendingTernary = 0) {
       const srcGap = (t.line === prev.line && t.start > prev.end) ? t.start - prev.end : 1;
       sep = ' '.repeat(Math.max(min, srcGap));
     }
-    // ...except after another ';' or before an empty clause's ')' -- the
-    // pristine corpus spaces empty for-header clauses (`for (i = 0; ;
-    // i++)`, `for (...; i < len; )`, 6:0).
+    // ...except after another ';' when the header around it has real
+    // content -- the pristine corpus spaces a partially-empty
+    // for-header's empty clauses (`for (i = 0; ; i++)`,
+    // `for (x = 1; ; )`, 6:0) but writes the FULLY-empty header tight
+    // (`for (;;)`, its only corpus spelling, and clang-format's): tight
+    // whenever everything back to the opening '(' is semicolons.
     else if (NO_SPACE_BEFORE.has(t.text) &&
-             !((t.text === ';' || t.text === ')') && prev && prev.text === ';')) sep = '';
+             !((t.text === ';' || t.text === ')') && prev && prev.text === ';' &&
+               !(() => {
+                 let j = i - 1;
+                 while (j >= 0 && toks[j].text === ';') j--;
+                 return j >= 0 && toks[j].text === '(';
+               })())) sep = '';
     // '++'/'--' are tight-before only in POSTFIX position -- the previous
     // token must actually end an expression (`i++`, `a[0]--`, `f()++`).
     // In prefix position they keep the normal space (`return ++count;`,

--- a/tools/lpc-syntax/test.mjs
+++ b/tools/lpc-syntax/test.mjs
@@ -885,6 +885,49 @@ check('clang-format parity: SpacesBeforeTrailingComments -- a trailing'
         const mid = 'int f() {\n  h(/* mid */ 1);  // tail\n}\n';
         return formatLPC(mid) === mid && formatLPC(formatLPC(mid)) === mid;
       })());
+check('docs/lpc/style-guide.md contract: every spelling the style guide'
+      + ' documents is a fixed point of the formatter (spacing table,'
+      + ' brace/switch examples, fully-empty `for (;;)` tight vs'
+      + ' partially-empty `for (i = 0; ; i++)`/`for (x = 1; ; )` spaced'
+      + ' -- the corpus\'s and clang-format\'s split), so the published'
+      + ' docs and the engine cannot drift apart',
+      (() => {
+        const fixedPoints = [
+          'int find(string name) {\n  if (!name) {\n    return -1;\n  } else {\n    return lookup(name);\n  }\n}\n',
+          'void f() {\n  do {\n    step();\n  } while (more());\n}\n',
+          'void create() {}\n',
+          'void f() { if (x) g(); while (x) g(); foreach (v in arr) g(v); }\n',
+          'void f() { for (;;) g(); }\n',
+          'void f() { for (i = 0; ; i++) g(); }\n',
+          'void f() { for (x = 1; ; ) g(); }\n',
+          'void f() { for (; i < n; i++) g(); }\n',
+          'int f() { return (x); }\n',
+          'void f() { write(msg); funcs[0](5, 5); x = f(a)(b); }\n',
+          'void f() { err = catch(g()); ob = new("/obj"); }\n',
+          'void f() { a = b + c * d; a >>= 2; x = a ? b : c; }\n',
+          'void f() { x = -a; y = !ok; z = ~bits; ++i; i++; }\n',
+          'void f() { x = (string)x; y = (mixed *)arr; }\n',
+          'int f() { return (int)v; }\n',
+          'void f() { x = arr[0]; y = m["key"]; z = s[1..<2]; }\n',
+          'void f() { ob->query(); efun::write("x"); }\n',
+          'string *names;\nint *fn(mixed *args) { return args; }\n',
+          'int *a = ({ 1, 2, 3 });\nint *b = ({});\n',
+          'mapping m = ([ "a": 1, "b": 2 ]);\nmapping n = ([]);\n',
+          'function g = (: f :);\nfunction h = (: $1 + $2 :);\n',
+          'void f(int a, string b: (: "x" :)) {}\n',
+          'void f() { g(args...); }\nvoid h(int a, ...) {}\n',
+          'int f() {\n  return 1;  // why\n}\n',
+          'void f(int x) {\n  switch (x) {\n    case 1:\n      handle_one();\n      break;\n    case LOW..HIGH:  // LPC range label\n      handle_range();\n      break;\n    default:\n      handle_rest();\n  }\n}\n',
+          'void event_ping(object from, int v) { origin = from; value = v + 1; }\n',
+          'int f(int raw) {\n  if (!raw)\n    return mask[0];\n  return 0;\n}\n',
+        ];
+        for (const src of fixedPoints) {
+          const out = formatLPC(src);
+          if (out !== src || formatLPC(out) !== out) return false;
+        }
+        return formatLPC('void f() { for (; ; ) g(); }\n') === 'void f() { for (;;) g(); }\n' &&
+               formatLPC('void f() { for (i = 0;; i++) g(); }\n') === 'void f() { for (i = 0; ; i++) g(); }\n';
+      })());
 check("a default-argument colon is tight after the parameter name"
       + ' (`string b: (: "str" :)` -- every pristine-corpus site), while'
       + ' ternary colons in argument lists keep their space',

--- a/tools/lpc-syntax/vscode/lib/format.mjs
+++ b/tools/lpc-syntax/vscode/lib/format.mjs
@@ -1426,11 +1426,19 @@ function renderLine(toks, mappingContext = false, pendingTernary = 0) {
       const srcGap = (t.line === prev.line && t.start > prev.end) ? t.start - prev.end : 1;
       sep = ' '.repeat(Math.max(min, srcGap));
     }
-    // ...except after another ';' or before an empty clause's ')' -- the
-    // pristine corpus spaces empty for-header clauses (`for (i = 0; ;
-    // i++)`, `for (...; i < len; )`, 6:0).
+    // ...except after another ';' when the header around it has real
+    // content -- the pristine corpus spaces a partially-empty
+    // for-header's empty clauses (`for (i = 0; ; i++)`,
+    // `for (x = 1; ; )`, 6:0) but writes the FULLY-empty header tight
+    // (`for (;;)`, its only corpus spelling, and clang-format's): tight
+    // whenever everything back to the opening '(' is semicolons.
     else if (NO_SPACE_BEFORE.has(t.text) &&
-             !((t.text === ';' || t.text === ')') && prev && prev.text === ';')) sep = '';
+             !((t.text === ';' || t.text === ')') && prev && prev.text === ';' &&
+               !(() => {
+                 let j = i - 1;
+                 while (j >= 0 && toks[j].text === ';') j--;
+                 return j >= 0 && toks[j].text === '(';
+               })())) sep = '';
     // '++'/'--' are tight-before only in POSTFIX position -- the previous
     // token must actually end an expression (`i++`, `a[0]--`, `f()++`).
     // In prefix position they keep the normal space (`return ++count;`,


### PR DESCRIPTION
Follow-up to #1270 (the LPC formatter and testsuite reformat).

## Docs

Adds two hand-authored pages to the **LPC Language** docs tree (wired into `sidebars.ts` and `lpc/index.md`; zh-CN sidebar keys rescaffolded and the new labels translated):

- **`docs/lpc/style-guide.md`** — the LPC house style. Grounded in the Google C++ Style Guide (the base of the driver's own `src/.clang-format`) and MaJerle's community C style guide, adapted where LPC differs, with conventions measured from the testsuite corpus. Split into the formatter-enforced layout layer (indent, 100-column limit, K&R braces, the full spacing table, case labels, follow-the-source line breaks) and the judgment layer (naming, visibility, comments, preprocessor and error-handling practice).
- **`docs/lpc/formatter.md`** — user-facing formatter reference: running it (`testsuite/format.sh`, `bin/format-corpus.mjs` on arbitrary file sets, the `formatLPC()` API, VS Code settings), the options and why their defaults mirror `src/.clang-format`, the normalize-vs-preserve contract, the three write gates (token-sequence equivalence, literal byte-identity, idempotency), the known unbracketed-continuation limitation, and the relation to the C++ style.

## Formatter fix

Verifying the formatter against every rule the docs state surfaced one real discrepancy, fixed here: the empty-for-clause spacing rule was spacing the **fully**-empty header (`for (; ; )`). The pristine corpus and clang-format both write that form tight; partially-empty headers keep their spaced empty clauses. `for (;;)` now renders tight while `for (i = 0; ; i++)` and `for (x = 1; ; )` are unchanged (tight only when everything back to the opening `(` is semicolons). No corpus file changes shape — the corpus's only `for(;;)` sits inside a comment.

## Docs contract test

`test.mjs` gains a "docs contract" battery: 27 fixed-point spellings taken verbatim from the style guide plus the normalization cases, so a formatter change that breaks a documented rule — or a doc edit that misstates the formatter — fails the suite. `vscode/lib/format.mjs` is the regenerated copy.

## Validation

- `node tools/lpc-syntax/test.mjs` green (172 checks)
- `testsuite/format.sh --check` clean on the current corpus
- corpus-wide token/literal/idempotency and width-sweep harnesses clean
- full two-locale Docusaurus build with no broken links

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HSL1G3iHXu1dd8XhnBQ2fe

---
_Generated by [Claude Code](https://claude.ai/code/session_01HSL1G3iHXu1dd8XhnBQ2fe)_