### PR TITLE
lpcc: JSON-native stage outputs, wasm lpcc, disassembler fixes

### DIFF
--- a/.github/actions/build-wasm/action.yml
+++ b/.github/actions/build-wasm/action.yml
@@ -81,3 +81,14 @@ runs:
     - name: Run LPC testsuite in the wasm driver
       shell: bash
       run: node tools/wasm/run-testsuite.js
+
+    # The wasm lpcc (NODERAWFS node CLI, shipped by the fluffos-vscode
+    # extension): compile a real testsuite file and check the --json
+    # tokens envelope comes back.
+    - name: Smoke-test wasm lpcc
+      shell: bash
+      run: |
+        cd testsuite
+        node ../build-wasm/src/lpcc.js --json --tokens etc/config.test single/tests/efuns/dual_extension.lpc \
+          | grep -q '"fluffos_lpcc"'
+        echo "wasm lpcc OK"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -270,6 +270,7 @@ jobs:
           ASSET_NAME="fluffos-${VERSION}-wasm.zip"
           STAGE=$(mktemp -d)
           cp build-wasm/src/fluffos.js build-wasm/src/fluffos.wasm "$STAGE/"
+          cp build-wasm/src/lpcc.js build-wasm/src/lpcc.wasm "$STAGE/"
           cp src/www/wasm/index.html "$STAGE/"
           cp src/www/telnet.js "$STAGE/"
           cp -r src/www/vendor "$STAGE/"

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -166,7 +166,7 @@
     {
       "name": "wasm",
       "configurePreset": "wasm",
-      "targets": ["driver-web"]
+      "targets": ["driver-web", "lpcc-web"]
     }
   ]
 }

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -812,6 +812,27 @@ if (EMSCRIPTEN)
     "-g0"
     "--profiling-funcs"
   )
+
+  # lpcc for node: the compiler front-end (diagnostics + -E/--tokens/--ast/
+  # -O0/--json stage outputs) as a plain node CLI program. NODERAWFS maps
+  # the wasm FS straight onto the host filesystem, so
+  # `node lpcc.js <config> <file>` behaves exactly like the native binary
+  # -- this is the artifact the fluffos-vscode extension ships so its
+  # Compiler Explorer and save-time diagnostics need no native build.
+  add_executable(lpcc-web "main_lpcc.cc")
+  target_link_libraries(lpcc-web PUBLIC ${FLUFFOS_LINK})
+  set_target_properties(lpcc-web PROPERTIES OUTPUT_NAME "lpcc" SUFFIX ".js")
+  target_link_options(lpcc-web PRIVATE
+    "SHELL:-s ALLOW_MEMORY_GROWTH=1"
+    "SHELL:-s INITIAL_MEMORY=64MB"
+    "${FLUFFOS_WASM_STACK_FLAG}"
+    "SHELL:-s NODERAWFS=1"
+    "SHELL:-s ENVIRONMENT=node"
+    "SHELL:-s EXIT_RUNTIME=1"
+    # Same DWARF note as driver-web: keep names, drop debug sections.
+    "-g0"
+    "--profiling-funcs"
+  )
 else ()
   add_executable(driver "main.cc")
   target_link_libraries(driver PUBLIC ${FLUFFOS_LINK})

--- a/src/compiler/internal/compiler.cc
+++ b/src/compiler/internal/compiler.cc
@@ -2770,6 +2770,9 @@ static program_t* epilog(void) {
     dump_tree(comp_trees[TREE_INIT]);
     printf("\n");
   }
+  if (g_compile.opt_dump_ast_json) {
+    dump_program_ast_json(g_compile.filename, comp_trees[TREE_MAIN], comp_trees[TREE_INIT]);
+  }
   generate(comp_trees[TREE_MAIN]);
   // DEBUG:
   // dump_tree(comp_trees[TREE_MAIN]);

--- a/src/compiler/internal/compiler.h
+++ b/src/compiler/internal/compiler.h
@@ -382,6 +382,10 @@ struct CompileState {
   // codegen; compile with the tree optimizer disabled (PRAGMA_OPTIMIZE
   // cleared) so dump_prog shows PRE-optimization bytecode.
   bool opt_dump_ast = false;
+  // lpcc --ast --json: same dump point, machine-readable one-line
+  // {"fluffos_lpcc":1,"stage":"ast",...} envelope with per-node source
+  // lines (the S-expression form carries no positions).
+  bool opt_dump_ast_json = false;
   bool opt_no_optimize = false;
 
   // Set to 2 when a class declaration body completes, decremented as each

--- a/src/compiler/internal/disassembler.cc
+++ b/src/compiler/internal/disassembler.cc
@@ -7,8 +7,23 @@
 #include "compiler/internal/icode.h"
 
 #include <fmt/format.h>
+#include <nlohmann/json.hpp>
 
-static void disassemble(FILE* f /*f*/, char* code /*code*/, int /*start*/ start, int /*end*/ end,
+// --------------------------------------------------------------------------
+// JSON-native dumps: the ONE opcode switch in disassemble() emits through a
+// DisSink with two backends -- text (the exact legacy dump format) and a
+// nlohmann::json model (lpcc --json bytecode envelope). There is no second
+// decoder to drift; the text output is a rendering of the same emissions.
+// --------------------------------------------------------------------------
+struct DisSink {
+  FILE* f = nullptr;             // text backend (legacy format) when non-null
+  nlohmann::json* fns = nullptr; // json backend: array of function objects
+  nlohmann::json* cur = nullptr; // current function's "instructions" array
+  const char* src_file = nullptr;  // current source position (json rows
+  int src_line = 0;                // carry it natively, no trailing annots)
+};
+
+static void disassemble(DisSink& sink, char* code /*code*/, int /*start*/ start, int /*end*/ end,
                         program_t* prog /*prog*/);
 static const char* disassem_string(const char* /*str*/);
 static int short_compare(const void* /*a*/, const void* /*b*/);
@@ -55,7 +70,9 @@ void dump_prog_details(program_t* prog, FILE* f, int flags) {
 
   if (flags & 1) {
     fprintf(f, "DISASSEMBLY:\n");
-    disassemble(f, prog->program, 0, prog->program_size, prog);
+    DisSink sink;
+    sink.f = f;
+    disassemble(sink, prog->program, 0, prog->program_size, prog);
   } else {
     fprintf(f, "PROGRAM:");
     for (i = 0; i < prog->program_size; i++) {
@@ -80,9 +97,92 @@ void dump_prog_details(program_t* prog, FILE* f, int flags) {
  * 1 - do disassembly
  * 2 - dump line number table
  */
+// One row of the FUNCTIONS table, computed once for the text and json
+// renderers (single source for the flag-char encodings).
+struct FnTabRow {
+  int index;
+  const char* name;
+  bool inherited;
+  char smods[4];
+  char sflags[8];
+  // inherited kind:
+  int inh_low = 0, inh_fio = 0, inh_vio = 0;
+  // defined kind:
+  int offset = 0, locals = 0, args = 0, def_args = 0;
+  std::string defmap;
+};
+
+static void fn_table_rows(program_t* prog, std::vector<FnTabRow>& rows) {
+  int num_funcs_total = prog->last_inherited + prog->num_functions_defined;
+  for (int i = 0; i < num_funcs_total; i++) {
+    FnTabRow r;
+    int flags;
+    int runtime_index;
+    function_t* func_entry = find_func_entry(prog, i);
+    int low, high, mid;
+
+    r.index = i;
+    r.name = func_entry->funcname;
+
+    flags = prog->function_flags[i];
+    if (flags & FUNC_ALIAS) {
+      runtime_index = flags & ~FUNC_ALIAS;
+      r.sflags[4] = 'a';
+    } else {
+      runtime_index = i;
+      r.sflags[4] = '-';
+    }
+
+    flags = prog->function_flags[runtime_index];
+
+    r.smods[0] = (flags & DECL_HIDDEN) ? '-' : '-';
+    r.smods[0] = (flags & DECL_PRIVATE) ? 'p' : '-';
+    r.smods[0] = (flags & DECL_PROTECTED) ? 'P' : '-';
+    r.smods[0] = (flags & DECL_PUBLIC) ? '+' : '-';
+    r.smods[1] = (flags & DECL_NOMASK) ? 'm' : '-';
+    r.smods[2] = (flags & DECL_NOSAVE) ? 's' : '-';
+    r.smods[3] = '\0';
+
+    r.sflags[0] = (flags & FUNC_INHERITED) ? 'i' : '-';
+    r.sflags[1] = (flags & FUNC_UNDEFINED) ? 'u' : '-';
+    r.sflags[2] = (flags & FUNC_STRICT_TYPES) ? 's' : '-';
+    r.sflags[3] = (flags & FUNC_PROTOTYPE) ? 'p' : '-';
+    r.sflags[5] = (flags & FUNC_TRUE_VARARGS) ? 'V' : '-';
+    r.sflags[6] = (flags & FUNC_VARARGS) ? 'v' : '-';
+    r.sflags[7] = '\0';
+
+    r.inherited = (flags & FUNC_INHERITED) != 0;
+    if (r.inherited) {
+      low = 0;
+      high = prog->num_inherited - 1;
+      while (high > low) {
+        mid = (low + high + 1) / 2;
+        if (prog->inherit[mid].function_index_offset > runtime_index) {
+          high = mid - 1;
+        } else {
+          low = mid;
+        }
+      }
+      r.inh_low = low;
+      r.inh_fio = runtime_index - prog->inherit[low].function_index_offset;
+      r.inh_vio = prog->inherit[low].variable_index_offset;
+    } else {
+      r.offset = runtime_index - prog->last_inherited;
+      r.locals = func_entry->num_local;
+      r.args = func_entry->num_arg;
+      r.def_args = func_entry->num_arg - func_entry->min_arg;
+      for (int j = 0; j < func_entry->num_arg; j++) {
+        if (func_entry->default_args_findex[j] != 0) {
+          r.defmap += fmt::format(FMT_STRING(" {}:{}"), j, func_entry->default_args_findex[j]);
+        }
+      }
+    }
+    rows.push_back(std::move(r));
+  }
+}
+
 void dump_prog(program_t* prog, FILE* f, int flags) {
   int i;
-  int num_funcs_total;
 
   fprintf(f, "NAME: /%s\n", prog->filename);
   fprintf(f, "INHERITS:\n");
@@ -100,71 +200,16 @@ void dump_prog(program_t* prog, FILE* f, int flags) {
   fprintf(f,
           "      ------------------------- ------  ----  -------  ---  --- --------  ------ "
           "----------\n");
-  num_funcs_total = prog->last_inherited + prog->num_functions_defined;
-
-  for (i = 0; i < num_funcs_total; i++) {
-    char sflags[8];
-    int flags;
-    int runtime_index;
-    function_t* func_entry = find_func_entry(prog, i);
-    int low, high, mid;
-
-    flags = prog->function_flags[i];
-    if (flags & FUNC_ALIAS) {
-      runtime_index = flags & ~FUNC_ALIAS;
-      sflags[4] = 'a';
+  std::vector<FnTabRow> rows;
+  fn_table_rows(prog, rows);
+  for (const auto& r : rows) {
+    if (r.inherited) {
+      fprintf(f, "%4d: %-24s  %6d  %4s  %7s  %3d %3d\n", r.index, r.name, r.inh_low, r.smods,
+              r.sflags, r.inh_fio, r.inh_vio);
     } else {
-      runtime_index = i;
-      sflags[4] = '-';
-    }
-
-    flags = prog->function_flags[runtime_index];
-
-    char smods[4];
-    smods[0] = (flags & DECL_HIDDEN) ? '-' : '-';
-    smods[0] = (flags & DECL_PRIVATE) ? 'p' : '-';
-    smods[0] = (flags & DECL_PROTECTED) ? 'P' : '-';
-    smods[0] = (flags & DECL_PUBLIC) ? '+' : '-';
-    smods[1] = (flags & DECL_NOMASK) ? 'm' : '-';
-    smods[2] = (flags & DECL_NOSAVE) ? 's' : '-';
-    smods[3] = '\0';
-
-    sflags[0] = (flags & FUNC_INHERITED) ? 'i' : '-';
-    sflags[1] = (flags & FUNC_UNDEFINED) ? 'u' : '-';
-    sflags[2] = (flags & FUNC_STRICT_TYPES) ? 's' : '-';
-    sflags[3] = (flags & FUNC_PROTOTYPE) ? 'p' : '-';
-    sflags[5] = (flags & FUNC_TRUE_VARARGS) ? 'V' : '-';
-    sflags[6] = (flags & FUNC_VARARGS) ? 'v' : '-';
-    sflags[7] = '\0';
-
-    if (flags & FUNC_INHERITED) {
-      low = 0;
-      high = prog->num_inherited - 1;
-      while (high > low) {
-        mid = (low + high + 1) / 2;
-        if (prog->inherit[mid].function_index_offset > runtime_index) {
-          high = mid - 1;
-        } else {
-          low = mid;
-        }
-      }
-
-      fprintf(f, "%4d: %-24s  %6d  %4s  %7s  %3d %3d\n", i, func_entry->funcname, low, smods,
-              sflags, runtime_index - prog->inherit[low].function_index_offset,
-              prog->inherit[low].variable_index_offset);
-    } else {
-      fprintf(f, "%4d: %-24s  %6d  %4s  %7s             %7d   %5d %10d", i, func_entry->funcname,
-              runtime_index - prog->last_inherited, smods, sflags, func_entry->num_local,
-              func_entry->num_arg, func_entry->num_arg - func_entry->min_arg);
-
-      std::string default_arg_findex_map;
-      for (int j = 0; j < func_entry->num_arg; j++) {
-        if (func_entry->default_args_findex[j] != 0) {
-          default_arg_findex_map +=
-              fmt::format(FMT_STRING(" {}:{}"), j, func_entry->default_args_findex[j]);
-        }
-      }
-      fprintf(f, " %s\n", default_arg_findex_map.c_str());
+      fprintf(f, "%4d: %-24s  %6d  %4s  %7s             %7d   %5d %10d", r.index, r.name, r.offset,
+              r.smods, r.sflags, r.locals, r.args, r.def_args);
+      fprintf(f, " %s\n", r.defmap.c_str());
     }
   }
 
@@ -213,22 +258,23 @@ static int short_compare(const void* a, const void* b) {
 
 static const char* pushes[] = {"string", "number", "global", "local"};
 
-static void print_function_sig(FILE* f, program_t* prog, int idx) {
+static std::string function_sig_string(program_t* prog, int idx) {
   char buf[255];
   auto end = &buf[sizeof(buf) - 1];
+  std::string out;
 
   auto funp = prog->function_table[idx];
   auto funflags = prog->function_flags[prog->last_inherited + idx];
 
   buf[0] = '\0';
   get_type_modifiers(&buf[0], end, funflags);
-  fprintf(f, "%s", buf);
+  out += buf;
 
   get_type_name(&buf[0], end, funp.type);
-  fprintf(f, "%s", buf);
-  fprintf(f, "%s", funp.funcname);
+  out += buf;
+  out += funp.funcname;
 
-  fprintf(f, "(");
+  out += "(";
   unsigned short* types;
   if (prog->type_start && prog->type_start[idx] != INDEX_START_NONE) {
     types = &prog->argument_types[prog->type_start[idx]];
@@ -240,20 +286,21 @@ static void print_function_sig(FILE* f, program_t* prog, int idx) {
       for (int i = 0; i < funp.num_arg; i++) {
         auto p = get_type_name(buf, end, types[i]);
         *(p - 1) = '\0';  // get rid of last space
-        if (i != 0) fprintf(f, ",");
-        fprintf(f, "%s", buf);
+        if (i != 0) out += ",";
+        out += buf;
       }
     } else {
-      fprintf(f, "args: %d", funp.num_arg);
+      out += fmt::format(FMT_STRING("args: {}"), funp.num_arg);
       if (funp.min_arg != funp.num_arg) {
-        fprintf(f, "min args: %d", funp.num_arg);
+        out += fmt::format(FMT_STRING("min args: {}"), funp.num_arg);
       }
     }
   }
-  fprintf(f, ")");
+  out += ")";
+  return out;
 }
 
-static void disassemble(FILE* f, char* code, int start, int end, program_t* prog) {
+static void disassemble(DisSink& sink, char* code, int start, int end, program_t* prog) {
   extern int num_simul_efun;
   short instr;
   int i, j, ri;
@@ -293,16 +340,23 @@ static void disassemble(FILE* f, char* code, int start, int end, program_t* prog
   while ((pc - code) < end) {
     if ((next_func >= 0) && ((pc - code) >= offsets[next_func])) {
       if (next_func > 0) {
-        if (last_file && last_line > 0) {
-          fprintf(f, "; %s:%d\n", last_file, last_line);
+        if (sink.f && last_file && last_line > 0) {
+          fprintf(sink.f, "; %s:%d\n", last_file, last_line);
         }
         last_file = nullptr;
         last_line = 0;
       }
-      fprintf(f, "\n;; Function: ");
       auto func_idx = offsets[next_func + 1];
-      print_function_sig(f, prog, func_idx);
-      fprintf(f, "\n");
+      std::string sig = function_sig_string(prog, func_idx);
+      if (sink.f) {
+        fprintf(sink.f, "\n;; Function: %s\n", sig.c_str());
+      }
+      if (sink.fns) {
+        sink.fns->push_back({{"sig", sig},
+                             {"name", prog->function_table[func_idx].funcname},
+                             {"instructions", nlohmann::json::array()}});
+        sink.cur = &sink.fns->back()["instructions"];
+      }
 
       next_func += 2;
       if (next_func >= (NUM_FUNS_D * 2)) {
@@ -320,16 +374,21 @@ static void disassemble(FILE* f, char* code, int start, int end, program_t* prog
       int new_line = 0;
       get_explicit_line_number_info(pc, prog, &new_file, &new_line);
       if (last_file != new_file || last_line != new_line) {
-        if (last_file && last_line > 0) {
-          fprintf(f, "; %s:%d\n", last_file, last_line);
+        if (sink.f && last_file && last_line > 0) {
+          fprintf(sink.f, "; %s:%d\n", last_file, last_line);
         }
         last_file = new_file;
         last_line = new_line;
       }
+      sink.src_file = new_file;
+      sink.src_line = new_line;
     }
 
-    fflush(f);
-    fprintf(f, "%04tx: ", (pc - 1) - code);  // Address
+    size_t iaddr = (pc - 1) - code;
+    if (sink.f) {
+      fflush(sink.f);
+      fprintf(sink.f, "%04tx: ", (pc - 1) - code);  // Address
+    }
 
     switch (instr) {
       case F_PUSH: {
@@ -525,14 +584,19 @@ static void disassemble(FILE* f, char* code, int start, int end, program_t* prog
         pc++;
         break;
       case F_LOOP_COND_NUMBER:
+        // Layout per do_loop_cond_number(): 1-byte local, sizeof(LPC_INT)
+        // (8-byte) literal, 2-byte BACKWARD branch offset. This used to
+        // advance only 4 past the literal, desyncing the address stream --
+        // every later instruction in the section decoded as garbage and the
+        // next function's listing was swallowed.
         i = EXTRACT_UCHAR(pc++);
         COPY_INT(&iarg, pc);
-        pc += 4;
+        pc += sizeof(LPC_INT);
         COPY_SHORT(&sarg, pc);
         offset = (pc - code) - sarg;
         pc += 2;
-        sprintf(buff, "LV%d < %" LPC_INT_FMTSTR_P " bbranch_when_non_zero %04x (%04x)", i, iarg,
-                sarg, offset);
+        sprintf(buff, "LV%d < %" LPC_INT_FMTSTR_P " branch back %04x (%04x)", i, iarg, sarg,
+                offset);
         break;
       case F_LOOP_COND_LOCAL:
         i = EXTRACT_UCHAR(pc++);
@@ -659,14 +723,47 @@ static void disassemble(FILE* f, char* code, int start, int end, program_t* prog
         addr = pc - code;
         aptr = pc;
 
-        fprintf(f, "switch\n");
-        fprintf(f, "      type: %02x table: %04x-%04x deflt: %04x\n", static_cast<unsigned>(ttype),
-                addr + stable, addr + etable, addr + def);
+        nlohmann::json swrow;
+        if (sink.fns) {
+          swrow = {{"a", iaddr}, {"m", "switch"}, {"cases", nlohmann::json::array()}};
+          if (sink.src_line > 0 && sink.src_file != nullptr) {
+            swrow["f"] = sink.src_file;
+            swrow["l"] = sink.src_line;
+          }
+        }
+        if (sink.f) fprintf(sink.f, "switch\n");
+        if (sink.f) {
+          fprintf(sink.f, "      type: %02x table: %04x-%04x deflt: %04x\n",
+                  static_cast<unsigned>(ttype), addr + stable, addr + etable, addr + def);
+        }
+        if (sink.fns) {
+          swrow["type"] = ttype;
+          swrow["tstart"] = addr + stable;
+          swrow["tend"] = addr + etable;
+          swrow["deflt"] = addr + def;
+          sink.cur->push_back(swrow);
+        }
+        // Body instructions between the header and the table go to the SAME
+        // sink (json rows land in the current function like any other).
         /* recursively disassemble stuff in switch */
-        disassemble(f, code, pc - code + 7, addr + stable, prog);
+        disassemble(sink, code, pc - code + 7, addr + stable, prog);
+
+        nlohmann::json* swcases = nullptr;
+        if (sink.fns && sink.cur != nullptr) {
+          // find our switch row again (the recursion may have appended rows,
+          // but our row object was copied in -- locate by address)
+          for (auto& r : *sink.cur) {
+            if (r.contains("a") && r["a"] == iaddr && r["m"] == "switch") {
+              swcases = &r["cases"];
+              break;
+            }
+          }
+        }
 
         /* now print out table - ugly... */
-        fprintf(f, "      switch table (for %04x)\n", static_cast<unsigned>(pc - code - 1));
+        if (sink.f) {
+          fprintf(sink.f, "      switch table (for %04x)\n", static_cast<unsigned>(pc - code - 1));
+        }
         if (ttype == 0xfe) {
           ttype = 0; /* direct lookup */
         } else if (ttype >> 4 == 0xf) {
@@ -682,11 +779,14 @@ static void disassemble(FILE* f, char* code, int start, int end, program_t* prog
           // 64-bit); stop the short-offset walk before it, not 4 bytes before.
           while (pc < aptr + etable - (int)sizeof(LPC_INT)) {
             COPY_SHORT(&sarg, pc);
-            fprintf(f, "\t%2d: %04x\n", i++, addr + sarg);
+            if (sink.f) fprintf(sink.f, "\t%2d: %04x\n", i, addr + sarg);
+            if (swcases) swcases->push_back({{"i", i}, {"to", addr + sarg}});
+            i++;
             pc += 2;
           }
           COPY_INT(&iarg, pc);
-          fprintf(f, "\tminval = %" LPC_INT_FMTSTR_P "\n", iarg);
+          if (sink.f) fprintf(sink.f, "\tminval = %" LPC_INT_FMTSTR_P "\n", iarg);
+          if (swcases) swcases->push_back({{"minval", iarg}});
           pc += sizeof(LPC_INT);
         } else {
           while (pc < aptr + etable) {
@@ -694,12 +794,17 @@ static void disassemble(FILE* f, char* code, int start, int end, program_t* prog
             COPY_SHORT(&sarg, pc + sizeof(char*));
             if (ttype == 1 || !parg) {
               if (sarg == 1) {
-                fprintf(f, "\t%-4p\t<range start>\n", parg);
+                if (sink.f) fprintf(sink.f, "\t%-4p\t<range start>\n", parg);
+                if (swcases) swcases->push_back({{"range_start", true}});
               } else {
-                fprintf(f, "\t%-4p\t%04x\n", parg, addr + sarg);
+                if (sink.f) fprintf(sink.f, "\t%-4p\t%04x\n", parg, addr + sarg);
+                if (swcases) swcases->push_back({{"to", addr + sarg}});
               }
             } else {
-              fprintf(f, "\t\"%s\"\t%04x\n", disassem_string(parg), addr + sarg);
+              if (sink.f) fprintf(sink.f, "\t\"%s\"\t%04x\n", disassem_string(parg), addr + sarg);
+              if (swcases) {
+                swcases->push_back({{"key", disassem_string(parg)}, {"to", addr + sarg}});
+              }
             }
             pc += 2 + sizeof(char*);
           }
@@ -724,7 +829,10 @@ static void disassemble(FILE* f, char* code, int start, int end, program_t* prog
         break;
       }
       case 0:
-        fprintf(f, "*** zero opcode ***\n");
+        if (sink.f) fprintf(sink.f, "*** zero opcode ***\n");
+        if (sink.fns && sink.cur != nullptr) {
+          sink.cur->push_back({{"a", iaddr}, {"m", "*** zero opcode ***"}});
+        }
         continue;
       default:
         // fprintf(f, "*** %s (%d) ***\n", query_instr_name(instr), instr);
@@ -737,13 +845,26 @@ static void disassemble(FILE* f, char* code, int start, int end, program_t* prog
       while (saved_pc != pc) {
         p += sprintf(p, "%02hhX ", *saved_pc++);
       }
-      fprintf(f, " %-25s", tmp);  // byte code in HEX
+      if (sink.f) {
+        fprintf(sink.f, " %-25s", tmp);  // byte code in HEX
+        fprintf(sink.f, " %-35s; %s\n", query_instr_name(instr), buff);
+      }
+      if (sink.fns && sink.cur != nullptr) {
+        nlohmann::json row = {{"a", iaddr},
+                              {"x", tmp},
+                              {"m", query_instr_name(instr)},
+                              {"o", buff}};
+        if (sink.src_line > 0 && sink.src_file != nullptr) {
+          row["f"] = sink.src_file;
+          row["l"] = sink.src_line;
+        }
+        sink.cur->push_back(row);
+      }
     }
-    fprintf(f, " %-35s; %s\n", query_instr_name(instr), buff);
   }
 
   // print last line
-  fprintf(f, "; %s:%d\n", last_file, last_line);
+  if (sink.f) fprintf(sink.f, "; %s:%d\n", last_file, last_line);
 
   if (offsets) {
     free(offsets);
@@ -791,4 +912,127 @@ static void dump_line_numbers(FILE* f, program_t* prog) {
     fprintf(f, "%04x-%04x: %i\n", addr, addr + sz - 1, s);
     addr += sz;
   }
+}
+
+// ---------------------------------------------------------------------------
+// JSON-native dump (lpcc --json bytecode). Same emissions as the text form:
+// the instruction stream comes from the SAME disassemble() switch via the
+// json sink backend; the tables share fn_table_rows(); the line-table walk
+// mirrors dump_line_numbers() (kept adjacent -- change both together).
+// ---------------------------------------------------------------------------
+
+static nlohmann::json prog_details_json(program_t* prog, int flags) {
+  nlohmann::json p;
+  p["file"] = prog->filename;
+
+  p["globals"] = nlohmann::json::array();
+  for (int i = 0; i < prog->num_variables_total; i++) {
+    p["globals"].push_back({{"i", i}, {"name", variable_name(prog, i)}});
+  }
+
+  int variable_runtime_index = 0;
+  if (prog->num_inherited > 0) {
+    variable_runtime_index = prog->inherit[prog->num_inherited - 1].variable_index_offset +
+                             prog->inherit[prog->num_inherited - 1].prog->num_variables_total;
+  }
+  p["variables"] = nlohmann::json::array();
+  for (int i = 0; i < prog->num_variables_defined; i++) {
+    char buf[255];
+    auto end = &buf[sizeof(buf) - 1];
+    get_type_name(&buf[0], end, prog->variable_types[i]);
+    p["variables"].push_back({{"i", variable_runtime_index + i},
+                              {"decl", std::string(buf) + prog->variable_table[i]}});
+  }
+
+  p["strings"] = nlohmann::json::array();
+  for (int i = 0; i < prog->num_strings; i++) {
+    p["strings"].push_back({{"i", i}, {"text", prog->strings[i]}});
+  }
+
+  if (flags & 1) {
+    nlohmann::json fns = nlohmann::json::array();
+    // Preamble entry catches any rows before the first function header
+    // (dropped below if none appear).
+    fns.push_back({{"sig", ""}, {"name", ""}, {"instructions", nlohmann::json::array()}});
+    DisSink sink;
+    sink.fns = &fns;
+    sink.cur = &fns.back()["instructions"];
+    disassemble(sink, prog->program, 0, prog->program_size, prog);
+    if (!fns.empty() && fns[0]["name"] == "" && fns[0]["instructions"].empty()) {
+      fns.erase(fns.begin());
+    }
+    p["functions"] = fns;
+  }
+
+  if ((flags & 2) && prog->line_info != nullptr && prog->file_info != nullptr) {
+    // Mirrors dump_line_numbers()'s walk.
+    unsigned short* fi = prog->file_info;
+    auto* li_end = reinterpret_cast<unsigned char*>((reinterpret_cast<char*>(fi)) + fi[0]);
+    auto* li_start = reinterpret_cast<unsigned char*>(fi + fi[1]);
+
+    p["line_files"] = nlohmann::json::array();
+    for (unsigned short* q = fi + 2; q < reinterpret_cast<unsigned short*>(li_start); q += 2) {
+      p["line_files"].push_back({{"lines", q[0]}, {"file", prog->strings[q[1] - 1]}});
+    }
+
+    p["line_ranges"] = nlohmann::json::array();
+    unsigned char* li = li_start;
+    int addr = 0;
+    while (li < li_end) {
+      int sz = *li++;
+      ADDRESS_TYPE s;
+#if !defined(USE_32BIT_ADDRESSES)
+      COPY_SHORT(&s, li);
+#else
+      COPY4(&s, li);
+#endif
+      li += sizeof(ADDRESS_TYPE);
+      p["line_ranges"].push_back({{"from", addr}, {"to", addr + sz - 1}, {"line", s}});
+      addr += sz;
+    }
+  }
+  return p;
+}
+
+static void collect_programs_json(program_t* prog, int flags, nlohmann::json& out) {
+  out.push_back(prog_details_json(prog, flags));
+  for (int i = 0; i < prog->num_inherited; i++) {
+    collect_programs_json(prog->inherit[i].prog, flags, out);
+  }
+}
+
+nlohmann::json dump_prog_json(program_t* prog, int flags) {
+  nlohmann::json j;
+  j["name"] = std::string("/") + prog->filename;
+
+  j["inherits"] = nlohmann::json::array();
+  for (int i = 0; i < prog->num_inherited; i++) {
+    j["inherits"].push_back({{"name", prog->inherit[i].prog->filename},
+                             {"fio", prog->inherit[i].function_index_offset},
+                             {"vio", prog->inherit[i].variable_index_offset}});
+  }
+
+  j["functions_table"] = nlohmann::json::array();
+  std::vector<FnTabRow> rows;
+  fn_table_rows(prog, rows);
+  for (const auto& r : rows) {
+    nlohmann::json e = {{"i", r.index}, {"name", r.name}, {"mods", r.smods},
+                        {"flags", r.sflags}, {"inherited", r.inherited}};
+    if (r.inherited) {
+      e["inh"] = r.inh_low;
+      e["fio"] = r.inh_fio;
+      e["vio"] = r.inh_vio;
+    } else {
+      e["offset"] = r.offset;
+      e["locals"] = r.locals;
+      e["args"] = r.args;
+      e["def_args"] = r.def_args;
+      if (!r.defmap.empty()) e["defmap"] = r.defmap;
+    }
+    j["functions_table"].push_back(e);
+  }
+
+  j["programs"] = nlohmann::json::array();
+  collect_programs_json(prog, flags, j["programs"]);
+  return j;
 }

--- a/src/compiler/internal/disassembler.h
+++ b/src/compiler/internal/disassembler.h
@@ -2,6 +2,21 @@
 #define COMPILER_INTERNAL_DISASSEMBLER_H
 
 #include <cstdio>  // for FILE
+
+#include <nlohmann/json_fwd.hpp>
+
 void dump_prog(struct program_t* prog, FILE* f, int flags);
+
+// JSON-native form of the same dump (lpcc --json bytecode): the model the
+// text format is a rendering of. Shape:
+//   { name, inherits:[{name,fio,vio}],
+//     functions_table:[{i,name,mods,flags,inherited, then per-kind fields}],
+//     programs:[{file, globals:[{i,name}], variables:[{i,decl}],
+//                strings:[{i,text}],
+//                functions:[{sig,name,instructions:[{a,x,m,o,f,l}...]}],
+//                line_files:[{lines,file}], line_ranges:[{from,to,line}]}] }
+// (top program first, then each inherited program's dump, matching the text
+// recursion order). flags as dump_prog: 1 = disassemble, 2 = line tables.
+nlohmann::json dump_prog_json(struct program_t* prog, int flags);
 
 #endif  // COMPILER_INTERNAL_DISASSEMBLER_H

--- a/src/compiler/internal/generate.cc
+++ b/src/compiler/internal/generate.cc
@@ -5,6 +5,8 @@
 #include <cstdio>
 #include <vector>
 
+#include <nlohmann/json.hpp>  // lpcc --ast --json envelope
+
 #include "include/function.h"  // for F_SIMUL etc , FIXME
 #include "efuns.autogen.h"
 #include "vm/internal/base/number.h"  // for formatting lpc int
@@ -485,264 +487,311 @@ static void lpc_tree_list(parse_node_t* dest, parse_node_t* expr) {
 #define ARG_4 dest->r.expr->r.expr->r.expr->r.expr
 #define ARG_5 dest->r.expr->r.expr->r.expr->r.expr->r.expr
 
-void dump_expr_list(parse_node_t* expr) {
-  if (!expr) {
-    return;
+// dump_tree (lpcc --ast text form) renders the SAME model the --json mode
+// emits (ast_json below): one switch, two renderings -- the S-expression
+// text is `(label scalars children...)` with seq nodes spliced flat, which
+// is shape-compatible with the historical hand-printed form.
+static void render_sexpr(const nlohmann::json& n);
+
+static void render_sexpr_children(const nlohmann::json& n, bool* first) {
+  if (n.contains("a")) {
+    for (const auto& a : n["a"]) {
+      if (!*first) printf(" ");
+      *first = false;
+      if (a.is_string()) {
+        printf("%s", a.get<std::string>().c_str());
+      } else {
+        printf("%s", a.dump().c_str());
+      }
+    }
   }
-  do {
-    dump_tree(expr->v.expr);
-  } while ((expr = expr->r.expr));
+  if (n.contains("c")) {
+    for (const auto& c : n["c"]) {
+      if (!*first) printf(" ");
+      *first = false;
+      render_sexpr(c);
+    }
+  }
 }
 
-static void dump_lvalue_list(parse_node_t* expr) {
-  printf("(lvalue_list ");
-  while ((expr = expr->r.expr)) {
-    dump_tree(expr->l.expr);
+static void render_sexpr(const nlohmann::json& n) {
+  const std::string k = n.value("k", "");
+  if (k == "seq") {
+    // sequencing node: splice children flat, like the historical dump
+    bool first = true;
+    if (n.contains("c")) {
+      for (const auto& c : n["c"]) {
+        if (!first) printf(" ");
+        first = false;
+        render_sexpr(c);
+      }
+    }
+    return;
+  }
+  printf("(%s", k.c_str());
+  bool firstitem = false;  // label already printed; separate items with ' '
+  render_sexpr_children(n, &firstitem);
+  printf(")");
+}
+
+// --- lpcc --ast --json ------------------------------------------------------
+//
+// Structured mirror of dump_tree. Node schema (keys omitted when empty):
+//   {"k": label, "l": source line, "a": [scalar operands], "c": [children]}
+// NODE_TWO_VALUES is a pure sequencing node; it renders as {"k":"seq"} with
+// nested sequences spliced flat, matching the S-expression form's implicit
+// concatenation. Kept adjacent to dump_tree ON PURPOSE: any new NODE_* case
+// added there must be added here (both are driven by the same switch shape).
+
+static nlohmann::json ast_json(parse_node_t* expr);
+
+static void ast_json_children(nlohmann::json& node, parse_node_t* expr) {
+  // dump_expr_list: right-linked list of v.expr items
+  while (expr) {
+    node["c"].push_back(ast_json(expr->v.expr));
+    expr = expr->r.expr;
   }
 }
 
-void dump_tree(parse_node_t* expr) {
-  if (!expr) {
+static void ast_json_seq(nlohmann::json& arr, parse_node_t* expr) {
+  if (!expr) return;
+  if (expr->kind == NODE_TWO_VALUES) { // splice nested sequences flat
+    ast_json_seq(arr, expr->l.expr);
+    ast_json_seq(arr, expr->r.expr);
     return;
   }
+  arr.push_back(ast_json(expr));
+}
+
+static nlohmann::json ast_json(parse_node_t* expr) {
+  nlohmann::json n = nlohmann::json::object();
+  if (!expr) {
+    n["k"] = "nil";
+    return n;
+  }
+  if (expr->line > 0) n["l"] = expr->line;
+  auto kids = [&](parse_node_t* e) { if (e) n["c"].push_back(ast_json(e)); };
+  auto scalar = [&](LPC_INT v) { n["a"].push_back(v); };
+  const auto instr_name = [](int op) { return instrs[op & ~NOVALUE_USED_FLAG].name; };
+
   switch (expr->kind) {
     case NODE_TERNARY_OP:
-      printf("(%s ", instrs[expr->r.expr->v.number].name);
-      dump_tree(expr->l.expr);
-      expr = expr->r.expr;
-      dump_tree(expr->l.expr);
-      dump_tree(expr->r.expr);
-      printf(")");
+    case NODE_TERNARY_OP_1:
+      n["k"] = instr_name(expr->r.expr->v.number);
+      if (expr->kind == NODE_TERNARY_OP_1) scalar(expr->type);
+      kids(expr->l.expr);
+      kids(expr->r.expr->l.expr);
+      kids(expr->r.expr->r.expr);
       break;
     case NODE_BINARY_OP:
-      printf("(%s ", instrs[expr->v.number].name);
-      dump_tree(expr->l.expr);
-      dump_tree(expr->r.expr);
-      printf(")");
+    case NODE_BINARY_OP_1:
+      n["k"] = instr_name(expr->v.number);
+      if (expr->kind == NODE_BINARY_OP_1) scalar(expr->type);
+      kids(expr->l.expr);
+      kids(expr->r.expr);
       break;
     case NODE_UNARY_OP:
-      printf("(%s ", instrs[expr->v.number].name);
-      dump_tree(expr->r.expr);
-      printf(")");
-      break;
-    case NODE_OPCODE:
-      printf("(%s)", instrs[expr->v.number].name);
-      break;
-    case NODE_TERNARY_OP_1: {
-      int p = expr->type;
-      printf("(%s ", instrs[expr->r.expr->v.number].name);
-      dump_tree(expr->l.expr);
-      expr = expr->r.expr;
-      dump_tree(expr->l.expr);
-      dump_tree(expr->r.expr);
-      printf(" %i)", p);
-      break;
-    }
-    case NODE_BINARY_OP_1:
-      printf("(%s ", instrs[expr->v.number].name);
-      dump_tree(expr->l.expr);
-      dump_tree(expr->r.expr);
-      printf(" %i)", expr->type);
+      n["k"] = instr_name(expr->v.number);
+      kids(expr->r.expr);
       break;
     case NODE_UNARY_OP_1:
-      printf("(%s ", instrs[expr->v.number].name);
-      dump_tree(expr->r.expr);
-      printf(" %" LPC_INT_FMTSTR_P ")", expr->l.number);
+      n["k"] = instr_name(expr->v.number);
+      scalar(expr->l.number);
+      kids(expr->r.expr);
+      break;
+    case NODE_OPCODE:
+      n["k"] = instr_name(expr->v.number);
       break;
     case NODE_OPCODE_1:
-      printf("(%s %" LPC_INT_FMTSTR_P ")", instrs[expr->v.number].name, expr->l.number);
+      n["k"] = instr_name(expr->v.number);
+      scalar(expr->l.number);
       break;
     case NODE_OPCODE_2:
-      printf("(%s %" LPC_INT_FMTSTR_P " %" LPC_INT_FMTSTR_P ")", instrs[expr->v.number].name,
-             expr->l.number, expr->r.number);
+      n["k"] = instr_name(expr->v.number);
+      scalar(expr->l.number);
+      scalar(expr->r.number);
       break;
     case NODE_RETURN:
-      if (expr->r.expr) {
-        printf("(return ");
-        dump_tree(expr->r.expr);
-        printf(")");
-      } else {
-        printf("(return_zero)");
-      }
+      n["k"] = expr->r.expr ? "return" : "return_zero";
+      kids(expr->r.expr);
       break;
     case NODE_STRING:
-      printf("(string %" LPC_INT_FMTSTR_P ")", expr->v.number);
+      n["k"] = "string";
+      scalar(expr->v.number); // string-table index; resolve via dump_prog STRINGS
       break;
     case NODE_REAL:
-      printf("(real %" LPC_FLOAT_FMTSTR_P ")", expr->v.real);
+      n["k"] = "real";
+      n["a"].push_back(expr->v.real);
       break;
     case NODE_NUMBER:
-      printf("(number %" LPC_INT_FMTSTR_P ")", expr->v.number);
+      n["k"] = "number";
+      scalar(expr->v.number);
       break;
     case NODE_LAND_LOR:
-      if (expr->v.number == F_LAND) {
-        printf("(&& ");
-      } else {
-        printf("(|| ");
-      }
-      dump_tree(expr->l.expr);
-      dump_tree(expr->r.expr);
-      printf(")");
+      n["k"] = (expr->v.number == F_LAND) ? "&&" : "||";
+      kids(expr->l.expr);
+      kids(expr->r.expr);
       break;
     case NODE_NULLISH:
-      printf("(?? ");
-      dump_tree(expr->l.expr);
-      dump_tree(expr->r.expr);
-      printf(")");
+      n["k"] = "??";
+      kids(expr->l.expr);
+      kids(expr->r.expr);
       break;
     case NODE_LOGICAL_ASSIGN:
-      printf("(%s ", instrs[expr->v.number].name);
-      dump_tree(expr->l.expr);
-      dump_tree(expr->r.expr);
-      printf(")");
-      break;
     case NODE_BRANCH_LINK:
-      printf("(branch_link ");
-      dump_tree(expr->l.expr);
-      dump_tree(expr->r.expr);
-      printf(")");
+      n["k"] = expr->kind == NODE_BRANCH_LINK ? "branch_link" : instr_name(expr->v.number);
+      kids(expr->l.expr);
+      kids(expr->r.expr);
       break;
     case NODE_CALL_2:
-      printf("(%s %" LPC_INT_FMTSTR_P " %" LPC_INT_FMTSTR_P " %i ", instrs[expr->v.number].name,
-             expr->l.number >> 16, expr->l.number & 0xffff,
-             (expr->r.expr ? expr->r.expr->kind : 0));
-      dump_expr_list(expr->r.expr);
-      printf(")");
+      n["k"] = instr_name(expr->v.number);
+      scalar(expr->l.number >> 16);
+      scalar(expr->l.number & 0xffff);
+      ast_json_children(n, expr->r.expr);
       break;
     case NODE_CALL_1:
-      printf("(%s %" LPC_INT_FMTSTR_P " %i ", instrs[expr->v.number].name, expr->l.number,
-             (expr->r.expr ? expr->r.expr->kind : 0));
-      dump_expr_list(expr->r.expr);
-      printf(")");
+      n["k"] = instr_name(expr->v.number);
+      scalar(expr->l.number);
+      ast_json_children(n, expr->r.expr);
       break;
     case NODE_CALL:
-      printf("(%s %" LPC_INT_FMTSTR_P " ", instrs[expr->v.number].name, expr->l.number);
-      dump_expr_list(expr->r.expr);
-      printf(")");
+      n["k"] = instr_name(expr->v.number);
+      scalar(expr->l.number);
+      ast_json_children(n, expr->r.expr);
       break;
     case NODE_TWO_VALUES:
-      dump_tree(expr->l.expr);
-      dump_tree(expr->r.expr);
+      n["k"] = "seq";
+      ast_json_seq(n["c"], expr->l.expr);
+      ast_json_seq(n["c"], expr->r.expr);
       break;
     case NODE_CONTROL_JUMP:
-      if (expr->v.number == CJ_BREAK_SWITCH) {
-        printf("(break_switch)");
-      } else if (expr->v.number == CJ_BREAK) {
-        printf("(break)");
-      } else if (expr->v.number == CJ_CONTINUE) {
-        printf("(continue)");
-      } else {
-        printf("(UNKNOWN CONTROL JUMP)");
-      }
+      n["k"] = (expr->v.number == CJ_BREAK_SWITCH) ? "break_switch"
+               : (expr->v.number == CJ_BREAK)      ? "break"
+               : (expr->v.number == CJ_CONTINUE)   ? "continue"
+                                                   : "unknown_control_jump";
       break;
     case NODE_PARAMETER:
-      printf("(parameter %" LPC_INT_FMTSTR_P ")", expr->v.number);
+      n["k"] = "parameter";
+      scalar(expr->v.number);
       break;
     case NODE_PARAMETER_LVALUE:
-      printf("(parameter_lvalue %" LPC_INT_FMTSTR_P ")", expr->v.number);
+      n["k"] = "parameter_lvalue";
+      scalar(expr->v.number);
       break;
     case NODE_IF:
-      printf("(if ");
-      dump_tree(expr->v.expr);
-      printf("\n");
-      dump_tree(expr->l.expr);
-      if (expr->r.expr) {
-        printf("\n");
-        dump_tree(expr->r.expr);
-      }
-      printf(")\n");
+      n["k"] = "if";
+      kids(expr->v.expr);
+      kids(expr->l.expr);
+      kids(expr->r.expr);
       break;
     case NODE_LOOP:
-      printf("(loop %i\n", expr->type);
-      dump_tree(expr->v.expr);
-      printf("\n");
-      dump_tree(expr->l.expr);
-      printf("\n");
-      dump_tree(expr->r.expr);
-      printf(")\n");
+      n["k"] = "loop";
+      scalar(expr->type);
+      kids(expr->v.expr);
+      kids(expr->l.expr);
+      kids(expr->r.expr);
       break;
     case NODE_FOREACH:
-      printf("(foreach ");
-      dump_tree(expr->l.expr);
-      dump_tree(expr->r.expr);
-      dump_tree(expr->v.expr);
-      printf(")\n");
+      n["k"] = "foreach";
+      kids(expr->l.expr);
+      kids(expr->r.expr);
+      kids(expr->v.expr);
       break;
     case NODE_CASE_NUMBER:
     case NODE_CASE_STRING:
-      printf("(case)");
+      n["k"] = "case";
       break;
     case NODE_DEFAULT:
-      printf("(default)");
+      n["k"] = "default";
       break;
     case NODE_SWITCH_STRINGS:
     case NODE_SWITCH_NUMBERS:
     case NODE_SWITCH_DIRECT:
     case NODE_SWITCH_RANGES:
-      printf("(switch ");
-      dump_tree(expr->l.expr);
-      dump_tree(expr->r.expr);
-      printf(")");
+      n["k"] = "switch";
+      kids(expr->l.expr);
+      kids(expr->r.expr);
       break;
     case NODE_CATCH:
-      printf("(catch ");
-      dump_tree(expr->r.expr);
-      printf(")");
+      n["k"] = "catch";
+      kids(expr->r.expr);
       break;
-    case NODE_LVALUE_EFUN:
-      printf("(lvalue_efun ");
-      dump_tree(expr->l.expr);
-      dump_lvalue_list(expr->r.expr);
-      printf(")");
+    case NODE_LVALUE_EFUN: {
+      n["k"] = "lvalue_efun";
+      kids(expr->l.expr);
+      parse_node_t* lv = expr->r.expr;
+      while (lv && (lv = lv->r.expr)) n["c"].push_back(ast_json(lv->l.expr));
       break;
-    case NODE_FUNCTION_CONSTRUCTOR:
-      printf("(function %" LPC_INT_FMTSTR_P " ", expr->v.number & 0xff);
-      if (expr->r.expr) {
-        printf("(array ");
-        dump_expr_list(expr->r.expr);
-        printf(")");
-      } else {
-        printf("(number 0)");
-      }
+    }
+    case NODE_FUNCTION_CONSTRUCTOR: {
+      n["k"] = "functional";
+      scalar(expr->v.number & 0xff);
+      scalar(expr->v.number >> 8);
+      if (expr->r.expr) ast_json_children(n, expr->r.expr);
       switch (expr->v.number & 0xff) {
-        case FP_SIMUL:
-          printf("(fp-simul %" LPC_INT_FMTSTR_P ")", expr->v.number >> 8);
-          break;
-        case FP_LOCAL:
-          printf("(fp-local %" LPC_INT_FMTSTR_P ")", expr->v.number >> 8);
-          break;
         case FP_EFUN:
-          printf("(fp-efun %s)", instrs[expr->v.number >> 8].name);
+          n["a"].push_back(instr_name(expr->v.number >> 8));
           break;
         case FP_FUNCTIONAL:
         case FP_FUNCTIONAL | FP_NOT_BINDABLE:
-          printf("(fp-functional %" LPC_INT_FMTSTR_P " ", expr->v.number >> 8);
-          dump_tree(expr->l.expr);
-          printf(")");
+          kids(expr->l.expr);
           break;
       }
-      printf(" %" LPC_INT_FMTSTR_P ")", expr->v.number >> 8);
       break;
+    }
     case NODE_ANON_FUNC:
-      printf("(anon-func %" LPC_INT_FMTSTR_P " %" LPC_INT_FMTSTR_P " ", expr->v.number,
-             expr->l.number);
-      dump_tree(expr->r.expr);
-      printf(")");
+      n["k"] = "anon_func";
+      scalar(expr->v.number);
+      scalar(expr->l.number);
+      kids(expr->r.expr);
       break;
     case NODE_EFUN:
-      printf("(efun %s ", instrs[expr->v.number & ~NOVALUE_USED_FLAG].name);
-      dump_expr_list(expr->r.expr);
-      printf(")");
+      n["k"] = "efun";
+      n["a"].push_back(instr_name(expr->v.number));
+      ast_json_children(n, expr->r.expr);
       break;
     case NODE_FUNCTION:
-      printf("(function ");
-      dump_tree(expr->r.expr);
-      printf(")");
+      n["k"] = "function";
+      scalar(expr->v.number); // function index
+      kids(expr->r.expr);
       break;
     default:
-      printf("(unknown: %d)", expr->kind);
+      n["k"] = "unknown";
+      scalar(expr->kind);
       break;
   }
+  return n;
+}
+
+void dump_tree(parse_node_t* expr) {
+  nlohmann::json roots = nlohmann::json::array();
+  ast_json_seq(roots, expr);
+  bool first = true;
+  for (const auto& r : roots) {
+    if (!first) printf("\n");
+    first = false;
+    render_sexpr(r);
+  }
+}
+
+void dump_program_ast_json(const char* filename, parse_node_t* tree_main,
+                           parse_node_t* tree_init) {
+  nlohmann::json envelope = {
+      {"fluffos_lpcc", 1},
+      {"stage", "ast"},
+      {"file", filename != nullptr ? filename : "?"},
+      {"trees", nlohmann::json::array()},
+  };
+  nlohmann::json main_roots = nlohmann::json::array();
+  ast_json_seq(main_roots, tree_main);
+  nlohmann::json init_roots = nlohmann::json::array();
+  ast_json_seq(init_roots, tree_init);
+  envelope["trees"].push_back({{"title", "TREE_MAIN"}, {"roots", main_roots}});
+  envelope["trees"].push_back({{"title", "TREE_INIT"}, {"roots", init_roots}});
+  // Filenames/instr names are ASCII, but stay consistent with the other
+  // envelopes: never throw on stray bytes.
+  printf("%s\n",
+         envelope.dump(-1, ' ', false, nlohmann::json::error_handler_t::replace).c_str());
 }
 
 void lpc_tree_form(parse_node_t* expr, parse_node_t* dest) {

--- a/src/compiler/internal/generate.h
+++ b/src/compiler/internal/generate.h
@@ -17,8 +17,11 @@ int generate_conditional_branch(struct parse_node_t*);
 
 // Tree dumping is a product feature now (lpcc --ast), not debug
 // scaffolding -- unconditional in every build type.
-void dump_expr_list(struct parse_node_t*);
 void dump_tree(struct parse_node_t*);
+// lpcc --ast --json: one-line {"fluffos_lpcc":1,"stage":"ast",...} envelope
+// covering both trees, with per-node source lines.
+void dump_program_ast_json(const char* filename, struct parse_node_t* tree_main,
+                           struct parse_node_t* tree_init);
 void lpc_tree_form(struct parse_node_t*, struct parse_node_t*);
 
 #endif

--- a/src/compiler/internal/grammar.autogen.cc
+++ b/src/compiler/internal/grammar.autogen.cc
@@ -4270,4 +4270,13 @@ yypushreturn:
 #undef yyes_capacity
 #line 1159 "$REPO_ROOT$/src/compiler/internal/grammar.y"
 
-/* FluffOS generated-from grammar.y sha256=1e0b0dc0115624b2604b675a147b6ef88d5e9f72cbc76dc9e48b661f1a4eeacc */
+
+// Public accessor for the parser's symbol-name table: maps a raw yylex
+// token number (what lpcc --tokens prints) to its grammar spelling
+// ("L_IDENTIFIER", "'{'"). Lives in the epilogue because yysymbol_name()
+// and YYTRANSLATE are file-static in the generated parser; consumed by
+// the lpcc --json staged outputs (stage_output.cc).
+const char* lpc_token_name(int token) {
+  return yysymbol_name(YY_CAST(yysymbol_kind_t, YYTRANSLATE(token)));
+}
+/* FluffOS generated-from grammar.y sha256=728753a714187bc4267cb6913374a16543a24935e9017960519fd14e02f3fcb5 */

--- a/src/compiler/internal/grammar.autogen.h
+++ b/src/compiler/internal/grammar.autogen.h
@@ -191,4 +191,4 @@ void yypstate_delete (yypstate *ps);
 
 
 #endif /* !YY_YY_GRAMMAR_AUTOGEN_H_INCLUDED  */
-/* FluffOS generated-from grammar.y sha256=1e0b0dc0115624b2604b675a147b6ef88d5e9f72cbc76dc9e48b661f1a4eeacc */
+/* FluffOS generated-from grammar.y sha256=728753a714187bc4267cb6913374a16543a24935e9017960519fd14e02f3fcb5 */

--- a/src/compiler/internal/grammar.y
+++ b/src/compiler/internal/grammar.y
@@ -1157,3 +1157,12 @@ constant:
 ;
 
 %%
+
+// Public accessor for the parser's symbol-name table: maps a raw yylex
+// token number (what lpcc --tokens prints) to its grammar spelling
+// ("L_IDENTIFIER", "'{'"). Lives in the epilogue because yysymbol_name()
+// and YYTRANSLATE are file-static in the generated parser; consumed by
+// the lpcc --json staged outputs (stage_output.cc).
+const char* lpc_token_name(int token) {
+  return yysymbol_name(YY_CAST(yysymbol_kind_t, YYTRANSLATE(token)));
+}

--- a/src/compiler/internal/stage_output.cc
+++ b/src/compiler/internal/stage_output.cc
@@ -9,6 +9,12 @@
 #include "compiler/internal/lexer_rules_pp.h"
 #include "compiler/internal/scratchpad.h"
 
+#include <nlohmann/json.hpp>
+
+// Defined in grammar.y's epilogue (the name table is file-static in the
+// generated parser).
+extern const char* lpc_token_name(int token);
+
 // ---------------------------------------------------------------------------
 // lpcc's pre-parse stage dumps: pull tokens through the real
 // reentrant scanner (lexing + preprocessing, no parser) and print them.
@@ -91,9 +97,80 @@ void print_token_pp(int kind, const YYSTYPE& lval, compiler_context_t* ctx, cons
   }
 }
 
+// std::string counterpart of print_token_pp/print_quoted, for the JSON
+// mode. Mirrors the text rendering exactly so both modes agree on
+// spellings (strings re-quoted, numbers re-rendered, identifiers raw).
+std::string quote_to_string(const char* s, size_t n, char quote) {
+  std::string r;
+  r += quote;
+  for (size_t i = 0; i < n; i++) {
+    char c = s[i];
+    switch (c) {
+      case '\n':
+        r += "\\n";
+        break;
+      case '\t':
+        r += "\\t";
+        break;
+      case '\r':
+        r += "\\r";
+        break;
+      case '\\':
+        r += "\\\\";
+        break;
+      default:
+        if (c == quote) r += '\\';
+        r += c;
+    }
+  }
+  r += quote;
+  return r;
+}
+
+std::string token_spelling(int kind, const YYSTYPE& lval, compiler_context_t* ctx,
+                           const char* text) {
+  char buf[64];
+  switch (kind) {
+    case L_STRING:
+      if (lval.string != nullptr) {
+        return quote_to_string(lval.string->data(), lval.string->size(),
+                               ctx->is_template ? '`' : '"');
+      }
+      return "";
+    case L_TEMPLATE_HEAD:
+    case L_TEMPLATE_MIDDLE:
+    case L_TEMPLATE_TAIL: {
+      std::string r = (kind == L_TEMPLATE_HEAD) ? "`" : "}";
+      if (lval.string != nullptr) r.append(lval.string->data(), lval.string->size());
+      r += (kind == L_TEMPLATE_TAIL) ? "`" : "${";
+      return r;
+    }
+    case L_NUMBER:
+      if (ctx->is_char_literal) {
+        snprintf(buf, sizeof(buf), "'%c'", static_cast<char>(lval.number));
+      } else {
+        snprintf(buf, sizeof(buf), "%" PRIu64, static_cast<uint64_t>(lval.number));
+      }
+      return buf;
+    case L_REAL:
+      snprintf(buf, sizeof(buf), "%g", lval.real);
+      return buf;
+    case L_IDENTIFIER:
+      if (lval.string != nullptr) return std::string(lval.string->data(), lval.string->size());
+      return "";
+    case L_DEFINED_NAME:
+      if (lval.ihe != nullptr && lval.ihe->name != nullptr) return lval.ihe->name;
+      return "";
+    default:
+      return text;
+  }
+}
+
 }  // namespace
 
-bool lpc_dump_stage_tokens(int fd, const char* name, bool pp_form, FILE* out) {
+enum class StageDumpMode { kTokens, kPreprocessed, kTokensJson };
+
+static bool dump_stage_tokens_impl(int fd, const char* name, StageDumpMode mode, FILE* out) {
   // Minimal compile-shaped environment: the lexer's bookkeeping
   // (add_program_file / save_file_info for #include accounting) writes
   // into the compiler mem_block areas that prolog() normally allocates.
@@ -127,11 +204,18 @@ bool lpc_dump_stage_tokens(int fd, const char* name, bool pp_form, FILE* out) {
   YYSTYPE lval;
   int last_line = 1;
   bool line_start = true;
+  nlohmann::json jtokens = nlohmann::json::array();
   while (ok) {
     YYLTYPE lloc;
     int kind = yylex(&lval, &lloc, scanner);
     if (kind <= 0) break;
-    if (pp_form) {
+    if (mode == StageDumpMode::kTokensJson) {
+      jtokens.push_back({{"l", lloc.first_line},
+                         {"c", lloc.first_column},
+                         {"k", kind},
+                         {"n", lpc_token_name(kind)},
+                         {"t", token_spelling(kind, lval, ctx, yyget_text(scanner))}});
+    } else if (mode == StageDumpMode::kPreprocessed) {
       // Preserve source line structure from token positions.
       if (lloc.first_line > last_line) {
         int gap = lloc.first_line - last_line;
@@ -150,7 +234,14 @@ bool lpc_dump_stage_tokens(int fd, const char* name, bool pp_form, FILE* out) {
     ctx->is_char_literal = false;
     ctx->is_template = false;
   }
-  if (ok && pp_form) fputc('\n', out);
+  if (ok && mode == StageDumpMode::kPreprocessed) fputc('\n', out);
+  if (ok && mode == StageDumpMode::kTokensJson) {
+    nlohmann::json envelope = {
+        {"fluffos_lpcc", 1}, {"stage", "tokens"}, {"file", name}, {"tokens", jtokens}};
+    // Source bytes aren't guaranteed UTF-8; replace instead of throwing.
+    fputs(envelope.dump(-1, ' ', false, nlohmann::json::error_handler_t::replace).c_str(), out);
+    fputc('\n', out);
+  }
 
   // Unified cleanup for success AND load failure: buffers down first,
   // then the scanner, then the compile-shaped environment.
@@ -163,4 +254,13 @@ bool lpc_dump_stage_tokens(int fd, const char* name, bool pp_form, FILE* out) {
     FREE(mem_block[i].block);
   }
   return ok;
+}
+
+bool lpc_dump_stage_tokens(int fd, const char* name, bool pp_form, FILE* out) {
+  return dump_stage_tokens_impl(
+      fd, name, pp_form ? StageDumpMode::kPreprocessed : StageDumpMode::kTokens, out);
+}
+
+bool lpc_dump_stage_tokens_json(int fd, const char* name, FILE* out) {
+  return dump_stage_tokens_impl(fd, name, StageDumpMode::kTokensJson, out);
 }

--- a/src/compiler/internal/stage_output.h
+++ b/src/compiler/internal/stage_output.h
@@ -19,4 +19,11 @@
 // Returns false if the stream failed to load.
 bool lpc_dump_stage_tokens(int fd, const char* name, bool pp_form, FILE* out);
 
+// lpcc --json --tokens: same scan, machine-readable. Emits ONE line:
+//   {"fluffos_lpcc":1,"stage":"tokens","file":...,
+//    "tokens":[{"l":line,"c":col,"k":kind,"n":"L_IDENTIFIER","t":"spelling"},...]}
+// so consumers can find the payload in mixed stdout by the "fluffos_lpcc"
+// envelope marker instead of scraping the human format.
+bool lpc_dump_stage_tokens_json(int fd, const char* name, FILE* out);
+
 #endif

--- a/src/main_lpcc.cc
+++ b/src/main_lpcc.cc
@@ -2,11 +2,12 @@
 
 #include <cstdlib>
 #include <cstdio>
-#include <event2/event.h>
 #include <iostream>
 #include <unistd.h>
 
 #include "mainlib.h"
+
+#include <nlohmann/json.hpp>
 
 #include "thirdparty/scope_guard/scope_guard.hpp"
 #include "compiler/internal/disassembler.h"
@@ -30,7 +31,13 @@ int main(int argc, char** argv) {
   //   --ast     dump parse trees before codegen (then compile as usual)
   //   -O0       compile with the tree optimizer off -> the dump_prog
   //             output is PRE-optimization bytecode
+  //   --json    machine-readable variant of a stage output (--tokens, --ast,
+  //             and the default/-O0 bytecode dump). The payload is ONE line
+  //             starting with {"fluffos_lpcc":1,...} so consumers can find
+  //             it in mixed stdout. The bytecode model comes from the same
+  //             disassembler switch as the text dump (DisSink json backend).
   bool flag_pp = false, flag_tokens = false, flag_ast = false, flag_noopt = false;
+  bool flag_json = false;
   const char* pos[3] = {argv[0], nullptr, nullptr};
   int npos = 1;
   for (int i = 1; i < argc; i++) {
@@ -43,11 +50,17 @@ int main(int argc, char** argv) {
       flag_ast = true;
     else if (a == "-O0")
       flag_noopt = true;
+    else if (a == "--json")
+      flag_json = true;
     else if (npos < 3)
       pos[npos++] = argv[i];
   }
   if (npos != 3) {
-    std::cerr << "Usage: lpcc [-E|--tokens|--ast|-O0] config_file lpc_file" << std::endl;
+    std::cerr << "Usage: lpcc [-E|--tokens|--ast|-O0] [--json] config_file lpc_file" << std::endl;
+    return 1;
+  }
+  if (flag_json && flag_pp) {
+    std::cerr << "lpcc: --json is not available for -E" << std::endl;
     return 1;
   }
   argv = const_cast<char**>(pos);
@@ -79,11 +92,13 @@ int main(int argc, char** argv) {
       fprintf(stderr, "lpcc: cannot open %s\n", file);
       return 1;
     }
-    bool ok = lpc_dump_stage_tokens(fd, file, flag_pp, stdout);
+    bool ok = flag_json ? lpc_dump_stage_tokens_json(fd, file, stdout)
+                        : lpc_dump_stage_tokens(fd, file, flag_pp, stdout);
     close(fd);
     return ok ? 0 : 1;
   }
-  g_compile.opt_dump_ast = flag_ast;
+  g_compile.opt_dump_ast = flag_ast && !flag_json;
+  g_compile.opt_dump_ast_json = flag_ast && flag_json;
   g_compile.opt_no_optimize = flag_noopt;
 
   {
@@ -104,10 +119,45 @@ int main(int argc, char** argv) {
     return 1;
   }
 
+  if (flag_json && flag_ast) {
+    // Companion envelope for --ast --json: the AST's "l" values are
+    // ABSOLUTE compilation-unit lines (includes inlined) and its
+    // (string N) atoms are string-table indices; this supplies both
+    // mappings. Consumers accumulate `segments` in order to translate an
+    // absolute line to (file, line-within-file).
+    nlohmann::json seg = nlohmann::json::array();
+    unsigned short* fi = obj->prog->file_info;
+    if (obj->prog->line_info != nullptr && fi != nullptr) {
+      auto* li_start = reinterpret_cast<unsigned char*>(fi + fi[1]);
+      for (unsigned short* p = fi + 2; p < reinterpret_cast<unsigned short*>(li_start); p += 2) {
+        seg.push_back({{"lines", p[0]}, {"file", obj->prog->strings[p[1] - 1]}});
+      }
+    }
+    nlohmann::json strs = nlohmann::json::array();
+    for (int i = 0; i < static_cast<int>(obj->prog->num_strings); i++) {
+      strs.push_back(obj->prog->strings[i]);
+    }
+    nlohmann::json envelope = {
+        {"fluffos_lpcc", 1}, {"stage", "files"}, {"segments", seg}, {"strings", strs}};
+    // LPC strings are arbitrary bytes; replace invalid UTF-8 instead of throwing.
+    printf("%s\n",
+           envelope.dump(-1, ' ', false, nlohmann::json::error_handler_t::replace).c_str());
+  }
+
   if (!flag_ast) {
     ScopedTracer const tracer("dump_prog");
 
-    dump_prog(obj->prog, stdout, 1 | 2);
+    if (flag_json) {
+      nlohmann::json envelope = {{"fluffos_lpcc", 1},
+                                 {"stage", "bytecode"},
+                                 {"file", file},
+                                 {"optimized", !flag_noopt},
+                                 {"program", dump_prog_json(obj->prog, 1 | 2)}};
+      printf("%s\n",
+             envelope.dump(-1, ' ', false, nlohmann::json::error_handler_t::replace).c_str());
+    } else {
+      dump_prog(obj->prog, stdout, 1 | 2);
+    }
   }
 
   Tracer::collect();


### PR DESCRIPTION
One commit powering the fluffos-vscode Compiler Explorer (Source/Tokens/AST/Bytecode views), which ships lpcc as its compiler backend. The front-end's dumps are now **JSON-native**: each stage has one model, and both the human text output and the `--json` envelope are renderings of it.

## `--json` stage outputs

One-line `{"fluffos_lpcc":1,...}` envelopes, findable in mixed stdout; all dumps use `error_handler_t::replace` (LPC source bytes aren't guaranteed UTF-8).

- **tokens** — positions, spellings, and token **names** via `lpc_token_name()`, a new public accessor in `grammar.y`'s epilogue over the parser's file-static `yysymbol_name()`/`YYTRANSLATE` table (`grammar.autogen.*` regenerated via the pinned copy-back).
- **ast** — per-node source **lines**, plus a `{"stage":"files"}` companion envelope with the absolute-line→file segment table and string table so `(string N)` atoms resolve. `dump_tree`'s ~240-line hand-printed switch is **gone**: the `--ast` text is `render_sexpr()` over the same `ast_json` model (one switch, two renderings; shape-compatible output, one root per line, function nodes carry their index).
- **bytecode** (default and `-O0`; envelope carries `optimized:true/false`) — the one opcode switch in `disassemble()` emits through a `DisSink` with two backends: text reproduces the legacy format (**verified byte-identical** across a fixture corpus incl. switch tables and both optimizer modes), json builds the model natively — per-program sections (top + inherited), the FUNCTIONS table via a shared `fn_table_rows()`, instruction rows `{a,x,m,o,f,l}` with source `file:line` **native on every row**, structured switch tables (resolved string keys, case targets, minval), and the line tables. `dump_prog_json()` exported via `json_fwd`.

## Disassembler fix

`loop_cond_number` copied its 8-byte `LPC_INT` literal (`COPY_INT` == `COPY8`) but advanced `pc` only 4, desyncing the address stream — `*** zero opcode ***` garbage and the next function's listing swallowed. Now advances `sizeof(LPC_INT)`; the `bbranch_when_non_zero` comment typo is `branch back`.

## wasm lpcc (`lpcc.js` / `lpcc.wasm`)

The emscripten branch builds `lpcc-web`: `main_lpcc.cc` as a plain node CLI with `NODERAWFS`, so `node lpcc.js <config> <file>` behaves exactly like the native binary (the unneeded `event2` include is dropped — `mainlib.h` forward-declares `init_main`'s `event_base`). Added to the wasm build preset's targets, smoke-tested in the CI wasm job (compile a testsuite file, expect the `--json` tokens envelope), and shipped in the release wasm zip. This is the artifact the fluffos-vscode extension bundles so its compiler features need zero native setup.

## Validation

- Full LPC testsuite passes; text dump output verified byte-identical to the pre-refactor format across the fixture corpus
- All stage envelopes verified end-to-end by the fluffos-vscode Compiler Explorer (fixtures + parser tests pinned there, JSON and text parses asserted to agree)
- The `wasm` CI job builds and smoke-tests the wasm lpcc (emsdk is network-blocked locally)
- CI was fully green on this branch's pre-squash tip (`da7c233`), including the wasm job

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AXqX4Kf55ArA39suS9cdCv