### PR TITLE
compiler: fix line-attribution bug for lineless return statements

### DIFF
--- a/src/compiler/internal/grammar_rules.cc
+++ b/src/compiler/internal/grammar_rules.cc
@@ -14,6 +14,19 @@ extern int context;       // defined in grammar.autogen.cc (via grammar.y preamb
 extern int func_present;  // defined in grammar.autogen.cc (via grammar.y preamble)
 extern int num_refs;      // defined in grammar.autogen.cc (via grammar.y preamble)
 
+// Snapshot of the function declaration's own line, taken in rule_func_type()
+// (fired right after `type optional_star identifier` -- current_line is
+// still on the function header, in the right file) and consumed by
+// rule_func() once the whole body has been parsed. rule_func() can't just
+// capture current_line itself: by the time it fires, parsing has moved on
+// past the closing '}' (LALR needs a lookahead token to reduce), which can
+// mean a completely different file if the function was the last thing in
+// an #included header. Function declarations don't nest (LPC has no named
+// function inside a function), so a single non-reentrant slot is safe --
+// anonymous/lambda functions go through rule_primary_expr_anon_func()
+// instead and never touch this.
+static int pending_func_decl_line;
+
 void rule_program(parse_node_t* program_node) { comp_trees[TREE_MAIN] = program_node; }
 
 bool rule_inheritence(parse_node_t** result_node, int type_mod,
@@ -150,6 +163,7 @@ LPC_INT rule_func_type(LPC_INT type, LPC_INT optional_star, const ScratchString*
 #ifdef SENSIBLE_MODIFIERS
   int acc_mod;
 #endif
+  pending_func_decl_line = current_line_base + current_line;
   func_present = 1;
   flags = (type >> 16);
 
@@ -254,6 +268,20 @@ void rule_func(parse_node_t** function, LPC_INT type, LPC_INT optional_star, con
       (*function)->v.number = fun;
       (*function)->l.number = max_num_locals;
       (*function)->r.expr = *block_or_semi;
+      // Safety net alongside the explicit-return line fix in
+      // rule_return_void()/rule_return_expr() (grammar_rules_loops.cc): a
+      // function whose body has NO explicit return (an implicit
+      // `return 0;`/`return;` gets synthesized above by rule_func() itself,
+      // via CREATE_RETURN's default new_node_no_line()) can still reach
+      // codegen with every one of its statements' lines equal to 0 -- e.g.
+      // an empty body, or one whose only statement the optimizer discards
+      // entirely (a side-effect-free expression statement). Stamping the
+      // function's own declaration line here (captured early, in
+      // rule_func_type(), before parsing could drift into a different
+      // file -- see pending_func_decl_line's comment) makes
+      // i_generate_node()'s existing `if (expr->line && ...)` guard call
+      // switch_to_line() at function entry regardless of what's inside.
+      (*function)->line = pending_func_decl_line;
 
       if (!(*func_types & FUNC_TRUE_VARARGS) && argument.num_arg) {
         bool have_default_args = false;

--- a/src/compiler/internal/grammar_rules_loops.cc
+++ b/src/compiler/internal/grammar_rules_loops.cc
@@ -198,6 +198,18 @@ void rule_return_void(parse_node_t** result) {
   if (exact_types && !IS_TYPE(exact_types, TYPE_VOID))
     yywarn("Non-void functions must return a value.");
   CREATE_RETURN(*result, 0);
+  // A real, user-written `return;` is reduced while current_line is still
+  // on the statement itself (unlike the implicit-return synthesis in
+  // rule_func()/rule_primary_expr_anon_func(), which fires after the whole
+  // body -- and possibly an #include pop -- has been consumed). Stamp it
+  // explicitly: CREATE_RETURN stays new_node_no_line() by default because
+  // a bare `return <constant-or-nothing>;` can otherwise be the ONLY node
+  // in a statement's whole codegen (every child is itself a
+  // new_node_no_line() leaf -- CREATE_NUMBER/CREATE_REAL/CREATE_STRING),
+  // so switch_to_line() would never fire for it and its bytecode would
+  // silently inherit whatever line was active beforehand (abs_line 0 if
+  // it's the first statement generated in the compile unit).
+  (*result)->line = current_line_base + current_line;
 }
 
 void rule_return_expr(parse_node_t** result, parse_node_t* expr) {
@@ -215,4 +227,6 @@ void rule_return_expr(parse_node_t** result, parse_node_t* expr) {
   } else {
     CREATE_RETURN(*result, expr);
   }
+  // See the comment in rule_return_void() above.
+  (*result)->line = current_line_base + current_line;
 }

--- a/src/compiler/internal/trees.h
+++ b/src/compiler/internal/trees.h
@@ -109,6 +109,19 @@ typedef struct parse_node_block_s {
 #define CREATE_TERNARY_OP_1(vn, op, t, x, y, z, p)        \
   SAFE((vn) = new_node(); (vn)->kind = NODE_TERNARY_OP_1; \
        INT_CREATE_TERNARY_OP(vn, op, t, x, y, z); (vn)->r.expr->type = p;)
+// NOTE: this macro is also used to synthesize IMPLICIT returns (an
+// appended `return 0;` for a function/closure body that doesn't already
+// end in one -- see rule_func() and rule_primary_expr_anon_func()) at a
+// point where current_line no longer reflects the body at all (parsing has
+// already moved on to whatever follows, possibly across an #include pop
+// into a different file). Those call sites rely on this staying
+// new_node_no_line() and must keep working unmodified. Real, user-written
+// `return` statements get an accurate line stamped explicitly by
+// rule_return_void()/rule_return_expr() right after calling this macro --
+// see the comment there for why (a NODE_RETURN wrapping only
+// new_node_no_line() children, e.g. `return <constant>;`, would otherwise
+// never trigger switch_to_line() and its bytecode would silently inherit
+// whichever line was active beforehand).
 #define CREATE_RETURN(vn, val) \
   SAFE((vn) = new_node_no_line(); (vn)->kind = NODE_RETURN; (vn)->r.expr = val;)
 #define CREATE_LAND_LOR(vn, op, x, y)                                                        \

--- a/src/tests/test_compiler.cc
+++ b/src/tests/test_compiler.cc
@@ -39,6 +39,7 @@
 #include "compiler/internal/scratchpad.h"
 #include "compiler/internal/stage_output.h"
 #include "mainlib.h"
+#include "vm/internal/base/interpret.h"
 #include "vm/vm.h"
 
 // ---------------------------------------------------------------------------
@@ -2233,6 +2234,89 @@ TEST(CompileEntry, FatalInsideIncludeAbortsCleanly) {
   program_t* good = compile_file("int ok2() { return 3; }\n", "/after_fatal_inc");
   ASSERT_NE(good, nullptr);
   deallocate_program(good);
+}
+
+namespace {
+function_t* find_function_by_name(program_t* prog, const char* name) {
+  for (int i = 0; i < prog->num_functions_defined; i++) {
+    if (prog->function_table[i].funcname && std::string(prog->function_table[i].funcname) == name) {
+      return &prog->function_table[i];
+    }
+  }
+  return nullptr;
+}
+}  // namespace
+
+// Regression tests for a line-attribution bug: a `return <constant>;`/
+// `return;` statement can be built entirely from new_node_no_line() nodes
+// (CREATE_RETURN wrapping a CREATE_NUMBER/CREATE_REAL/CREATE_STRING leaf,
+// or nothing at all), so i_generate_node()'s line-switch guard in icode.cc
+// never fired for it, silently attributing its bytecode to whichever line
+// was already active -- abs_line 0 if it was the first thing generated in
+// the compile unit, which an #include'd header's leading function always
+// is. Fixed by rule_return_void()/rule_return_expr() (grammar_rules_loops.cc)
+// stamping a real line onto every explicit return statement, plus a
+// safety net in rule_func() (grammar_rules.cc) stamping every function's
+// own declaration line for the implicit-return case. Both were confirmed
+// to fail (wrong file and/or line 0) on the pre-fix binary. get_explicit_
+// line_number_info() is the same decoder dump_trace()/error()/backtraces
+// and the WebSocket debugger's breakpoint resolution all use, so this
+// exercises the shared root cause without depending on debugger machinery.
+TEST(CompileEntry, ReturnConstantInsideIncludedHeaderGetsCorrectLine) {
+  ensure_compile_env();
+  std::string inc_path = std::string(TESTSUITE_DIR) + "/zz_line_attr_header.h";
+  {
+    std::ofstream inc(inc_path);
+    inc << "int header_fn() {\n"  // line 1
+        << "  return 42;\n"       // line 2: must resolve here, not line 0
+        << "}\n";                 // line 3
+  }
+  program_t* prog = compile_file(
+      "#include \"zz_line_attr_header.h\"\n"
+      "int use_it() { return header_fn(); }\n",
+      "/line_attr_return_const");
+  unlink(inc_path.c_str());
+  ASSERT_NE(prog, nullptr);
+
+  function_t* func = find_function_by_name(prog, "header_fn");
+  ASSERT_NE(func, nullptr);
+
+  const char* file = nullptr;
+  int line = 0;
+  get_explicit_line_number_info(prog->program + func->address, prog, &file, &line);
+  ASSERT_NE(file, nullptr);
+  EXPECT_STREQ(file, "zz_line_attr_header.h");
+  EXPECT_EQ(line, 2);
+
+  deallocate_program(prog);
+}
+
+TEST(CompileEntry, ImplicitReturnInsideIncludedHeaderGetsCorrectLine) {
+  ensure_compile_env();
+  std::string inc_path = std::string(TESTSUITE_DIR) + "/zz_line_attr_header2.h";
+  {
+    std::ofstream inc(inc_path);
+    inc << "void header_fn_empty() {\n"  // line 1: must resolve here, not line 0
+        << "}\n";                        // line 2
+  }
+  program_t* prog = compile_file(
+      "#include \"zz_line_attr_header2.h\"\n"
+      "int use_it2() { header_fn_empty(); return 1; }\n",
+      "/line_attr_implicit_return");
+  unlink(inc_path.c_str());
+  ASSERT_NE(prog, nullptr);
+
+  function_t* func = find_function_by_name(prog, "header_fn_empty");
+  ASSERT_NE(func, nullptr);
+
+  const char* file = nullptr;
+  int line = 0;
+  get_explicit_line_number_info(prog->program + func->address, prog, &file, &line);
+  ASSERT_NE(file, nullptr);
+  EXPECT_STREQ(file, "zz_line_attr_header2.h");
+  EXPECT_EQ(line, 1);
+
+  deallocate_program(prog);
 }
 
 TEST(CompileEntry, FdGrowthPathViaPipe) {


### PR DESCRIPTION
## Summary

A `return <constant>;`/`return;` statement can be built entirely from `new_node_no_line()` nodes (`CREATE_RETURN` wrapping a `CREATE_NUMBER`/`CREATE_REAL`/`CREATE_STRING` leaf, or nothing at all), so `i_generate_node()`'s line-switch guard in `icode.cc` never fired for it. Its bytecode silently inherited whichever line was already active — `abs_line 0` if it was the first thing generated in the compile unit, which an `#include`d header's leading function always is. A related gap hit functions with no explicit `return` at all.

Fixed in two parts:
- `rule_return_void()`/`rule_return_expr()` (`grammar_rules_loops.cc`) now stamp a real line onto every explicit, user-written `return` statement right after `CREATE_RETURN`, which itself deliberately stays `new_node_no_line()` by default since it's also used to synthesize implicit returns at a point where `current_line` no longer reflects the body (`rule_func()`, `rule_primary_expr_anon_func()`).
- `rule_func()` (`grammar_rules.cc`) stamps the function's own declaration line — captured early and safely in `rule_func_type()`, before parser lookahead can drift into a different file — onto the `NODE_FUNCTION` wrapper node, so a function with an implicit return or empty body still gets an accurate line.

This bug affects anything that decodes a program's line tables: runtime backtraces (`dump_trace()`), uncaught-error location reporting, and (originally surfaced by) a WebSocket LPC debugger currently in review in #1286, where it made breakpoints inside `#include`d header files never resolve.

## Test plan

- Two new regression tests in `test_compiler.cc` (`ReturnConstantInsideIncludedHeaderGetsCorrectLine`, `ImplicitReturnInsideIncludedHeaderGetsCorrectLine`) drive a real compile via `compile_file()` and inspect the resulting program's line table via `get_explicit_line_number_info()` — the same decoder `dump_trace()`/`error()`/backtraces use. Both were confirmed to fail on the pre-fix binary (wrong file and/or line 0).
- [x] Full GTest unit suite passes on Debug+ASan/UBSan (320/320) and RelWithDebInfo (320/320)
- [x] Full LPC testsuite (`ctest -L testsuite`) run 3× (randomized file order) clean on Debug+ASan/UBSan
- [x] Full LPC testsuite run 3× (randomized file order) clean on RelWithDebInfo

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_014yUZe1SjXPhAoSbEv2pDV2

---
_Generated by [Claude Code](https://claude.ai/code/session_014yUZe1SjXPhAoSbEv2pDV2)_