### PR TITLE
websocket: pin TLS ALPN to http/1.1, never negotiate h2

### DIFF
--- a/src/net/websocket.cc
+++ b/src/net/websocket.cc
@@ -80,6 +80,11 @@ struct lws_context* init_websocket_context(event_base* base, port_def_t* port) {
   info.options = LWS_SERVER_OPTION_LIBEVENT | LWS_SERVER_OPTION_VALIDATE_UTF8;
 
   if (!port->tls_cert.empty() && !port->tls_key.empty()) {
+    // Never negotiate h2 via ALPN: the ws output/teardown path only supports
+    // HTTP/1.1-upgrade websockets. An h2-encapsulated ws (RFC 8441 extended
+    // CONNECT) garbles output and segfaults in lws's close path
+    // (rops_callback_on_writable_ws derefs a NULL h2 parent).
+    info.alpn = "http/1.1";
     info.options |= LWS_SERVER_OPTION_DO_SSL_GLOBAL_INIT;
     info.options |= LWS_SERVER_OPTION_ALLOW_NON_SSL_ON_SSL_PORT;
     info.options |= LWS_SERVER_OPTION_REDIRECT_HTTP_TO_HTTPS;


### PR DESCRIPTION
Vendored lws compiles in HTTP/2, so wss ports advertised h2; clients that
took it carried the ws inside an h2 stream (RFC 8441) -- a path the ws output/teardown code never supported: garbled output on connect, then a NULL h2-parent deref in rops_callback_on_writable_ws on close. h2 buys a MUD port nothing, so force the HTTP/1.1 upgrade path.

In Firefox, websocket connections are crashing the driver as soon as a person connects.

```
Processing TLS config for port 11003...
Accepting websocket(TLS) connections on 0.0.0.0:11003.
Initializations complete.
Stack trace (most recent call last):
#19   Object "", at 0xffffffffffffffff, in
#18   Object "/home/mud/merentha_builders/build/driver", at 0x64b34c85aa74, in _start
#17   Object "/usr/lib/x86_64-linux-gnu/libc.so.6", at 0x7ccc1a42a28a, in __libc_start_main
#16   Object "/usr/lib/x86_64-linux-gnu/libc.so.6", at 0x7ccc1a42a1c9, in
#15   Source "/home/mud/merentha_builders/driver/src/main.cc", line 5, in main [0x64b34c8578fc]
          2: extern "C" {
          3: int driver_main(int argc, char** argv);
          4: }
      >   5: int main(int argc, char** argv) { driver_main(argc, argv); }
#14 | Source "/home/mud/merentha_builders/driver/src/mainlib.cc", line 430, in backend
    |   428:   debug_message("Initializations complete.\n\n");
    |   429:   setup_signal_handlers();
    | > 430:   backend(base);
    |   431:
    |   432:   return 0;
      Source "/home/mud/merentha_builders/driver/src/backend_libevent.cc", line 127, in driver_main [0x64b34ca0b86b]
        124:   event_add(g_ev_tick, &t);
        125:
        126:   try {
      > 127:     event_base_loop(base, 0);
        128:   } catch (...) {  // catch everything
        129:     fatal("BUG: jumped out of event loop!");
        130:   }
#13   Source "/home/mud/merentha_builders/driver/src/thirdparty/libevent/event.c", line 2068, in event_base_loop [0x64b34c9e61d7]
       2065:            timeout_process(base);
       2066:
       2067:            if (N_ACTIVE_CALLBACKS(base)) {
      >2068:                    int n = event_process_active(base);
       2069:                    if ((flags & EVLOOP_ONCE)
       2070:                        && N_ACTIVE_CALLBACKS(base) == 0
       2071:                        && n != 0)
#12   Source "/home/mud/merentha_builders/driver/src/thirdparty/libevent/event.c", line 1819, in event_process_active [0x64b34c9b797e]
       1816:                    base->event_running_priority = i;
       1817:                    activeq = &base->activequeues[i];
       1818:                    if (i < limit_after_prio)
      >1819:                            c = event_process_active_single_queue(base, activeq,
       1820:                                INT_MAX, NULL);
       1821:                    else
       1822:                            c = event_process_active_single_queue(base, activeq,
#11 | Source "/home/mud/merentha_builders/driver/src/thirdparty/libevent/event.c", line 1718, in event_persist_closure
    |  1716:            case EV_CLOSURE_EVENT_PERSIST:
    |  1717:                    EVUTIL_ASSERT(ev != NULL);
    | >1718:                    event_persist_closure(base, ev);
    |  1719:                    break;
    |  1720:            case EV_CLOSURE_EVENT: {
      Source "/home/mud/merentha_builders/driver/src/thirdparty/libevent/event.c", line 1659, in event_process_active_single_queue [0x64b34c9b75ba]
       1656:    EVBASE_RELEASE_LOCK(base, th_base_lock);
       1657:
       1658:    // Execute the callback
      >1659:    (evcb_callback)(evcb_fd, evcb_res, evcb_arg);
       1660: }
       1661:
       1662: /*
#10 | Source "/home/mud/merentha_builders/driver/src/thirdparty/libwebsockets/lib/event-libs/libevent/libevent.c", line 145, in lws_service_fd_tsi
    |   143:            return;
    |   144:
    | > 145:    lws_service_fd_tsi(context, &eventfd, wsi->tsi);
    |   146:
    |   147:    if (pt->destroy_self) {
      Source "/home/mud/merentha_builders/driver/src/thirdparty/libwebsockets/lib/core-net/service.c", line 646, in lws_event_cb [0x64b34c99f7b6]
        643:    struct lws *wsi;
        644:    char cow = 0;
        645:
      > 646:    if (!context || context->service_no_longer_possible)
        647:            return -1;
        648:
        649:    pt = &context->pt[tsi];
#9    Source "/home/mud/merentha_builders/driver/src/thirdparty/libwebsockets/lib/core-net/service.c", line 767, in lws_service_fd_tsi [0x64b34c987a0f]
        764:    // lwsl_notice("%s: %s: wsistate 0x%x\n", __func__, wsi->role_ops->name,
        765:    //          wsi->wsistate);
        766:
      > 767:    switch (lws_rops_func_fidx(wsi->role_ops, LWS_ROPS_handle_POLLIN).
        768:                                           handle_POLLIN(pt, wsi, pollfd)) {
        769:    case LWS_HPI_RET_WSI_ALREADY_DIED:
        770:            pt->inside_lws_service = 0;
#8    Source "/home/mud/merentha_builders/driver/src/thirdparty/libwebsockets/lib/roles/h2/ops-h2.c", line 159, in rops_handle_POLLIN_h2 [0x64b34c998d4c]
        157:    if ((pollfd->revents & LWS_POLLOUT) &&
        158:        lwsi_state_can_handle_POLLOUT(wsi) &&
      > 159:        lws_handle_POLLOUT_event(wsi, pollfd)) {
        160:            if (lwsi_state(wsi) == LRS_RETURNED_CLOSE)
        161:                    lwsi_set_state(wsi, LRS_FLUSHING_BEFORE_CLOSE);
        162:            /* the write failed... it's had it */
#7    Source "/home/mud/merentha_builders/driver/src/thirdparty/libwebsockets/lib/core-net/service.c", line 207, in lws_handle_POLLOUT_event [0x64b34c986f62]
        204: #endif
        205:
        206:    if (lws_rops_fidx(wsi->role_ops, LWS_ROPS_perform_user_POLLOUT)) {
      > 207:            if (lws_rops_func_fidx(wsi->role_ops,
        208:                                   LWS_ROPS_perform_user_POLLOUT).
        209:                                            perform_user_POLLOUT(wsi) == -1)
        210:                    goto bail_die;
#6  | Source "/home/mud/merentha_builders/driver/src/thirdparty/libwebsockets/lib/roles/h2/ops-h2.c", line 1145, in lws_close_free_wsi
    |  1143:                        (n || w->h2.send_END_STREAM)) {
    |  1144:                            lwsl_info("closing stream after h2 action\n");
    | >1145:                            lws_close_free_wsi(w, LWS_CLOSE_STATUS_NOSTATUS,
    |  1146:                                               "h2 end stream");
    |  1147:                            wa = &wsi->mux.child_list;
    | Source "/home/mud/merentha_builders/driver/src/thirdparty/libwebsockets/lib/core-net/close.c", line 1068, in __lws_close_free_wsi
    |  1066:    lws_pt_lock(pt, __func__);
    |  1067:    /* may destroy vhost, cannot hold vhost lock outside it */
    | >1068:    __lws_close_free_wsi(wsi, reason, caller);
    |  1069:    lws_pt_unlock(pt);
      Source "/home/mud/merentha_builders/driver/src/thirdparty/libwebsockets/lib/core-net/close.c", line 1059, in rops_perform_user_POLLOUT_h2 [0x64b34c99a02e]
       1058: void
      >1059: lws_close_free_wsi(struct lws *wsi, enum lws_close_status reason, const char *caller)
       1060: {
       1061:    struct lws_context *cx = wsi->a.context;
       1062:    struct lws_context_per_thread *pt = &wsi->a.context->pt[(int)wsi->tsi];
#5    Source "/home/mud/merentha_builders/driver/src/thirdparty/libwebsockets/lib/core-net/close.c", line 828, in __lws_close_free_wsi [0x64b34c981326]
        825:                    pro = &wsi->a.vhost->protocols[0];
        826:
        827:            if (pro && pro->callback)
      > 828:                    pro->callback(wsi,
        829:                            wsi->role_ops->close_cb[lwsi_role_server(wsi)],
        830:                            wsi->user_space, NULL, 0);
        831:            wsi->told_user_closed = 1;
#4    Source "/home/mud/merentha_builders/driver/src/net/ws_telnet.cc", line 167, in ws_telnet_callback [0x64b34c8adcd8]
        165:       auto* ip = pss->user;
        166:       if (ip) {
      > 167:         remove_interactive(ip->ob, 0);
        168:         pss->user = nullptr;
        169:       }
        170:       // Always free the session resources: on driver-initiated closes
#3    Source "/home/mud/merentha_builders/driver/src/comm.cc", line 807, in remove_interactive [0x64b34c8b727b]
        804:   // Tear down the byte transport (socket/TLS buffers, websocket handle,
        805:   // command timer, or the WASM JS bridge).
        806:   if (ip->transport != nullptr) {
      > 807:     ip->transport->close();
        808:     delete ip->transport;
        809:     ip->transport = nullptr;
        810:   }
#2  | Source "/home/mud/merentha_builders/driver/src/net/transport_libevent.cc", line 190, in close_user_websocket
    |   188:   void close() override {
    |   189:     if (ip_->lws != nullptr) {
    | > 190:       close_user_websocket(ip_->lws);
    |   191:       ip_->lws = nullptr;
    |   192:     }
    | Source "/home/mud/merentha_builders/driver/src/net/websocket.cc", line 145, in close_user_websocket
    |   143: void close_websocket_context(struct lws_context* context) { lws_context_destroy(context); }
    |   144:
    | > 145: void close_user_websocket(struct lws* wsi) {
    |   146:   lws_set_timeout(wsi, pending_timeout::PENDING_FLUSH_STORED_SEND_BEFORE_CLOSE, LWS_TO_KILL_ASYNC);
    |   147:   switch (lws_get_protocol(wsi)->id) {
      Source "/home/mud/merentha_builders/driver/src/net/websocket.cc", line 164, in close [0x64b34c8acb27]
        161:       if (pss) {
        162:         if (evbuffer_get_length(pss->buffer) > 0) {
        163:           // try flush before closing.
      > 164:           lws_callback_on_writable(wsi);
        165:         }
        166:         pss->user = nullptr;
        167:       }
#1  | Source "/home/mud/merentha_builders/driver/src/thirdparty/libwebsockets/lib/core-net/pollfd.c", line 526, in lws_callback_on_writable
    |   525: int
    | > 526: lws_callback_on_writable(struct lws *wsi)
    |   527: {
    |   528:    struct lws *w = wsi;
      Source "/home/mud/merentha_builders/driver/src/thirdparty/libwebsockets/lib/core-net/pollfd.c", line 537, in lws_callback_on_writable [0x64b34c9e9f05]
        534:            return 0;
        535:
        536:    if (lws_rops_fidx(wsi->role_ops, LWS_ROPS_callback_on_writable)) {
      > 537:            int q = lws_rops_func_fidx(wsi->role_ops,
        538:                                       LWS_ROPS_callback_on_writable).
        539:                                                  callback_on_writable(wsi);
        540:            if (q)
#0    Source "/home/mud/merentha_builders/driver/src/thirdparty/libwebsockets/lib/roles/ws/ops-ws.c", line 2047, in rops_callback_on_writable_ws [0x64b34c99ae54]
       2044:                                                 encapsulation_parent(wsi);
       2045:
       2046:            assert(enc);
      >2047:            if (lws_rops_func_fidx(enc->role_ops,
       2048:                                   LWS_ROPS_callback_on_writable).
       2049:                                            callback_on_writable(wsi))
       2050:                    return 1;
Segmentation fault (Address not mapped to object [0x438])
./run.sh: line 17: 52863 Segmentation fault      (core dumped) ./build/driver "cfg/$config.config"
```