### PR TITLE
Fix object-destruct UAF and compiler_tests string-table corruption

### DIFF
--- a/src/base/internal/stralloc.cc
+++ b/src/base/internal/stralloc.cc
@@ -95,6 +95,21 @@ static block_t* alloc_new_shared_string(const char* /*string*/, int /*h*/, const
 void init_strings() {
   int x, y;
 
+  // Idempotent: a real driver process calls this exactly once (vm_init()),
+  // but a second call anywhere -- reachable in practice from a test binary
+  // that hosts both a lightweight, no-full-boot compiler harness and a
+  // real driver boot in the same process -- would otherwise silently
+  // reallocate base_table, orphaning every shared string interned so far
+  // (still live, valid memory, just unreachable from the fresh table) with
+  // no free/migration. The first free_string() of one of those orphaned
+  // strings then fails its "is this still in the table" sanity check and
+  // aborts the process. Skip rather than orphan: whichever call happens
+  // first wins, matching the invariant the driver already relies on.
+  if (base_table) {
+    debug_message("init_strings: called again, ignoring (already initialized).\n");
+    return;
+  }
+
   /* ensure that htable size is a power of 2 */
   y = CONFIG_INT(__SHARED_STRING_HASH_TABLE_SIZE__);
   /* Cap the round-up at 2^30: a larger configured value would shift past

--- a/src/tests/test_compiler.cc
+++ b/src/tests/test_compiler.cc
@@ -268,6 +268,19 @@ static std::vector<Token> TokenizeSession(bool keep_macros, const std::string& s
   // segfaulted CompileEntry tests running after any tokenizer test.
   lpc_lex_scanner_destroyed(scanner);
   yylex_destroy(scanner);
+  // Symmetric with start_new_file() above: that call arms lexer_utils.cc's
+  // file-local main_filename exactly once per top-level compile (a
+  // make_shared_string() ref), and only end_new_file() ever disarms it.
+  // Skipping this call here (as this function did before) leaves
+  // main_filename permanently pinned to THIS session's filename for the
+  // rest of the process -- harmless-looking on its own, but a real bug
+  // when a later CompileEntry test's ensure_compile_env() then
+  // re-initializes the shared-string table (see the g_test_env_inited
+  // comment above): the pin still points at a live, valid block, but one
+  // that's no longer reachable from the fresh table, so the eventual
+  // free_string() of a REAL compile's own main_filename trips "free_string
+  // called on non-shared string" against this session's stale pin.
+  end_new_file();
   free_string(const_cast<char*>(current_file));
   current_file = nullptr;
   for (int i = 0; i < NUMAREAS; i++) {

--- a/src/tests/test_lpc.cc
+++ b/src/tests/test_lpc.cc
@@ -5,6 +5,28 @@
 
 #include "compiler/internal/compiler.h"
 
+namespace {
+// Runs `fn` (arbitrary LPC-triggering driver code -- load_object_from_source,
+// destruct_object, free_object, ... can all run create()/__INIT/applies)
+// under a proper recovery point, matching the pattern DriverTest's other
+// tests use inline. Without this, an error() thrown with no established
+// error_context hits the driver's fatal() fallback and aborts the whole
+// test binary instead of failing just one check.
+template <typename F>
+void RunGuarded(F&& fn) {
+  error_context_t econ{};
+  save_context(&econ);
+  try {
+    fn();
+  } catch (...) {
+    restore_context(&econ);
+    ADD_FAILURE() << "unexpected error() during test";
+    return;
+  }
+  pop_context(&econ);
+}
+}  // namespace
+
 // Test fixture class
 class DriverTest : public ::testing::Test {
  public:
@@ -226,4 +248,74 @@ TEST_F(DriverTest, ExplodeReversibleAllDelimiters) {
   // is the static the_null_array; nothing to free.)
   v = explode_string("a", 1, "a", 1, false);
   EXPECT_EQ(v->size, 0);
+}
+
+// Regression test for a heap-use-after-free in dealloc_object()
+// (src/vm/internal/base/object.cc): destruct_object() pushes the object
+// onto the global obj_list_destruct queue (simulate.cc); on the unfixed
+// binary, dealloc_object() never unlinked the object from that queue when
+// its ref count hit 0, so a same-call-sequence destruct+free of object A
+// left obj_list_destruct pointing at freed memory. The very next
+// destruct_object() call anywhere -- here, on an unrelated object B --
+// then wrote through that dangling head pointer. Fails under ASan on the
+// unfixed binary; on a plain build it would silently corrupt whatever
+// memory A's address gets reused for.
+TEST_F(DriverTest, DestructThenImmediateFreeDoesNotDangleObjListDestruct) {
+  object_t* a = nullptr;
+  object_t* b = nullptr;
+  RunGuarded([&] { a = load_object_from_source("void bump() {}\n", "lifecycle_head_a", 0); });
+  RunGuarded([&] { b = load_object_from_source("void bump() {}\n", "lifecycle_head_b", 0); });
+  ASSERT_NE(a, nullptr);
+  ASSERT_NE(b, nullptr);
+
+  RunGuarded([&] {
+    destruct_object(a);
+    free_object(&a, "DestructThenImmediateFreeDoesNotDangleObjListDestruct");
+  });
+  RunGuarded([&] {
+    destruct_object(b);
+    free_object(&b, "DestructThenImmediateFreeDoesNotDangleObjListDestruct");
+  });
+}
+
+// Regression test for the general (not just head) case of the same bug:
+// destructing A, B, C in order chains obj_list_destruct as C -> B -> A.
+// Freeing the MIDDLE object (B) directly -- exactly what reclaim_objects()
+// does when it finds a stray reference to an already-destructed object --
+// must correctly relink C's neighbor pointer to skip the freed B, or a
+// later destruct_object() call (which touches the current head's
+// neighbor pointers) dereferences freed memory.
+TEST_F(DriverTest, MidChainFreeKeepsObjListDestructWalkable) {
+  object_t* a = nullptr;
+  object_t* b = nullptr;
+  object_t* c = nullptr;
+  object_t* d = nullptr;
+  RunGuarded([&] { a = load_object_from_source("void bump() {}\n", "lifecycle_mid_a", 0); });
+  RunGuarded([&] { b = load_object_from_source("void bump() {}\n", "lifecycle_mid_b", 0); });
+  RunGuarded([&] { c = load_object_from_source("void bump() {}\n", "lifecycle_mid_c", 0); });
+  ASSERT_NE(a, nullptr);
+  ASSERT_NE(b, nullptr);
+  ASSERT_NE(c, nullptr);
+
+  RunGuarded([&] { destruct_object(a); });
+  RunGuarded([&] { destruct_object(b); });
+  RunGuarded([&] { destruct_object(c); });
+
+  // Free the middle object directly, simulating reclaim_objects() dropping
+  // a stray reference to a destructed object mid-queue.
+  RunGuarded([&] { free_object(&b, "MidChainFreeKeepsObjListDestructWalkable"); });
+
+  // Destructing (and freeing) a 4th object exercises the current
+  // obj_list_destruct head's neighbor pointers -- on the unfixed binary
+  // this is where the stale link left by the mid-chain free above would
+  // be dereferenced.
+  RunGuarded([&] { d = load_object_from_source("void bump() {}\n", "lifecycle_mid_d", 0); });
+  ASSERT_NE(d, nullptr);
+  RunGuarded([&] {
+    destruct_object(d);
+    free_object(&d, "MidChainFreeKeepsObjListDestructWalkable");
+  });
+
+  RunGuarded([&] { free_object(&c, "MidChainFreeKeepsObjListDestructWalkable"); });
+  RunGuarded([&] { free_object(&a, "MidChainFreeKeepsObjListDestructWalkable"); });
 }

--- a/src/vm/internal/base/object.cc
+++ b/src/vm/internal/base/object.cc
@@ -1966,6 +1966,19 @@ void dealloc_object(object_t* ob, const char* from) {
     SETOBNAME(ob, nullptr);
   }
 #ifdef DEBUG
+  // obj_list_destruct (destruct_object()'s "not yet swept by
+  // remove_destructed_objects()" queue, simulate.cc) is NOT gated by
+  // DEBUG, unlike obj_list_dangling below -- but in a DEBUG build the two
+  // lists happen to share this object's next_all/prev_all storage
+  // (destruct_object() pushes onto both, one right after the other, so
+  // the two chains are always structurally identical until something is
+  // unlinked). The neighbor fixup the obj_list_dangling unlink below
+  // performs therefore already keeps the underlying chain correct for
+  // obj_list_destruct's own forward walk too; only its separate head
+  // *variable* needs updating here.
+  if (obj_list_destruct == ob) {
+    obj_list_destruct = ob->next_all;
+  }
   prev_all = ob->prev_all;
   if (prev_all) {
     prev_all->next_all = ob->next_all;
@@ -1981,6 +1994,27 @@ void dealloc_object(object_t* ob, const char* from) {
   ob->next_all = 0;
   ob->prev_all = 0;
   tot_dangling_object--;
+#else
+  // No obj_list_dangling bookkeeping exists in this build to perform the
+  // equivalent neighbor fixup as a side effect (see the DEBUG branch
+  // above), so unlink from obj_list_destruct explicitly here. Otherwise a
+  // later destruct_object() call anywhere in the driver can dereference
+  // this object's now-freed address via a stale obj_list_destruct head or
+  // a neighbor's stale next_all/prev_all -- a real, ASan-confirmed
+  // heap-use-after-free (reachable via reclaim_objects() freeing a stray
+  // reference to a destructed object still queued mid-chain, or simply an
+  // object whose only reference drops immediately after destruct()).
+  if (obj_list_destruct == ob) {
+    obj_list_destruct = ob->next_all;
+    if (obj_list_destruct) {
+      obj_list_destruct->prev_all = nullptr;
+    }
+  } else if (ob->prev_all) {
+    ob->prev_all->next_all = ob->next_all;
+    if (ob->next_all) {
+      ob->next_all->prev_all = ob->prev_all;
+    }
+  }
 #endif
   tot_alloc_object--;
   FREE((char*)ob);


### PR DESCRIPTION
## Summary

Two pre-existing, unrelated memory-safety/test-isolation bugs found while validating the new WebSocket LPC debugger (`src/debugger/`, tracked separately). Both reproduce on a clean checkout, unrelated to that feature work.

- **`object.cc`: `dealloc_object()` left a dangling `obj_list_destruct` head.** `destruct_object()` unconditionally pushes onto the global `obj_list_destruct` queue, but `dealloc_object()` never unlinked the object from that queue when its ref count hit 0. Freeing an object shortly after destructing it (the normal `destruct_object()` + `free_object()` sequence, and what `reclaim_objects()` does for a stray mid-queue reference) left the queue pointing at freed memory; the next `destruct_object()` call anywhere then wrote through the dangling pointer — a heap-use-after-free confirmed with ASan.
- **`compiler_tests`: cross-test shared-string table corruption.** Two compounding bugs: `TokenizeSession()` never called `end_new_file()`, permanently pinning `lexer_utils.cc`'s `main_filename` to the first session's filename for the rest of the process; and `init_strings()` had no guard against being called twice, so the real driver boot's `vm_init()` silently reallocated the shared-string hash table and orphaned everything interned so far (including the leaked pin), which crashed the first `free_string()` against the orphaned block with "free_string called on non-shared string".

See the two commit messages for full root-cause analysis.

## Test plan
- [x] New regression tests in `test_lpc.cc` (`DestructThenImmediateFreeDoesNotDangleObjListDestruct`, `MidChainFreeKeepsObjListDestructWalkable`) crash under ASan on the unfixed binary at the reported call site and pass cleanly with the fix.
- [x] `compiler_tests` full run (195 tests) crashes deterministically on the unfixed binary, passes cleanly with the fix.
- [x] Full LPC testsuite (608 files) passes twice on both RelWithDebInfo and Debug+ASan/UBSan.
- [x] All GTest suites pass.

Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014yUZe1SjXPhAoSbEv2pDV2

---
_Generated by [Claude Code](https://claude.ai/code/session_014yUZe1SjXPhAoSbEv2pDV2)_