### PR TITLE
Fix stale T_UNDEFINED subtype in f_xor/f_lsh/f_rsh

### DIFF
--- a/src/packages/ops/ops.cc
+++ b/src/packages/ops/ops.cc
@@ -367,6 +367,7 @@ void f_lsh() {
   LPC_INT count = sp->u.number & 63;
   sp--;
   sp->u.number <<= count;
+  sp->subtype = 0;
 }
 
 void f_lsh_eq() {
@@ -892,6 +893,7 @@ void f_rsh() {
   LPC_INT count = sp->u.number & 63;
   sp--;
   sp->u.number >>= count;
+  sp->subtype = 0;
 }
 
 void f_rsh_eq() {
@@ -1201,6 +1203,7 @@ void f_xor() {
   CHECK_TYPES(sp, T_NUMBER, 2, F_XOR);
   sp--;
   sp->u.number ^= (sp + 1)->u.number;
+  sp->subtype = 0;
 }
 
 void f_xor_eq() {

--- a/testsuite/single/tests/compiler/default_args_inherit.lpc
+++ b/testsuite/single/tests/compiler/default_args_inherit.lpc
@@ -17,12 +17,12 @@ void do_tests() {
   ASSERT_EQ(12, ob->go());   // child override: its own default (2) + 10
   ASSERT_EQ(12, ob->foo());  // external call dispatches the override too
   ASSERT_EQ(1, ob->gop());   // ::foo() keeps the PARENT's default (1)
-  ASSERT_EQ(15, ob->foo(5)); // explicit arg still wins
+  ASSERT_EQ(15, ob->foo(5));  // explicit arg still wins
   destruct(ob);
 
   object fpob = clone_object("/clone/defarg_fp");
   ASSERT_EQ(42, fpob->go_fp());  // (: foo :) stored then called
-  ASSERT_EQ(42, fpob->go_fp2()); // immediate (: foo :)()
+  ASSERT_EQ(42, fpob->go_fp2());  // immediate (: foo :)()
   destruct(fpob);
 
   ASSERT_EQ(77, defarg_simul());  // simul_efun default via call_direct

--- a/testsuite/single/tests/operators/compound_assign_undefined.lpc
+++ b/testsuite/single/tests/operators/compound_assign_undefined.lpc
@@ -55,8 +55,30 @@ void do_tests() {
   ASSERT_EQ(0, undefinedp(u));
   ASSERT_EQ(0, u);
 
-  // Plain (non-assign) `|` on an undefined operand must not carry the
-  // "undefined" subtype into a real computed result either.
+  // Plain (non-assign) binary ops on an undefined operand must not carry
+  // the "undefined" subtype into a real computed result either. `|` and
+  // `&` already handled this; `^`, `<<`, `>>` did not (f_xor()/f_lsh()/
+  // f_rsh() reuse the left operand's stack slot for the result, same as
+  // their siblings, but were missing the sp->subtype = 0 reset).
+  //
+  // undefinedp() only trips when BOTH subtype==T_UNDEFINED and the
+  // resulting u.number == 0 (see f_undefinedp() in efuns_main.cc), so
+  // each RHS below is chosen to keep the result 0 -- a nonzero result
+  // (e.g. u | 5 == 5) would pass this assertion even with the stale
+  // subtype bug present, silently failing to exercise the fix.
   u = m["missing"];
-  ASSERT_EQ(0, undefinedp(u | 5));
+  ASSERT_EQ(0, undefinedp(u | 0));
+
+  u = m["missing"];
+  ASSERT_EQ(0, undefinedp(u & 5));
+
+  u = m["missing"];
+  ASSERT_EQ(0, undefinedp(u ^ 0));
+  ASSERT_EQ(5, m["missing"] ^ 5);
+
+  u = m["missing"];
+  ASSERT_EQ(0, undefinedp(u << 3));
+
+  u = m["missing"];
+  ASSERT_EQ(0, undefinedp(u >> 3));
 }


### PR DESCRIPTION
Follow-up to #1300 (the #1295/#1296 stack-corruption fixes). After that PR merged, I audited `eval_instruction()` and `ops.cc` for more instances of the same "one arm forgot what its sibling arms do" shape. No further stack-imbalance or free-before-use bugs turned up, but the sweep surfaced a related, distinct defect in the same file.

## The bug

"undefined" (the value read back from a missing mapping key) is represented as `{T_NUMBER, subtype=T_UNDEFINED, u.number=0}`. `f_xor()`, `f_lsh()`, and `f_rsh()` (`src/packages/ops/ops.cc`) each reuse the left operand's stack slot for an in-place numeric result (`sp--; sp->u.number OP= ...;`) but never reset that slot's `subtype` — so `x ^ 0`, `x << n`, or `x >> n` on an undefined `x` produces a real, computed `0` that still reports `undefinedp() == 1`.

Their true siblings `f_and()` and `f_or()` already do this correctly — fixed for `f_or()` in a prior commit that explicitly used `f_and()` as the reference for the fix. `f_xor()`/`f_lsh()`/`f_rsh()` were missed by that pass because they don't have a `_eq` counterpart with quite the same shape to diff against.

## Test

`undefinedp()` only trips when the result is *also* numerically `0`, so the existing test's `u | 5` (5 is nonzero) didn't actually exercise this path for `|`. Extended `testsuite/single/tests/operators/compound_assign_undefined.lpc` with zero-producing RHS values for `|`, `^`, `<<`, `>>`.

## Validation

- Confirmed each new assertion fails on the unfixed binary (3 failing checks, exactly at the `^`/`<<`/`>>` lines) and passes on the fixed one, via a deterministic stash/rebuild/test/pop/rebuild/test cycle (clang RelWithDebInfo + ASan/UBSan).
- Full LPC suite green 2× on ASan RelWithDebInfo (5812–5815 checks / 611 files) and 1× on GCC Debug (`DEBUGMALLOC_EXTENSIONS`, 5828 checks / 611 files, no `Bad ref count`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BV55ZRoue2DepeM1q8UNXG

---
_Generated by [Claude Code](https://claude.ai/code/session_01BV55ZRoue2DepeM1q8UNXG)_