### PR TITLE
Harden five latent memory-safety / correctness gaps found in a driver audit

### DIFF
--- a/src/compiler/internal/icode.cc
+++ b/src/compiler/internal/icode.cc
@@ -554,6 +554,18 @@ void i_generate_node(parse_node_t* expr) {
     case NODE_CALL:
       generate_expr_list(expr->r.expr);
       end_pushes();
+      // l.number is the element/argument count and is emitted as a 16-bit
+      // short below; ins_short() truncates silently. A count > USHRT_MAX
+      // (e.g. an array/mapping literal with >65535 elements) would emit a
+      // wrong count while codegen still pushed every element, corrupting the
+      // VM stack at runtime. The physical evaluator stack currently caps at
+      // exactly 65536, so this is unreachable today -- but guard it the same
+      // way ins_rel_short()/upd_short() guard branch offsets, so raising the
+      // stack size can never turn it into silent corruption.
+      if (expr->l.number > USHRT_MAX) {
+        yyerror("too many elements in aggregate/argument list, near line %i",
+                line_being_generated);
+      }
       ins_byte(expr->v.number);
       ins_short(expr->l.number);
       break;

--- a/src/compiler/internal/lexer_rules_pp.cc
+++ b/src/compiler/internal/lexer_rules_pp.cc
@@ -3,6 +3,7 @@
 #include "compiler/internal/lexer_rules_pp.h"
 
 #include <cctype>
+#include <cstdint>
 #include <cstdlib>
 
 #include "compiler/internal/compiler.h"
@@ -400,8 +401,11 @@ namespace {
 // ---------------------------------------------------------------------------
 
 struct IfTok {
-  int op;    // 0 = number; otherwise an operator code (see ifexpr_binop)
-  long val;  // the number when op == 0
+  int op;        // 0 = number; otherwise an operator code (see ifexpr_binop)
+  int64_t val;   // the number when op == 0 -- 64-bit to match LPC_INT (a plain
+                 // `long` is 32-bit on Windows/LLP64, which would truncate #if
+                 // arithmetic and disagree with the runtime opcode / constant
+                 // folder, and make the `& 63` shift mask below UB there).
 };
 
 struct IfTokState {
@@ -418,9 +422,9 @@ void ifexpr_set_error(IfTokState* st, const char* msg) {
   if (st->error.empty()) st->error = msg;
 }
 
-long ifexpr_top(IfTokState* st);
+int64_t ifexpr_top(IfTokState* st);
 
-long ifexpr_atom(IfTokState* st) {
+int64_t ifexpr_atom(IfTokState* st) {
   if (ifexpr_at_end(st)) return 0;
   const IfTok& t = (*st->toks)[st->pos];
   if (t.op == 0) {
@@ -430,7 +434,7 @@ long ifexpr_atom(IfTokState* st) {
   switch (t.op) {
     case '(': {
       st->pos++;
-      long v = ifexpr_top(st);
+      int64_t v = ifexpr_top(st);
       if (ifexpr_peek_op(st) == ')') {
         st->pos++;
       } else {
@@ -457,8 +461,8 @@ long ifexpr_atom(IfTokState* st) {
   }
 }
 
-long ifexpr_binop(IfTokState* st, int min_prec) {
-  long lhs = ifexpr_atom(st);
+int64_t ifexpr_binop(IfTokState* st, int min_prec) {
+  int64_t lhs = ifexpr_atom(st);
   for (;;) {
     if (ifexpr_at_end(st)) break;
 
@@ -524,7 +528,7 @@ long ifexpr_binop(IfTokState* st, int min_prec) {
     if (prec < min_prec) break;
 
     st->pos++;
-    long rhs = ifexpr_binop(st, prec + 1);
+    int64_t rhs = ifexpr_binop(st, prec + 1);
 
     switch (op) {
       case 'O':
@@ -561,8 +565,8 @@ long ifexpr_binop(IfTokState* st, int min_prec) {
         lhs = lhs > rhs;
         break;
       case 's':
-        // A raw negative or >=64-bit (lhs/rhs are `long`) shift count is
-        // undefined behavior; mask to the low 6 bits (mod 64) instead of
+        // A raw negative or >=64-bit (lhs/rhs are 64-bit int64_t) shift count
+        // is undefined behavior; mask to the low 6 bits (mod 64) instead of
         // rejecting the expression, matching the runtime opcode.
         lhs = lhs << (rhs & 63);
         break;
@@ -583,8 +587,8 @@ long ifexpr_binop(IfTokState* st, int min_prec) {
           ifexpr_set_error(st, "division by 0 in #if");
           lhs = 0;
         } else if (rhs == -1) {
-          // x / -1 == -x; direct division traps (SIGFPE) for LONG_MIN.
-          lhs = (long)(0ULL - (unsigned long)lhs);
+          // x / -1 == -x; direct division traps (SIGFPE) for INT64_MIN.
+          lhs = (int64_t)(0ULL - (uint64_t)lhs);
         } else {
           lhs = lhs / rhs;
         }
@@ -606,17 +610,17 @@ long ifexpr_binop(IfTokState* st, int min_prec) {
   return lhs;
 }
 
-long ifexpr_top(IfTokState* st) {
-  long cond = ifexpr_binop(st, 0);
+int64_t ifexpr_top(IfTokState* st) {
+  int64_t cond = ifexpr_binop(st, 0);
   if (ifexpr_peek_op(st) == '?') {
     st->pos++;
-    long true_val = ifexpr_top(st);
+    int64_t true_val = ifexpr_top(st);
     if (ifexpr_peek_op(st) == ':') {
       st->pos++;
     } else {
       ifexpr_set_error(st, "'?' without ':' in #if");
     }
-    long false_val = ifexpr_top(st);
+    int64_t false_val = ifexpr_top(st);
     return cond ? true_val : false_val;
   }
   return cond;
@@ -635,7 +639,7 @@ ScratchString ifexpr_token_name(int tok, const union YYSTYPE* lv) {
 // suppressed and evaluate it. Consumes through the closing ')' (or the
 // bare name). Returns the 0/1 result; sets *ended when the expression
 // ran out mid-operand.
-long ifexpr_pull_defined(bool efun_form, void* yyscanner, bool* ended) {
+int64_t ifexpr_pull_defined(bool efun_form, void* yyscanner, bool* ended) {
   compiler_context_t* ctx = yyget_extra(yyscanner);
   ctx->suppress_expansion = true;
   union YYSTYPE lv;
@@ -645,7 +649,7 @@ long ifexpr_pull_defined(bool efun_form, void* yyscanner, bool* ended) {
     paren = true;
     tok = lpc_lex_ifexpr_next(&lv, yyscanner);
   }
-  long result = 0;
+  int64_t result = 0;
   if (tok == LPC_IFEXPR_END || tok <= 0) {
     *ended = true;
     ctx->suppress_expansion = false;
@@ -673,7 +677,7 @@ long ifexpr_pull_defined(bool efun_form, void* yyscanner, bool* ended) {
 
 }  // namespace
 
-long lpc_lex_eval_if_expr(std::string_view expr, void* yyscanner) {
+int64_t lpc_lex_eval_if_expr(std::string_view expr, void* yyscanner) {
   std::vector<IfTok> toks;
   ScratchString text(trim(expr));
   if (!text.empty()) {
@@ -687,7 +691,7 @@ long lpc_lex_eval_if_expr(std::string_view expr, void* yyscanner) {
           ended = true;
           break;
         case L_NUMBER:
-          toks.push_back(IfTok{0, static_cast<long>(lv.number)});
+          toks.push_back(IfTok{0, static_cast<int64_t>(lv.number)});
           break;
         case L_REAL:
           lexerror("floating point constants are not allowed in #if");
@@ -759,7 +763,7 @@ long lpc_lex_eval_if_expr(std::string_view expr, void* yyscanner) {
 
   IfTokState st;
   st.toks = &toks;
-  long result = ifexpr_top(&st);
+  int64_t result = ifexpr_top(&st);
   if (!st.error.empty()) {
     lexerror(st.error.c_str());
     return 0;

--- a/src/compiler/internal/lexer_rules_pp.h
+++ b/src/compiler/internal/lexer_rules_pp.h
@@ -13,6 +13,7 @@
 // input-stack push and macro expansion's ring-buffer splicing live in
 // lexer_utils.cc, next to the buffer machinery they manipulate.
 
+#include <cstdint>
 #include <memory>
 #include <string>
 #include <string_view>
@@ -50,7 +51,7 @@ ScratchString substitute(std::string_view body, const std::vector<std::string>& 
 // any parse problem (unpaired bracket, division/modulo by zero, trailing
 // '?' without ':', leftover content) calls lexerror() directly and
 // returns 0.
-long lpc_lex_eval_if_expr(std::string_view expr, void* yyscanner);
+int64_t lpc_lex_eval_if_expr(std::string_view expr, void* yyscanner);
 
 // There is NO session object. The preprocessor state lives directly in
 // g_compile: `macros` holds USER #defines only (predefines are immutable

--- a/src/packages/async/async.cc
+++ b/src/packages/async/async.cc
@@ -210,9 +210,20 @@ int aio_write(struct Request* req) {
 
 void* readthread(struct Request* req) {
   int const fd = open(req->path.c_str(), O_RDONLY);
-  auto size = read(fd, (void*)(req->data.data()), req->data.max_size());
+  if (fd < 0) {
+    req->ret = -1;
+    req->status = DONE;
+    return nullptr;
+  }
+  // Bound the read by the buffer's ACTUAL size, not max_size() (~2^62) --
+  // the caller sizes req->data before dispatching (mirror gzreadthread just
+  // above, which correctly uses .size()). A short read shrinks the buffer;
+  // a negative return leaves it untouched.
+  auto size = read(fd, (void*)(req->data.data()), req->data.size());
   close(fd);
-  req->data.resize(size);
+  if (size >= 0) {
+    req->data.resize(size);
+  }
   req->ret = size;
   req->status = DONE;
   return nullptr;

--- a/src/packages/parser/parser.cc
+++ b/src/packages/parser/parser.cc
@@ -3187,6 +3187,22 @@ static void parse_recurse(char** iwords, char** ostart, char** oend) {
   int first = 1;
   int l, idx;
 
+  // parse_recurse() enumerates every way to segment the sentence's words into
+  // dictionary phrases -- a tree whose branching factor is the number of
+  // registered compound-noun prefixes, so a cooperating dictionary can make it
+  // exponential independently of parse_rule()'s own backtracking. Meter it
+  // against the SAME budget/flag as parse_rule() (it shares the counter): once
+  // tripped, every pending parse_recurse() frame returns immediately, running
+  // its normal num_words--/FREE_MSTR cleanup on the way out (a plain return
+  // chain, not an error() that would skip it -- see the flag's comment above).
+  if (parse_rule_aborted) {
+    return;
+  }
+  if (++parse_rule_steps > MAX_PARSE_RULE_STEPS) {
+    parse_rule_aborted = true;
+    return;
+  }
+
   if (*iwords[0]) {
     *buf = 0;
     p = buf;

--- a/src/packages/sockets/socket_efuns.cc
+++ b/src/packages/sockets/socket_efuns.cc
@@ -2042,6 +2042,13 @@ void mark_sockets() {
     } else if ((s = lpc_socks[i].close_callback.s)) {
       EXTRA_REF(BLOCK(s))++;
     }
+    // f_socket_set_option() stores ref-counted strings (TLS SNI hostname /
+    // cert / key paths) into options[] via assign_svalue -- these are held
+    // off the object graph, so mark them too or check_memory() reports a
+    // bad ref count for a socket carrying a live TLS option (AGENTS.md §3).
+    for (auto& opt : lpc_socks[i].options) {
+      mark_svalue(&opt);
+    }
   }
 }
 #endif

--- a/testsuite/single/tests/compiler/if_expr_64bit.lpc
+++ b/testsuite/single/tests/compiler/if_expr_64bit.lpc
@@ -1,0 +1,42 @@
+// The #if preprocessor expression evaluator (ifexpr_* in
+// src/compiler/internal/lexer_rules_pp.cc) must compute in 64-bit, matching
+// LPC_INT and the runtime opcode / trees.cc constant folder. It used to use
+// a plain `long`, which is 32-bit on Windows/LLP64: there, a #if value wider
+// than 32 bits silently truncated (disagreeing with the same expression at
+// runtime) and a masked shift count of 32..63 was undefined behavior on the
+// 32-bit operand. On LP64 (Linux/macOS) `long` was already 64-bit, so this
+// test passes there regardless -- it pins the cross-platform contract and
+// guards against a regression back to a 32-bit evaluator type.
+void do_tests() {
+  object ob;
+  string src;
+
+  // shift_ok: a left shift past bit 31 -- 0 in a 32-bit evaluator, correct
+  // in 64-bit. mul_ok: a product that overflows 32 bits but fits 64.
+  // big_literal_ok: a literal above 2^32 must survive un-truncated.
+  src = "#if (1 << 40) == 1099511627776\n"
+    "int shift_ok() { return 1; }\n"
+    "#else\n"
+    "int shift_ok() { return 0; }\n"
+    "#endif\n"
+    "#if (1000000 * 1000000) == 1000000000000\n"
+    "int mul_ok() { return 1; }\n"
+    "#else\n"
+    "int mul_ok() { return 0; }\n"
+    "#endif\n"
+    "#if 5000000000 > 4294967296\n"
+    "int big_literal_ok() { return 1; }\n"
+    "#else\n"
+    "int big_literal_ok() { return 0; }\n"
+    "#endif\n";
+
+  rm("/gen_if_expr_64bit.c");
+  write_file("/gen_if_expr_64bit.c", src);
+  ob = load_object("/gen_if_expr_64bit");
+  ASSERT(objectp(ob));
+  ASSERT_EQ(1, ob->shift_ok());
+  ASSERT_EQ(1, ob->mul_ok());
+  ASSERT_EQ(1, ob->big_literal_ok());
+  destruct(ob);
+  rm("/gen_if_expr_64bit.c");
+}


### PR DESCRIPTION
A multi-subsystem audit (VM core, compiler front-end, network/socket, save/restore + DB/async, string/sscanf/parser) found **no new severe exploitable bug** beyond what #1304 already fixes — the driver is well-hardened. It did surface five lower-severity/latent issues, all fixed here and each verified against the actual code.

## Fixes

**1. `#if` evaluator computed in `long` → truncation/UB on Windows (LLP64).** [lexer_rules_pp.cc](src/compiler/internal/lexer_rules_pp.cc) — on LP64 (Linux/macOS) `long` is 64-bit and fine, but on the supported Windows/MinGW target it's 32-bit: `#if` arithmetic truncated to 32 bits (disagreeing with the runtime opcode and `trees.cc` constant folder) and the `<< (rhs & 63)` shift was UB for a masked count of 32–63 on a 32-bit operand. Widened `IfTok::val`, the `ifexpr_*` evaluator, and `lpc_lex_eval_if_expr()` to `int64_t`. Regression test `compiler/if_expr_64bit.lpc` pins the 64-bit contract.

**2. `parse_recurse()` unmetered backtracker (§13.12 sibling).** [parser.cc](src/packages/parser/parser.cc) — the `MAX_PARSE_RULE_STEPS` budget on `parse_rule()` only short-circuits the leaves; the word-segmentation tree itself kept traversing after the budget tripped, so a mudlib registering many overlapping compound nouns could make it exponential (a C-stack DoS invisible to `max_eval_cost`). Now honors the same shared counter/abort flag, unwinding via plain returns that run each frame's `num_words--`/`FREE_MSTR` cleanup.

**3. `mark_sockets()` ignored TLS option strings.** [socket_efuns.cc:2042](src/packages/sockets/socket_efuns.cc#L2042) — `f_socket_set_option()` stores ref-counted strings (SNI hostname / cert / key) in `options[]`; they're off-graph refs per §3. Balanced-freed, so not a safety bug, but a Debug `check_memory()` would false-positive on a socket holding a live TLS option. Marked transitively.

**4. `readthread()` dead-code buffer overflow.** [async.cc](src/packages/async/async.cc) — read with `.max_size()` (~2^62) as the count and `resize()`d a possibly-negative failed-`open()` return. Its only caller `aio_read()` is currently dead (the live path uses `gzreadthread`, correctly using `.size()`), so it's an unreachable typo — but a heap overflow if wired up. Bound by `.size()`, guard `fd < 0` and negative reads.

**5. Aggregate/argument count truncated to 16 bits (defensive).** [icode.cc](src/compiler/internal/icode.cc) — a literal with >65535 elements would truncate the `ins_short` count while codegen pushed every element → VM-stack corruption. Unreachable today only because the physical evaluator stack is hard-capped at exactly 65536 (== the truncation modulus), so the stack overflow fires first. Guarded like `ins_rel_short()`/`upd_short()` already guard branch offsets, so raising the stack size can never turn it into silent corruption.

## Testing
- Full LPC suite green **3×** (randomized order) on a Debug build, no ref-count reports.
- `testsuite/format.sh --check` and `node tools/lpc-syntax/test.mjs` clean.
- New regression: `compiler/if_expr_64bit.lpc` (passes on LP64 regardless; catches a 32-bit-`long` regression).

Note on severity: these are LOW/latent by design — #1 is compile-time correctness on Windows, #2 is precondition-gated, #3 is Debug-checker-only, #4 is dead code, #5 is a defensive backstop. Conventional "fails on the unfixed binary" regression tests aren't applicable to most (e.g. #1 can't fail on 64-bit-`long` Linux); they're fixed on code-symmetry + verification per §13's closing note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)