### PR TITLE
compiler: strip the actual source extension in the_file_name()

### DIFF
--- a/src/compiler/internal/compiler.cc
+++ b/src/compiler/internal/compiler.cc
@@ -3194,19 +3194,27 @@ static void clean_parser() {
 
 char* the_file_name(const char* name) {
   char* tmp;
-  int len;
+  const char* slash;
+  const char* dot;
+  int base;
 
-  len = strlen(name);
-  if (len < 3) {
-    return string_copy(name, "the_file_name");
-  }
-  tmp = new_string(len - 1, "the_file_name");
+  /* Return the leading-slash object name with its source extension
+   * stripped. Strip the actual extension rather than a fixed number of
+   * bytes: this used to chop the trailing two characters, which was only
+   * correct while ".c" was the sole source extension -- ".lpc" and any
+   * other length left a mangled tail (e.g. "/foo.l"). Only a dot in the
+   * basename counts as an extension. */
+  slash = strrchr(name, '/');
+  dot = strrchr(name, '.');
+  base = (dot && (!slash || dot > slash)) ? (int)(dot - name) : (int)strlen(name);
+
+  tmp = new_string(base + 1, "the_file_name");
   if (!tmp) {
     return string_copy(name, "the_file_name");
   }
   tmp[0] = '/';
-  strncpy(tmp + 1, name, len - 2);
-  tmp[len - 1] = '\0';
+  strncpy(tmp + 1, name, base);
+  tmp[base + 1] = '\0';
   return tmp;
 }
 


### PR DESCRIPTION
## Problem

`the_file_name()` (`src/compiler/internal/compiler.cc`) builds the leading-slash, extension-less object name that is passed as the `file` argument to the `valid_override` master apply. It stripped a **fixed two trailing bytes**:

```c
tmp[0] = '/';
strncpy(tmp + 1, name, len - 2);
tmp[len - 1] = '\0';
```

That was only correct while `.c` was the sole source extension. With `.lpc` (or any extension that isn't two characters), it chops the wrong number of bytes and leaves a mangled tail. For example, compiling `/adm/simul_efun/object.lpc`, `valid_override` receives:

```
file "/adm/simul_efun/object.l"   (expected "/adm/simul_efun/object")
```

The `valid_override` docs specify `file` as the extension-less object name (the example compares `file == "/adm/obj/simul_efun"`), so any master that matches on `file` silently fails to match under `.lpc`.

## Fix

Strip the *actual* extension by scanning back to the last dot in the basename, so both `.c` and `.lpc` (and anything else) resolve to the documented extension-less form:

- `/adm/simul_efun/object.lpc` → `/adm/simul_efun/object`
- `/adm/foo.c` → `/adm/foo` (unchanged)

A dot is only treated as an extension when it appears in the basename (after the last `/`), so dotted directory names don't get truncated. Allocation is sized to `base + 1` (`/` + kept bytes), matching `int_new_string`'s `size + 1` contract.

`the_file_name()`'s only callers are the two `valid_override` argument pushes in `grammar_rules_exprs.cc`, so the blast radius is contained to that apply.