### PR TITLE
compiler: strip the actual source extension in the_file_name()

### DIFF
--- a/src/compiler/internal/compiler.cc
+++ b/src/compiler/internal/compiler.cc
@@ -3194,19 +3194,27 @@ static void clean_parser() {
 
 char* the_file_name(const char* name) {
   char* tmp;
-  int len;
+  const char* slash;
+  const char* dot;
+  int base;
 
-  len = strlen(name);
-  if (len < 3) {
-    return string_copy(name, "the_file_name");
-  }
-  tmp = new_string(len - 1, "the_file_name");
+  /* Return the leading-slash object name with its source extension
+   * stripped. Strip the actual extension rather than a fixed number of
+   * bytes: this used to chop the trailing two characters, which was only
+   * correct while ".c" was the sole source extension -- ".lpc" and any
+   * other length left a mangled tail (e.g. "/foo.l"). Only a dot in the
+   * basename counts as an extension. */
+  slash = strrchr(name, '/');
+  dot = strrchr(name, '.');
+  base = (dot && (!slash || dot > slash)) ? (int)(dot - name) : (int)strlen(name);
+
+  tmp = new_string(base + 1, "the_file_name");
   if (!tmp) {
     return string_copy(name, "the_file_name");
   }
   tmp[0] = '/';
-  strncpy(tmp + 1, name, len - 2);
-  tmp[len - 1] = '\0';
+  strncpy(tmp + 1, name, base);
+  tmp[base + 1] = '\0';
   return tmp;
 }
 

--- a/testsuite/inherit/master/valid.lpc
+++ b/testsuite/inherit/master/valid.lpc
@@ -32,9 +32,25 @@ int valid_author(string) {
 // efun:: prefix and which may not.  This function is only called at
 // object compile-time.
 //
+// The last (file, name, mainfile) triple the driver applied is recorded
+// so tests can assert on the exact arguments the compiler builds --
+// /single/tests/compiler/valid_override_file.lpc pins `file` as the
+// leading-slash, extension-less object name for every source extension.
+//
 // returns: 1 if override is allowed, 0 if not.
 
-int valid_override(string file, string name) {
+nosave mixed *last_valid_override = 0;
+
+mixed *query_last_valid_override() {
+  return last_valid_override;
+}
+
+void clear_last_valid_override() {
+  last_valid_override = 0;
+}
+
+int valid_override(string file, string name, string mainfile) {
+  last_valid_override = ({ file, name, mainfile });
   if (file == OVERRIDES_FILE) {
     return 1;
   }

--- a/testsuite/single/tests/compiler/valid_override_file.lpc
+++ b/testsuite/single/tests/compiler/valid_override_file.lpc
@@ -1,0 +1,88 @@
+// Regression: the `file` argument the compiler passes to the
+// valid_override master apply (built by the_file_name(), see
+// src/compiler/internal/compiler.cc) must be the leading-slash,
+// EXTENSION-LESS object name for any source extension. The old code
+// stripped a fixed two trailing bytes -- correct only for ".c" -- so
+// compiling "/data/vo_probe_l.lpc" handed valid_override
+// "/data/vo_probe_l.l" and any master matching on the documented
+// extension-less form silently failed. The testsuite master
+// (/inherit/master/valid) records the last (file, name, mainfile)
+// triple it was applied with; on the unfixed driver the .lpc
+// ASSERT_EQs below fail with the mangled ".l" tail.
+
+#define PROBE_SRC "int probe() { return efun::strlen(\"hi\"); }\n"
+
+private object *loaded = ({});
+
+private void check_one(string path, string expect_file, string expect_main) {
+  object ob;
+  mixed err;
+  mixed *rec;
+
+  master()->clear_last_valid_override();
+  err = catch(ob = load_object(path));
+  ASSERT2(!err, "loading " + path + " should not error: " + err);
+  ASSERT2(objectp(ob), "probe " + path + " should compile");
+  if (objectp(ob)) {
+    loaded += ({ ob });
+    ASSERT_EQ(2, ob->probe());
+  }
+
+  rec = master()->query_last_valid_override();
+  ASSERT2(pointerp(rec), "valid_override should have been applied compiling " + path);
+  if (pointerp(rec)) {
+    ASSERT_EQ(expect_file, rec[0]);
+    ASSERT_EQ("strlen", rec[1]);
+    ASSERT_EQ(expect_main, rec[2]);
+  }
+}
+
+void do_tests() {
+  // Fresh fixtures every run; distinct basenames so the extension-blind
+  // object registry can't satisfy the second load from the first.
+  rm("/data/vo_probe_l.lpc");
+  rm("/data/vo_probe_c.c");
+  write_file("/data/vo_probe_l.lpc", PROBE_SRC);
+  write_file("/data/vo_probe_c.c", PROBE_SRC);
+
+  // .lpc source: broken before the fix ("/data/vo_probe_l.l").
+  check_one("/data/vo_probe_l.lpc", "/data/vo_probe_l", "/data/vo_probe_l.lpc");
+
+  // .c source: the historically-correct case, must stay unchanged.
+  check_one("/data/vo_probe_c.c", "/data/vo_probe_c", "/data/vo_probe_c.c");
+
+  // A dot in a DIRECTORY name is not an extension: only the basename's
+  // trailing extension may be stripped.
+  mkdir("/data/vo_v1.2");
+  rm("/data/vo_v1.2/probe.lpc");
+  write_file("/data/vo_v1.2/probe.lpc", PROBE_SRC);
+  check_one("/data/vo_v1.2/probe.lpc", "/data/vo_v1.2/probe", "/data/vo_v1.2/probe.lpc");
+
+  // Only the LAST dot in the basename is an extension boundary.
+  rm("/data/vo_multi.dot.lpc");
+  write_file("/data/vo_multi.dot.lpc", PROBE_SRC);
+  check_one("/data/vo_multi.dot.lpc", "/data/vo_multi.dot", "/data/vo_multi.dot.lpc");
+
+  // The efun:: call sits in an #include'd file: `file` is the file being
+  // scanned (the include, its extension stripped), `mainfile` stays the
+  // outermost compile target (with extension).
+  rm("/data/vo_inc.h");
+  rm("/data/vo_incuser.lpc");
+  write_file("/data/vo_inc.h", PROBE_SRC);
+  write_file("/data/vo_incuser.lpc", "#include \"/data/vo_inc.h\"\n");
+  check_one("/data/vo_incuser.lpc", "/data/vo_inc", "/data/vo_incuser.lpc");
+
+  // Teardown: destruct probes, remove fixtures, clear the recorder.
+  foreach (object ob in loaded) {
+    if (objectp(ob)) destruct(ob);
+  }
+  loaded = ({});
+  rm("/data/vo_probe_l.lpc");
+  rm("/data/vo_probe_c.c");
+  rm("/data/vo_v1.2/probe.lpc");
+  rmdir("/data/vo_v1.2");
+  rm("/data/vo_multi.dot.lpc");
+  rm("/data/vo_inc.h");
+  rm("/data/vo_incuser.lpc");
+  master()->clear_last_valid_override();
+}


### PR DESCRIPTION
the_file_name() builds the leading-slash, extension-less object name used
as the `file` argument to the valid_override master apply. It stripped a
fixed two trailing bytes, which was only correct while ".c" was the sole
source extension. With ".lpc" (or any non-two-char extension) it left a
mangled tail -- e.g. "/adm/simul_efun/object.lpc" surfaced as
"/adm/simul_efun/object.l" instead of "/adm/simul_efun/object".

Strip the actual extension by scanning back to the last dot in the
basename, so both ".c" and ".lpc" resolve to the documented extension-less
form. Its only callers are the two valid_override pushes, so the change is
contained.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>