### PR TITLE
websocket: sync vendored ws-over-h2 mux servicing with upstream 774c64a

### DIFF
--- a/src/thirdparty/libwebsockets/lib/roles/h2/ops-h2.c
+++ b/src/thirdparty/libwebsockets/lib/roles/h2/ops-h2.c
@@ -1014,7 +1014,7 @@ rops_perform_user_POLLOUT_h2(struct lws *wsi)
 		/* priority 1: post compression-transform buffered output */
 
 #if defined(LWS_ROLE_WS)
-		if (w->h2_stream_carries_ws) {
+		if (w->h2_stream_carries_ws && w->buflist_out) {
 			/*
 			 * ws-over-h2: whole DATA frames parked by
 			 * lws_h2_frame_write() waiting for tx credit.  Gate
@@ -1026,58 +1026,29 @@ rops_perform_user_POLLOUT_h2(struct lws *wsi)
 			 * once our own frames are gone.  If nothing of ours
 			 * is parked, fall through to normal servicing.
 			 */
-			if (w->buflist_out) {
-				if (lws_h2_ws_drain_parked_tx(wsi, w) < 0) {
-					lwsl_info("%s signalling to close\n",
-						  __func__);
-					lws_close_free_wsi(w,
-						LWS_CLOSE_STATUS_NOSTATUS,
-						"h2 end stream 1");
-					wa = &wsi->mux.child_list;
-					goto next_child;
-				}
-				if (!w->buflist_out)
-					/* fully drained: let the user write */
-					lws_callback_on_writable(w);
-				/*
-				 * else still skint: stay quiet, the
-				 * WINDOW_UPDATE handler re-arms every child
-				 */
+
+			if (lws_h2_ws_drain_parked_tx(wsi, w) < 0) {
+				lwsl_info("%s signalling to close\n",
+					  __func__);
+				lws_close_free_wsi(w,
+					LWS_CLOSE_STATUS_NOSTATUS,
+					"h2 end stream 1");
 				wa = &wsi->mux.child_list;
 				goto next_child;
 			}
-#if !defined(LWS_WITHOUT_EXTENSIONS)
-			/*
-			 * Tx path extension with more to send (eg,
-			 * permessage-deflate whose compressed output
-			 * exceeded its chunk buffer).  The h1 path services
-			 * this from rops_handle_POLLOUT_ws() priority 5; this
-			 * loop is the ONLY POLLOUT servicing an encapsulated
-			 * child ever gets, so it must do the same -- while
-			 * tx_draining_ext is set, lws_send_pipe_choked()
-			 * reports choked, so the user callback will never
-			 * write again and the connection wedges for good.
-			 */
-			if (lwsi_role_ws(w) &&
-			    lwsi_state(w) == LRS_ESTABLISHED &&
-			    w->ws && w->ws->tx_draining_ext) {
-				if (lws_write(w, NULL, 0,
-					      LWS_WRITE_CONTINUATION) < 0) {
-					lwsl_info("%s signalling to close\n",
-						  __func__);
-					lws_close_free_wsi(w,
-						LWS_CLOSE_STATUS_NOSTATUS,
-						"h2 ws ext drain");
-					wa = &wsi->mux.child_list;
-					goto next_child;
-				}
+			if (!w->buflist_out)
+				/* fully drained: let the user write */
 				lws_callback_on_writable(w);
-				wa = &wsi->mux.child_list;
-				goto next_child;
-			}
+			/*
+			 * else still skint: stay quiet, the
+			 * WINDOW_UPDATE handler re-arms every child
+			 */
+			wa = &wsi->mux.child_list;
+			goto next_child;
+		}
 #endif
-		} else
-#endif
+		/* ... for both ws-over-h2 and h2, deal with partial at nwsi */
+
 		if (lws_has_buffered_out(w)) {
 			lwsl_debug("%s: completing partial\n", __func__);
 			if (lws_issue_raw(w, NULL, 0) < 0) {
@@ -1091,6 +1062,34 @@ rops_perform_user_POLLOUT_h2(struct lws *wsi)
 			wa = &wsi->mux.child_list;
 			goto next_child;
 		}
+
+#if defined(LWS_ROLE_WS) && !defined(LWS_WITHOUT_EXTENSIONS)
+		/*
+		 * Tx path extension with more to send (eg, permessage-deflate
+		 * whose compressed output exceeded its chunk buffer).  The h1
+		 * path services this from rops_handle_POLLOUT_ws() priority 5;
+		 * this loop is the ONLY POLLOUT servicing an encapsulated
+		 * child ever gets, so it must do the same -- while
+		 * tx_draining_ext is set, lws_send_pipe_choked() reports
+		 * choked, so the user callback will never write again and the
+		 * connection wedges for good.  Sits after the nwsi-partial
+		 * branch above, mirroring h1's priority order.
+		 */
+		if (w->h2_stream_carries_ws && lwsi_role_ws(w) &&
+		    lwsi_state(w) == LRS_ESTABLISHED &&
+		    w->ws && w->ws->tx_draining_ext) {
+			if (lws_write(w, NULL, 0, LWS_WRITE_CONTINUATION) < 0) {
+				lwsl_info("%s signalling to close\n", __func__);
+				lws_close_free_wsi(w, LWS_CLOSE_STATUS_NOSTATUS,
+						   "h2 ws ext drain");
+				wa = &wsi->mux.child_list;
+				goto next_child;
+			}
+			lws_callback_on_writable(w);
+			wa = &wsi->mux.child_list;
+			goto next_child;
+		}
+#endif
 
 		/* priority 2: pre compression-transform buffered output */
 


### PR DESCRIPTION
Keeps the vendored lws aligned with upstream's final shape of the ws-over-h2 flow-control code.

Upstream took our buflist_out gating fix as [warmcat/libwebsockets@`347764c`](https://github.com/warmcat/libwebsockets/commit/347764c1f83141c81955300cda7cbb8c3bf55d71) and immediately followed it with Andy's own [`774c64a` "ws-over-h2: deal with choked nwsi"](https://github.com/warmcat/libwebsockets/commit/774c64a8d012876659fea2f51f737c54c21a20f3), which restructures the mux servicing priority-1 block:

- the carries-ws parked-frame drain gates directly on `carries_ws && buflist_out`;
- a carries-ws child with **nothing parked** now falls through to the generic nwsi-partial branch instead of skipping it — a child serviced while the network wsi holds a partial socket write defers (drain nwsi, re-arm, next child) rather than proceeding to the user callback, matching the priority ordering h1 connections get from `lws_handle_POLLOUT_event`.

This PR mirrors that exact shape into the vendored tree (modulo the `h2_stream_carries_ws` naming of our v4.5.x base), and relocates the permessage-deflate tx-drain servicing from #1299 (still fluffos-local; patches 2–3 of the upstream follow-up series are not yet merged there) to sit after the nwsi-partial branch, preserving the same h1-consistent priority order.

**Verification** (node h2 extended-CONNECT client, RelWithDebInfo): pmd-negotiated 30KB burst arrives complete and inflates correctly (3000/3000 markers through server context takeover); incompressible >1KB-compressed message exercises the ext drain path and reassembles intact from CONTINUATION fragments; full no-pmd h2/h1 matrix unchanged (stalled-window bursts, both subprotocols, h1 baseline); destroy-while-stalled close paths stable; LPC testsuite passes; 318 unit tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013GoWG8Jqm4zxsReCa9Ln4e

---
_Generated by [Claude Code](https://claude.ai/code/session_013GoWG8Jqm4zxsReCa9Ln4e)_