### PR TITLE
Fix crashes reported in #1295 and #1296 (present() null-deref; string+object stack corruption / UAF)

### DIFF
--- a/src/vm/internal/base/interpret.cc
+++ b/src/vm/internal/base/interpret.cc
@@ -2691,7 +2691,7 @@ void eval_instruction(char* p) {
               case T_OBJECT: {
                 char buff[1024];
                 object_t* ob = (sp - 1)->u.ob;
-                sprintf(buff, "/%s", ob->obname);
+                snprintf(buff, sizeof(buff), "/%s", ob->obname);
                 SVALUE_STRING_ADD_LEFT(buff, "f_add: 3");
                 free_object(&ob, "f_add: 3");
                 break;
@@ -2735,10 +2735,12 @@ void eval_instruction(char* p) {
           case T_OBJECT:
             switch ((sp - 1)->type) {
               case T_STRING: {
-                const char* fname = sp->u.ob->obname;
+                /* Extend before dropping the ref: if the stack holds the last
+                   reference to a destructed object, free_object() deallocates
+                   it immediately, freeing obname with it. */
+                EXTEND_SVALUE_STRING(sp - 1, "/", "f_add: str ob");
+                EXTEND_SVALUE_STRING(sp - 1, sp->u.ob->obname, "f_add: str ob");
                 free_object(&(sp--)->u.ob, "f_add: str+ob");
-                EXTEND_SVALUE_STRING(sp, "/", "f_add: str ob");
-                EXTEND_SVALUE_STRING(sp, fname, "f_add: str ob");
                 break;
               }
               default:
@@ -2793,10 +2795,13 @@ void eval_instruction(char* p) {
               sprintf(buff, "%" LPC_FLOAT_FMTSTR_P, sp->u.real);
               EXTEND_SVALUE_STRING(lval, buff, "f_add_eq: 2");
             } else if (sp->type == T_OBJECT) {
-              const char* fname = sp->u.ob->obname;
-              free_object(&(sp--)->u.ob, "f_add_eq: 2");
-              EXTEND_SVALUE_STRING(lval, "/", "f_add: str ob");
-              EXTEND_SVALUE_STRING(lval, fname, "f_add_eq: 2");
+              /* Extend before dropping the ref (obname dies with the object's
+                 last reference), and leave sp on the consumed RHS slot like
+                 the other branches: the extra sp-- here unbalanced the stack,
+                 making the trailing rvalue store below clobber a live slot. */
+              EXTEND_SVALUE_STRING(lval, "/", "f_add_eq: 2");
+              EXTEND_SVALUE_STRING(lval, sp->u.ob->obname, "f_add_eq: 2");
+              free_object(&sp->u.ob, "f_add_eq: 2");
             } else {
               bad_argument(sp, T_OBJECT | T_STRING | T_NUMBER | T_REAL, 2, instruction);
             }

--- a/src/vm/internal/simulate.cc
+++ b/src/vm/internal/simulate.cc
@@ -1219,7 +1219,10 @@ object_t* object_present(svalue_t* v, object_t* ob) {
   if (ob->super) {
     push_svalue(v);
     ret = apply(APPLY_ID, ob->super, 1, ORIGIN_DRIVER);
-    if (ob->super->flags & O_DESTRUCTED) {
+    /* The id() apply runs arbitrary LPC: it may destruct ob itself, which
+       sets ob->super to nullptr (destruct_object), or destruct the
+       environment. */
+    if ((ob->flags & O_DESTRUCTED) || !ob->super || (ob->super->flags & O_DESTRUCTED)) {
       return nullptr;
     }
     if (!IS_ZERO(ret)) {

--- a/testsuite/single/tests/efuns/present_destruct.lpc
+++ b/testsuite/single/tests/efuns/present_destruct.lpc
@@ -1,0 +1,53 @@
+// Regression test for https://github.com/fluffos/fluffos/issues/1296
+//
+// present(str) with no target searches the caller's inventory, then calls
+// id() on the caller's environment. That apply runs arbitrary LPC: if it
+// destructs the caller, destruct_object() sets caller->super to nullptr and
+// object_present() crashed dereferencing it (reading super->flags through a
+// null pointer). Destructing the environment itself from its own id() hits
+// the same code path (the caller gets destructed when it cannot be moved
+// out). Both cases must cleanly return 0 instead.
+
+string role;
+object victim;
+
+void create(string arg) { role = arg; }
+
+void set_victim(object o) { victim = o; }
+
+int id(string name) {
+  if (role == "killer" && victim) {
+    destruct(victim);
+  }
+  if (role == "suicider") {
+    destruct(this_object());
+  }
+  return 0;
+}
+
+void move(object dest) { move_object(dest); }
+
+object probe(string what) { return present(what); }
+
+void do_tests() {
+#ifndef __NO_ENVIRONMENT__
+  object env, searcher;
+
+  // The environment's id() destructs the searching object mid-present().
+  env = new(__FILE__, "killer");
+  searcher = new(__FILE__, "searcher");
+  searcher->move(env);
+  env->set_victim(searcher);
+  ASSERT_EQ(0, searcher->probe("nothing"));
+  ASSERT_EQ(0, searcher);
+  destruct(env);
+
+  // The environment's id() destructs the environment itself mid-present().
+  env = new(__FILE__, "suicider");
+  searcher = new(__FILE__, "searcher");
+  searcher->move(env);
+  ASSERT_EQ(0, searcher->probe("nothing"));
+  ASSERT_EQ(0, env);
+  if (searcher) destruct(searcher);
+#endif
+}

--- a/testsuite/single/tests/efuns/string_add_object.lpc
+++ b/testsuite/single/tests/efuns/string_add_object.lpc
@@ -1,0 +1,63 @@
+// Regression test for https://github.com/fluffos/fluffos/issues/1295
+// (string/object concatenation in F_ADD / F_ADD_EQ / F_VOID_ADD_EQ).
+//
+// Two defects lived in these opcodes:
+//
+// 1. "str" + ob and str += ob captured ob->obname, then dropped the stack's
+//    object reference with free_object() BEFORE appending the name. If the
+//    stack held the last reference to a destructed object (possible once
+//    destruct2() has released the destruct-list reference, minutes after
+//    destruction), the object -- and obname with it -- was deallocated and
+//    the append read freed memory. destruct2() cannot be forced from a
+//    synchronous testsuite run, so that half is pinned behaviorally: the
+//    append must happen before the reference is dropped.
+//
+// 2. str += ob additionally popped one stack slot too many (the object
+//    branch did sp-- where every sibling branch leaves sp on the consumed
+//    RHS slot), so the trailing rvalue store wrote one slot below the
+//    operands -- clobbering a live local / temporary. The guard variables
+//    below detect exactly that: on the broken driver they end up holding
+//    fragments of unrelated values.
+
+mapping m = ([]);
+
+// Returns the stashed object while removing the mapping's reference.
+object take() {
+  object r = m["k"];
+  map_delete(m, "k");
+  return r;
+}
+
+void do_tests() {
+  object o = new(__FILE__);
+  string expected, s, t;
+  mixed u;
+  int guard1 = 111;
+  int guard2 = 222;
+
+  // Baseline: "str" + live object appends "/" + obname.
+  expected = "x" + o;
+  ASSERT(stringp(expected));
+  ASSERT_EQ("x/" + file_name(o)[1..], expected);
+
+  // str += ob (statement => F_VOID_ADD_EQ): must not unbalance the stack.
+  s = "x";
+  s += o;
+  ASSERT_EQ(expected, s);
+
+  // str += ob as an rvalue (F_ADD_EQ): result lands in the right slot and
+  // the guards/live locals survive.
+  t = "x";
+  u = (t += o);
+  ASSERT_EQ(expected, t);
+  ASSERT_EQ(expected, u);
+  ASSERT_EQ(111, guard1);
+  ASSERT_EQ(222, guard2);
+
+  // A destructed object read back out of a container is fetched as 0, so
+  // concatenation sees a number, not a stale object.
+  m["k"] = o;
+  destruct(o);
+  ASSERT_EQ("x0", "x" + take());
+  ASSERT_EQ(0, m["k"]);
+}


### PR DESCRIPTION
Fixes the two segfaults reported in #1295 and #1296.

## #1296 — Segfault in `f_present` / `object_present`

`object_present()` invokes the environment's `id()` apply, which runs arbitrary LPC. If that LPC destructs the searching object, `destruct_object()` sets its `->super` to `nullptr`, and the post-apply check `ob->super->flags & O_DESTRUCTED` dereferenced a null pointer. The reported fault address `0x4` is exactly `offsetof(object_t, flags)` in a release build, matching the reported `call_heart_beat → f_present → object_present` trace. Destructing the environment itself from its own `id()` reaches the same dereference (the searcher gets destructed when it cannot be moved out).

Fix: after the apply returns, bail out cleanly (`present()` returns 0) when the searcher was destructed, its environment link went away, or the environment was destructed.

## #1295 — Segfault in `eval_instruction` at the `str + ob` concatenation

Three related defects in the `F_ADD` / `F_ADD_EQ` object branches:

- **`str += ob` corrupted the eval stack** (likely the reported crash's origin): the `T_OBJECT` branch popped one slot too many (`sp--` where every sibling branch leaves `sp` on the consumed RHS slot), so the trailing rvalue store wrote one slot *below* the operands, clobbering a live local/temporary — and `F_VOID_ADD_EQ` then popped a further slot. Reproduced deterministically: after `s += ob`, sibling `int` locals held fragments of unrelated strings. A clobbered slot later misread as an object svalue produces exactly the garbage-pointer fault (`0xb3656d2f64`, ASCII string bytes) in the report.
- **Use-after-free of `obname`**: `"str" + ob` and `str += ob` captured `ob->obname`, then dropped the stack's object reference with `free_object()` *before* appending the name. When the stack holds the last reference to a destructed object (possible once `destruct2()` has released the destruct-list reference, minutes after destruction), the object — and `obname` with it — is deallocated immediately and the append reads freed memory. Now the append happens before the reference is dropped.
- **`ob + "str"`** copied the unbounded `obname` into a fixed 1024-byte stack buffer with `sprintf`; now `snprintf`.

## Regression tests

- `testsuite/single/tests/efuns/present_destruct.lpc` — drives both destruct-from-`id()` shapes; on the unfixed driver it aborts with UBSan `member access within null pointer of type 'struct object_t'` at `simulate.cc:1222`.
- `testsuite/single/tests/efuns/string_add_object.lpc` — guard locals detect the `+=` stack clobber (fails on the unfixed driver), plus behavioral pins for append-before-free ordering and destructed-object concatenation semantics.

## Validation

- Clang RelWithDebInfo + ASan/UBSan: full LPC suite green 3× (randomized order), 5799–5802 checks / 610 files.
- GCC Debug (`DEBUGMALLOC_EXTENSIONS`): full suite green with `check_memory()` after every file, no `Bad ref count`.
- Both new tests verified to fail/crash on the unfixed binary and pass on the fixed one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BV55ZRoue2DepeM1q8UNXG

---
_Generated by [Claude Code](https://claude.ai/code/session_01BV55ZRoue2DepeM1q8UNXG)_