### PR TITLE
lpcc: emit --ast output for objects already loaded during boot

### DIFF
--- a/.github/actions/build-wasm/action.yml
+++ b/.github/actions/build-wasm/action.yml
@@ -83,12 +83,20 @@ runs:
       run: node tools/wasm/run-testsuite.js
 
     # The wasm lpcc (NODERAWFS node CLI, shipped by the fluffos-vscode
-    # extension): compile a real testsuite file and check the --json
-    # tokens envelope comes back.
+    # extension): every stage output against real testsuite files.
+    #   --tokens        : lexer stage envelope
+    #   bytecode dump   : switch.lpc's STRING switch pins the wasm32 table
+    #                     stride (keys are 8-byte ins_int, not sizeof(char*)
+    #                     -- a pointer-width walk desyncs and traps on wasm)
+    #   --ast on master : boot-loaded objects must recompile for their AST
     - name: Smoke-test wasm lpcc
       shell: bash
       run: |
         cd testsuite
         node ../build-wasm/src/lpcc.js --json --tokens etc/config.test single/tests/efuns/dual_extension.lpc \
           | grep -q '"fluffos_lpcc"'
+        node ../build-wasm/src/lpcc.js --json etc/config.test single/tests/operators/switch.lpc \
+          | grep -q '"stage":"bytecode"'
+        node ../build-wasm/src/lpcc.js --json --ast etc/config.test single/master.lpc \
+          | grep -q '"stage":"ast"'
         echo "wasm lpcc OK"

--- a/src/compiler/internal/disassembler.cc
+++ b/src/compiler/internal/disassembler.cc
@@ -790,8 +790,16 @@ static void disassemble(DisSink& sink, char* code, int start, int end, program_t
           pc += sizeof(LPC_INT);
         } else {
           while (pc < aptr + etable) {
-            COPY_PTR(&parg, pc);
-            COPY_SHORT(&sarg, pc + sizeof(char*));
+            // Table keys are written by icode.cc as ins_int() -- an LPC_INT
+            // (8 bytes) even on 32-bit targets, where string-case pointers
+            // are WIDENED into it (the runtime f_switch walks the table the
+            // same way, SWITCH_CASE_SIZE = sizeof(LPC_INT) + sizeof(short)).
+            // A sizeof(char*) stride here happens to coincide on 64-bit
+            // hosts but desyncs on wasm32 and reads wild pointers.
+            LPC_INT key;
+            COPY_INT(&key, pc);
+            parg = reinterpret_cast<char*>(static_cast<POINTER_INT>(key));
+            COPY_SHORT(&sarg, pc + sizeof(LPC_INT));
             if (ttype == 1 || !parg) {
               if (sarg == 1) {
                 if (sink.f) fprintf(sink.f, "\t%-4p\t<range start>\n", parg);
@@ -806,7 +814,7 @@ static void disassemble(DisSink& sink, char* code, int start, int end, program_t
                 swcases->push_back({{"key", disassem_string(parg)}, {"to", addr + sarg}});
               }
             }
-            pc += 2 + sizeof(char*);
+            pc += 2 + sizeof(LPC_INT);
           }
         }
         continue;

--- a/src/main_lpcc.cc
+++ b/src/main_lpcc.cc
@@ -107,11 +107,29 @@ int main(int argc, char** argv) {
     error_context_t econ{};
     save_context(&econ);
     try {
-      obj = find_object(file);
+      if (flag_ast) {
+        // The AST only exists during an actual compile. An object that was
+        // already loaded during boot (the master, the simul_efun object, and
+        // everything they inherit) would produce no --ast output at all, so
+        // force a fresh compile of those through the hot-reload path.
+        obj = find_object2(file);
+        if (obj != nullptr && obj->prog != nullptr) {
+          // recompile_object() refuses while current_object executes the old
+          // program, which would reject the master itself; nothing is
+          // executing here, so drop the context for the duration.
+          current_object = nullptr;
+          recompile_object(obj);
+        }
+      }
+      if (obj == nullptr || obj->prog == nullptr) {
+        current_object = master_ob;
+        obj = find_object(file);
+      }
     } catch (...) {
       restore_context(&econ);
     }
     pop_context(&econ);
+    current_object = master_ob;
   }
 
   if (obj == nullptr || obj->prog == nullptr) {


### PR DESCRIPTION
The AST dump flags are set after `vm_start()`, and `find_object()` returns an already-loaded object without recompiling — so `--ast` (text and `--json` alike) silently produced **nothing** for the master, the simul_efun object, and everything they inherit (every `std/` library file in the testsuite mudlib). The parse trees only exist during an actual compile, unlike the bytecode dump which reads the surviving program.

Found by sweeping all 761 testsuite files through the lpcc JSON pipeline (fluffos-vscode's corpus gate): 18 files compiled fine but emitted only the `files` envelope, no `ast` envelope.

**Fix:** detect the preloaded case with `find_object2()` and force a fresh compile through `recompile_object()` — the hot-reload path, which is defined for the master and simul_efun objects and preserves identity. `current_object` is dropped for the duration: `recompile_object()` refuses while `current_object` executes the old program, which would otherwise reject recompiling the master itself; nothing is executing at that point.

Verified: `--json --ast` (and text `--ast`) now emit trees for `single/master.lpc`, `single/simul_efun.lpc`, `inherit/master/valid.lpc`, and every `std/` file; normal (not-preloaded) files and the bytecode path are unchanged; the full 762-file corpus sweep passes with 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AXqX4Kf55ArA39suS9cdCv

---
_Generated by [Claude Code](https://claude.ai/code/session_01AXqX4Kf55ArA39suS9cdCv)_