### PR TITLE
fix: uninitialized float variables must stay undefined until first assignment

### DIFF
--- a/src/compiler/internal/grammar_rules_decls.cc
+++ b/src/compiler/internal/grammar_rules_decls.cc
@@ -69,21 +69,12 @@ void rule_new_name(LPC_INT star_modifier, const ScratchString* identifier) {
   if ((current_type & ~DECL_MODS) == TYPE_VOID)
     yyerror("Illegal to declare global variable of type void.");
 
-  int var_index = define_new_variable(identifier, current_type | star_modifier);
-
-  /* allocate_object_variables() zero-fills every object variable as plain
-   * int 0, with no per-slot type awareness -- a scalar `float` global with
-   * no initializer would otherwise sit at runtime as T_NUMBER until first
-   * assigned. Synthesize an implicit `= 0.0` so it's a real T_REAL from
-   * birth, like `float f = 0.0;` would produce. */
-  if (!star_modifier && (current_type & ~DECL_MODS) == TYPE_REAL) {
-    parse_node_t *expr_node, *real_node, *newnode;
-    CREATE_REAL(real_node, 0.0);
-    CREATE_BINARY_OP(expr_node, F_VOID_ASSIGN, 0, real_node, 0);
-    CREATE_OPCODE_1(expr_node->r.expr, F_GLOBAL_LVALUE, 0, var_index);
-    newnode = comp_trees[TREE_INIT];
-    CREATE_TWO_VALUES(comp_trees[TREE_INIT], 0, newnode, expr_node);
-  }
+  /* No synthesized initializer here even for `float`: a declared variable
+   * with no initializer must start undefined (const0u, undefinedp() == 1).
+   * Its declared type is enforced on first assignment instead -- '=' via
+   * do_promotions() and op= via the compile-time RHS coercion in
+   * rule_expr_assign(). */
+  define_new_variable(identifier, current_type | star_modifier);
 }
 
 void rule_new_name_with_init(LPC_INT star_modifier, const ScratchString* identifier,
@@ -145,17 +136,9 @@ parse_node_t* rule_new_local_def(const ScratchString* name, LPC_INT type_star) {
     yyerror("Illegal to declare local variable as reference");
     current_type &= ~LOCAL_MOD_REF;
   }
-  int local_num = add_local_name(name, current_type | type_star | LOCAL_MOD_UNUSED);
-
-  /* Same reasoning as the global-variable case in rule_new_name() above:
-   * push_undefineds() zero-fills locals as plain int 0, so synthesize an
-   * implicit `= 0.0` for a scalar `float` local with no initializer. */
-  if (!type_star && (current_type & ~DECL_MODS) == TYPE_REAL) {
-    parse_node_t *res, *real_node;
-    CREATE_REAL(real_node, 0.0);
-    CREATE_UNARY_OP_1(res, F_VOID_ASSIGN_LOCAL, 0, real_node, local_num);
-    return res;
-  }
+  /* Like rule_new_name(): no synthesized `= 0.0` for a bare `float` local --
+   * it must start undefined (push_undefineds/const0u) until first assigned. */
+  add_local_name(name, current_type | type_star | LOCAL_MOD_UNUSED);
   return nullptr;
 }
 

--- a/testsuite/single/tests/operators/compound_assign_float.lpc
+++ b/testsuite/single/tests/operators/compound_assign_float.lpc
@@ -14,21 +14,32 @@
 float global_f;
 
 void do_tests() {
-  float f;
+  float f, f2;
   int i;
 
-  // A declared float starts as a genuine float from birth (T_REAL 0.0),
-  // not integer 0.
-  ASSERT_EQ(1, floatp(f));
-  ASSERT_EQ(1, floatp(global_f));
+  // A declared float with no initializer starts UNDEFINED, exactly like any
+  // other uninitialized variable -- undefinedp() must report 1 until the
+  // first assignment...
+  ASSERT_EQ(1, undefinedp(f));
+  ASSERT_EQ(1, undefinedp(global_f));
 
+  // ...and the first assignment remembers the declared type: op= promotes
+  // via the compile-time RHS coercion + runtime promotion, plain = via
+  // do_promotions().
   f += 1;
+  ASSERT_EQ(0, undefinedp(f));
   ASSERT_EQ(1, floatp(f));
   ASSERT_EQ(1.0, f);
 
   global_f += 1;
+  ASSERT_EQ(0, undefinedp(global_f));
   ASSERT_EQ(1, floatp(global_f));
   ASSERT_EQ(1.0, global_f);
+
+  // Plain first assignment with an int RHS also lands as float.
+  f2 = 1;
+  ASSERT_EQ(1, floatp(f2));
+  ASSERT_EQ(1.0, f2);
 
   f = 0;
   f -= 1;


### PR DESCRIPTION
## Problem

#1303's zero-init half broke `float f; undefinedp(f)`: it synthesized an implicit `= 0.0` for every declared `float` local/global with no initializer, making the variable a genuine T_REAL 0.0 from birth. But an uninitialized variable must start **undefined** (`const0u`, `undefinedp() == 1`) regardless of declared type — mudlib code relies on `undefinedp()` to distinguish "never assigned" from "assigned 0.0".

## Fix

Revert just the two zero-init hunks (`rule_new_name` / `rule_new_local_def` in `grammar_rules_decls.cc`). The declared-type contract they were backing up is already fully enforced **on first assignment** by the other half of #1303, which stays intact:

- plain `=` promotes the RHS via `do_promotions()`
- `op=` coerces the RHS to the lvalue's declared type at compile time (`rule_expr_assign`), and the runtime opcodes promote a still-undefined T_NUMBER lvalue to float on a float RHS

So the corrected contract is: **before initialization the variable is undefined; on first assignment it remembers its declared type** — `float f;` → `undefinedp(f) == 1`, then `f += 1` → float 1.0.

## Testing

- `compound_assign_float.lpc` updated to pin the contract: `undefinedp() == 1` on freshly declared float locals and globals, `undefinedp() == 0` + `floatp() == 1` after the first `op=` or plain assignment (these assertions fail on the previous commit's binary)
- Full LPC suite passes 2× (randomized order) on a Debug build
- `testsuite/format.sh --check` and `node tools/lpc-syntax/test.mjs` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)