### PR TITLE
Default arguments: fix helper-name collisions and fill on all direct-call paths

### DIFF
--- a/src/compiler/internal/generate.cc
+++ b/src/compiler/internal/generate.cc
@@ -9,6 +9,7 @@
 
 #include "include/function.h"  // for F_SIMUL etc , FIXME
 #include "efuns.autogen.h"
+#include "keyword.h"                  // predefs[]: FP_EFUN name resolution
 #include "vm/internal/base/number.h"  // for formatting lpc int
 
 #include "compiler.h"  // for CURRENT_PROGRAM_SIZE
@@ -730,7 +731,11 @@ static nlohmann::json ast_json(parse_node_t* expr) {
       if (expr->r.expr) ast_json_children(n, expr->r.expr);
       switch (expr->v.number & 0xff) {
         case FP_EFUN:
-          n["a"].push_back(instr_name(expr->v.number >> 8));
+          // At AST time v.number>>8 is a predefs[] index (icode translates
+          // it to the instruction via predefs[idx].token when emitting).
+          // Resolving it against instrs[] directly printed an unrelated,
+          // build-dependent opcode name for every (: efun :) node.
+          n["a"].push_back(predefs[expr->v.number >> 8].word);
           break;
         case FP_FUNCTIONAL:
         case FP_FUNCTIONAL | FP_NOT_BINDABLE:

--- a/src/compiler/internal/grammar_rules.cc
+++ b/src/compiler/internal/grammar_rules.cc
@@ -297,9 +297,20 @@ void rule_func(parse_node_t** function, LPC_INT type, LPC_INT optional_star, con
               return;
             }
             FUNCTION_DEF(fun)->min_arg--;
-            // TODO: generate a unique name for the function
-            auto funcname = fmt::format(FMT_STRING("#__{}_{}_{}"), get_current_time(), identifier,
-                                        local.ihe->name, local.ihe->name);
+            // The helper's name must be unique across the whole inherit
+            // chain: it is defined DECL_NOMASK, so a parent and child both
+            // defining foo(int a: (: ... :)) with colliding helper names is
+            // an "Illegal to redefine 'nomask' function" compile error.
+            // A wall-clock timestamp only disambiguated compiles that
+            // happened in DIFFERENT seconds -- overriding an inherited
+            // default-arg function failed whenever parent and child
+            // compiled within the same second (the normal case), and
+            // compiles were unreproducible byte-wise. A process-global
+            // counter is unique for every compile in the process and
+            // deterministic given compile order.
+            static uint64_t default_arg_seq = 0;
+            auto funcname = fmt::format(FMT_STRING("#__{}_{}_{}"), ++default_arg_seq, identifier,
+                                        local.ihe->name);
             // the funcnum here will change in epilog().
             auto funcnum = define_new_function(
                 funcname.c_str(), 0, 0,

--- a/src/vm/internal/base/function.cc
+++ b/src/vm/internal/base/function.cc
@@ -307,13 +307,30 @@ svalue_t* call_function_pointer(funptr_t* funp, int num_arg) {
     case FP_LOCAL | FP_NOT_BINDABLE: {
       function_t* func;
 
-      fp = sp - num_arg + 1;
-
       if (current_object->prog->function_flags[funp->f.local.index] &
           (FUNC_PROTOTYPE | FUNC_UNDEFINED)) {
         error("Undefined lfun pointer called: %s\n",
               function_name(current_object->prog, funp->f.local.index));
       }
+      /* Function-pointer calls must fill default arguments like a direct
+       * call -- `(: foo :)()` used to run foo with zeros instead of its
+       * declared defaults. Fill BEFORE fp is set: the helpers push the
+       * missing values as ordinary arguments. */
+      {
+        auto* cprog = current_object->prog;
+        int roff = funp->f.local.index;
+        if (cprog->function_flags[roff] & FUNC_ALIAS) {
+          roff = cprog->function_flags[roff] & ~FUNC_ALIAS;
+        }
+        auto result = get_function_at_index(cprog, roff);
+        if (result.first != nullptr) {
+          num_arg = fill_default_args(result.first, &result.first->function_table[result.second],
+                                      cprog->function_flags[roff], num_arg);
+        }
+      }
+
+      fp = sp - num_arg + 1;
+
       push_control_stack(FRAME_FUNCTION);
       current_prog = funp->hdr.owner->prog;
 

--- a/src/vm/internal/base/interpret.cc
+++ b/src/vm/internal/base/interpret.cc
@@ -1587,6 +1587,76 @@ std::pair<program_t*, int> get_function_at_index(program_t* prog, int findex) {
   return std::make_pair(prog, findex);
 }
 
+/* Fill missing trailing arguments for a direct call to `funcp` (defined in
+ * `progp`): pad a varargs callee with undefineds up to min_arg, then run the
+ * generated default-argument helpers ("#__..." functions, one per defaulted
+ * parameter, each returning a functional that is evaluated for the value).
+ * Following apply()'s precedent, the helpers run in the CALLER's context --
+ * current_object is deliberately not switched. Returns the new argument
+ * count.
+ *
+ * Shared by F_CALL_FUNCTION_BY_ADDRESS, F_CALL_INHERITED, FP_LOCAL function
+ * pointers and call_direct() (simul_efuns): the last three used to skip
+ * default filling entirely, so `::foo()`, `(: foo :)()` and simul calls
+ * silently ran the callee with zeros in place of its declared defaults. */
+int fill_default_args(program_t* progp, function_t* funcp, int funflags, int num_arg) {
+  if ((funflags & FUNC_TRUE_VARARGS) || funcp->min_arg == funcp->num_arg) {
+    return num_arg;
+  }
+  if (num_arg < funcp->min_arg) {
+    if (funflags & FUNC_VARARGS) {
+      push_undefineds(funcp->min_arg - num_arg);
+      num_arg = funcp->min_arg;
+    } else {
+#ifdef DEBUG
+      dump_vm_state();
+#endif
+      error("Not enough arguments to function %s, expected at least %d args, actual %d args.\n",
+            funcp->funcname, funcp->min_arg, num_arg);
+    }
+  }
+  if (num_arg == funcp->num_arg) {
+    return num_arg;
+  }
+  auto* saved_fp = fp;
+  /* NOTE: this assumes default-argument helpers are always generated right
+   * after the function, in parameter order. */
+  for (int i = num_arg; i < funcp->num_arg; i++) {
+    auto* current_sp = sp;
+    auto* default_funcp = progp->function_table + funcp->default_args_findex[i];
+    if (default_funcp->funcname[0] != APPLY___INIT_SPECIAL_CHAR) {
+#ifdef DEBUG
+      dump_vm_state();
+      dump_prog(progp, stdout, 1 | 2);
+#endif
+      error("Driver Bug: Illegal default argument function name %s in %s\n",
+            default_funcp->funcname, progp->filename);
+    }
+    fp = sp + 1; /* the helper takes zero args */
+    push_control_stack(FRAME_FUNCTION);
+    caller_type = ORIGIN_LOCAL;
+    csp->pc = pc;
+    csp->num_local_variables = 0;
+    csp->fr.table_index = funcp->default_args_findex[i];
+    current_prog = progp;
+    call_program(progp, default_funcp->address);
+
+    if (sp - current_sp != 1 || sp->type != T_FUNCTION || sp->u.fp == nullptr) {
+      error("Driver Bug: Bad stack after default arguments call.\n");
+    }
+    /* take the returned closure, then evaluate it for the real value */
+    svalue_t sv_funcp;
+    assign_svalue_no_free(&sv_funcp, sp);
+    pop_stack();
+    push_svalue(call_function_pointer(sv_funcp.u.fp, 0));
+    free_svalue(&sv_funcp, "fill_default_args");
+    DEBUG_CHECK(sp - current_sp != 1 && dump_vm_state(),
+                "Bad stack after default arguments call.");
+  }
+  fp = saved_fp;
+  return funcp->num_arg;
+}
+
 function_t* setup_new_frame(int findex) {
   function_t* func_entry;
   int low, high, mid;
@@ -3320,86 +3390,12 @@ void eval_instruction(char* p) {
 
         auto pushed_args = EXTRACT_UCHAR(pc++) + num_varargs;
         num_varargs = 0;
-        auto saved_pc = pc;
 
         auto result = get_function_at_index(current_object->prog, offset);
         auto* progp = result.first;
         auto* funcp = &progp->function_table[result.second];
         DEBUG_CHECK(!progp || !funcp, "BUG: Invalid Program or Illegal function index.");
-        if (!(funflags & FUNC_TRUE_VARARGS) && funcp->min_arg != funcp->num_arg) {
-          if (pushed_args < funcp->min_arg) {
-            if (funflags & FUNC_VARARGS) {
-              push_undefineds(funcp->min_arg - pushed_args);
-              pushed_args = funcp->min_arg;
-            } else {
-#ifdef DEBUG
-              dump_vm_state();
-#endif
-              error(
-                  "Not enough arguments to function %s, expected at least %d args, actual %d "
-                  "args.\n",
-                  funcp->funcname, funcp->min_arg, pushed_args);
-            }
-          }
-          // for functions with default argument values, we want to invoke the closure to
-          // fill in the arguments
-          if (pushed_args != funcp->num_arg) {
-            // NOTE: this assumes default arguments closure are always generated right after the
-            // function in order
-            for (int i = pushed_args; i < funcp->num_arg; i++) {
-              auto* current_sp = sp;
-
-              auto* default_funcp = progp->function_table + funcp->default_args_findex[i];
-              if (default_funcp->funcname[0] != '#') {
-#ifdef DEBUG
-                dump_vm_state();
-                dump_prog(progp, stdout, 1 | 2);
-#endif
-                error("Illegal default argument function name %s in %s\n", default_funcp->funcname,
-                      progp->filename);
-              }
-
-              push_control_stack(FRAME_FUNCTION);
-              fp = sp + 1;  // zero args
-              caller_type = ORIGIN_LOCAL;
-              csp->pc = saved_pc;
-              csp->num_local_variables = 0;
-              csp->fr.table_index = funcp->default_args_findex[i];
-              current_prog = progp;
-              call_program(progp, default_funcp->address);
-
-              DEBUG_CHECK((sp - current_sp != 1) && dump_vm_state(),
-                          "F_CALL_FUNCTION_BYADDRESS: bad stack after calling arg closure.");
-
-              // get the returned closure then evaluate for the real value
-              svalue_t sv_funcp;
-              assign_svalue_no_free(&sv_funcp, sp);
-              pop_stack();
-
-              DEBUG_CHECK(
-                  (sv_funcp.type != T_FUNCTION || sv_funcp.u.fp == nullptr) && dump_vm_state(),
-                  "F_CALL_FUNCTION_BYADDRESS: default args closure returned null.");
-
-              if (sv_funcp.u.refed->ref != 1) {
-                fatal("F_CALL_FUNCTION_BYADDRESS: default args closure ref count %d != 1.\n",
-                      sv_funcp.u.refed->ref);
-              }
-
-              // evaluate the closure in current context
-              push_svalue(call_function_pointer(sv_funcp.u.fp, 0));
-
-              if (sv_funcp.u.refed->ref != 1) {
-                fatal("F_CALL_FUNCTION_BYADDRESS: default args closure ref count %d != 1.\n",
-                      sv_funcp.u.refed->ref);
-              }
-              free_svalue(&sv_funcp, "F_CALL_FUNCTION_BYADDRESS: default args closure");
-
-              DEBUG_CHECK(sp - current_sp != 1, "Bad stack after default arguments call.");
-            }
-
-            pushed_args = funcp->num_arg;
-          }
-        }
+        pushed_args = fill_default_args(progp, funcp, funflags, pushed_args);
 
         /* Save all important global stack machine registers */
         push_control_stack(FRAME_FUNCTION);
@@ -3427,13 +3423,33 @@ void eval_instruction(char* p) {
 
         LOAD_SHORT(offset, pc);
 
+        int pushed_args = EXTRACT_UCHAR(pc++) + num_varargs;
+        num_varargs = 0;
+
+        /* `::`-qualified calls must fill default arguments exactly like
+         * F_CALL_FUNCTION_BY_ADDRESS -- this path used to skip them, so the
+         * parent function ran with zeros instead of its declared defaults. */
+        {
+          int roff = offset;
+          if (temp_prog->function_flags[roff] & FUNC_ALIAS) {
+            roff = temp_prog->function_flags[roff] & ~FUNC_ALIAS;
+          }
+          auto rflags = temp_prog->function_flags[roff];
+          if (!(rflags & (FUNC_PROTOTYPE | FUNC_UNDEFINED))) {
+            auto result = get_function_at_index(temp_prog, roff);
+            if (result.first != nullptr) {
+              pushed_args = fill_default_args(
+                  result.first, &result.first->function_table[result.second], rflags, pushed_args);
+            }
+          }
+        }
+
         push_control_stack(FRAME_FUNCTION);
         current_prog = temp_prog;
 
         caller_type = ORIGIN_LOCAL;
 
-        csp->num_local_variables = EXTRACT_UCHAR(pc++) + num_varargs;
-        num_varargs = 0;
+        csp->num_local_variables = pushed_args;
 
         function_index_offset += ip->function_index_offset;
         variable_index_offset += ip->variable_index_offset;
@@ -4730,6 +4746,22 @@ void call_direct(object_t* ob, int offset, int origin, int num_arg) {
   program_t* prog = ob->prog;
 
   ob->time_of_ref = g_current_gametick;
+  /* Direct calls (simul_efuns, heart_beat) must fill default arguments too;
+   * simul_efuns with defaults used to run with zeros. */
+  {
+    int roff = offset;
+    if (prog->function_flags[roff] & FUNC_ALIAS) {
+      roff = prog->function_flags[roff] & ~FUNC_ALIAS;
+    }
+    auto rflags = prog->function_flags[roff];
+    if (!(rflags & (FUNC_PROTOTYPE | FUNC_UNDEFINED))) {
+      auto result = get_function_at_index(prog, roff);
+      if (result.first != nullptr) {
+        num_arg = fill_default_args(result.first, &result.first->function_table[result.second],
+                                    rflags, num_arg);
+      }
+    }
+  }
   push_control_stack(FRAME_FUNCTION | FRAME_OB_CHANGE);
   caller_type = origin;
   csp->num_local_variables = num_arg;

--- a/src/vm/internal/base/interpret.h
+++ b/src/vm/internal/base/interpret.h
@@ -147,6 +147,11 @@ LPC_INT codepoint_lvalue_add(LPC_INT delta);
 buffer_t* svalue_to_buffer_bytes(svalue_t* from);
 
 void call_direct(object_t*, int, int, int);
+std::pair<program_t*, int> get_function_at_index(program_t* prog, int findex);
+// Pad varargs callees + evaluate default-argument helper closures (caller
+// context) before a direct call; returns the new argument count. See
+// interpret.cc for the paths that share it.
+int fill_default_args(program_t* progp, function_t* funcp, int funflags, int num_arg);
 void eval_instruction(char* p);
 
 function_t* setup_inherited_frame(int);

--- a/testsuite/clone/defarg_child.lpc
+++ b/testsuite/clone/defarg_child.lpc
@@ -1,0 +1,6 @@
+// Fixture for tests/compiler/default_args_inherit.lpc: overrides an
+// inherited function that has a default argument, SAME parameter name.
+inherit "/clone/defarg_parent";
+int foo(int a: (: 2 :)) { return a + 10; }
+int go() { return foo(); }
+int gop() { return ::foo(); }

--- a/testsuite/clone/defarg_fp.lpc
+++ b/testsuite/clone/defarg_fp.lpc
@@ -1,0 +1,5 @@
+// Fixture for tests/compiler/default_args_inherit.lpc: defaults through a
+// local function pointer.
+int foo(int a: (: 42 :)) { return a; }
+int go_fp() { function f = (: foo :); return f(); }
+int go_fp2() { return evaluate((: foo :)); }

--- a/testsuite/clone/defarg_parent.lpc
+++ b/testsuite/clone/defarg_parent.lpc
@@ -1,0 +1,2 @@
+// Fixture for tests/compiler/default_args_inherit.lpc
+int foo(int a: (: 1 :)) { return a; }

--- a/testsuite/single/simul_efun.lpc
+++ b/testsuite/single/simul_efun.lpc
@@ -237,3 +237,7 @@ string author_file(string) {
 }
 
 void simul() {}
+
+// Simul_efun with a default argument: call_direct() must fill it (pinned by
+// tests/compiler/default_args_inherit.lpc -- simuls used to see 0).
+int defarg_simul(int a: (: 77 :)) { return a; }

--- a/testsuite/single/tests/compiler/default_args_inherit.lpc
+++ b/testsuite/single/tests/compiler/default_args_inherit.lpc
@@ -1,0 +1,30 @@
+// Default arguments across every direct-call dispatch path. These used to
+// fail in two distinct ways:
+//
+// 1. Overriding an inherited function that has a default argument (same
+//    parameter name) was a same-second-flaky COMPILE FAILURE: the generated
+//    helper was named #__<wall-clock-seconds>_<fn>_<param> and defined
+//    nomask, so a parent and child compiling within the same second
+//    collided -- "Illegal to redefine 'nomask' function". Names are a
+//    process-global sequence now, unique across the inherit chain.
+//
+// 2. Only F_CALL_FUNCTION_BY_ADDRESS and apply() filled defaults at all:
+//    `::`-qualified calls, local function-pointer calls and simul_efun
+//    calls (call_direct) ran the callee with ZEROS in place of its
+//    declared defaults.
+void do_tests() {
+  object ob = clone_object("/clone/defarg_child");
+  ASSERT_EQ(12, ob->go());   // child override: its own default (2) + 10
+  ASSERT_EQ(12, ob->foo());  // external call dispatches the override too
+  ASSERT_EQ(1, ob->gop());   // ::foo() keeps the PARENT's default (1)
+  ASSERT_EQ(15, ob->foo(5)); // explicit arg still wins
+  destruct(ob);
+
+  object fpob = clone_object("/clone/defarg_fp");
+  ASSERT_EQ(42, fpob->go_fp());  // (: foo :) stored then called
+  ASSERT_EQ(42, fpob->go_fp2()); // immediate (: foo :)()
+  destruct(fpob);
+
+  ASSERT_EQ(77, defarg_simul());  // simul_efun default via call_direct
+  ASSERT_EQ(5, defarg_simul(5));  // explicit arg still wins
+}


### PR DESCRIPTION
Two related bugs in the default-argument machinery, found by differential-testing a native (64-bit) lpcc against a wasm (32-bit) one over the whole testsuite, plus an AST-dump naming fix from the same investigation.

**1. Overriding an inherited default-arg function was a same-second-flaky compile failure.** The generated per-parameter helper was named `#__<wall-clock-seconds>_<fn>_<param>` and defined `DECL_NOMASK` — so a parent and child both defining `foo(int a: (: … :))` collided whenever they compiled within the same second (the normal case for an inherit chain): `Illegal to redefine 'nomask' function '#__…_foo_a'`. Across a second boundary it silently worked. The timestamp also made compiles unreproducible byte-wise. Helper names now use a process-global sequence: unique across the inherit chain, deterministic given compile order.

**2. Default arguments were silently dropped on three of the five dispatch paths.** Only `F_CALL_FUNCTION_BY_ADDRESS` and `apply()` filled defaults. With `int foo(int a: (: 42 :))`:
- `(: foo :)()` (FP_LOCAL function pointers) ran foo with `a == 0`
- `::foo()` (F_CALL_INHERITED) ran the parent with `a == 0`
- simul_efuns with defaults (`call_direct`) ran with `a == 0`

The fill logic (varargs padding + helper-closure evaluation, in the caller's context per `apply()`'s documented precedent) is extracted into one shared `fill_default_args()` in interpret.cc, and the three missing paths now call it. `apply.cc`'s copy is left as-is: it additionally pads missing args for non-varargs callees (a documented COMPAT behavior this helper must not adopt).

**3. `--ast` printed garbage names for `(: efun :)` nodes.** At AST time `v.number >> 8` is a `predefs[]` index (icode translates via `predefs[idx].token` when emitting bytecode), but `ast_json` resolved it directly against `instrs[]` — showing an unrelated, build-dependent opcode name (`loop_incr` on one build, `F_MAP_INDEX_OPTIONAL` on another, for the same `(: sizeof :)`). Now resolves through `predefs[].word`.

**Regression test** (`testsuite/single/tests/compiler/default_args_inherit.lpc` + `clone/defarg_*` fixtures + a default-arg simul in `single/simul_efun.lpc`) pins all four dispatch paths and the override semantics: the child override uses its own default, `::foo()` keeps the parent's default, explicit args always win. It fails deterministically on the unfixed driver (compile error on the inherit).

**Validation:** full LPC suite ×3 native RelWithDebInfo, full suite under ASan+UBSan Debug (clean — no sanitizer reports, no `Bad ref count`), full suite inside the wasm driver (609 files OK), and the native-vs-wasm differential over 549 comparable testsuite files now reports zero structural mismatches in bytecode and AST models.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AXqX4Kf55ArA39suS9cdCv

---
_Generated by [Claude Code](https://claude.ai/code/session_01AXqX4Kf55ArA39suS9cdCv)_