### PR TITLE
fix(lpc-syntax): refuse files with broken quoting instead of shreddin…

### DIFF
--- a/docs/lpc/formatter.md
+++ b/docs/lpc/formatter.md
@@ -110,19 +110,31 @@ Every write through `format.sh` / `format-corpus.mjs` is gated; a file
 that would violate any of these is reported, left untouched, and the
 run exits nonzero:
 
-1. **Token-sequence equivalence** — the output re-tokenizes to exactly
+1. **Clean lex** — the input must tokenize without hitting end-of-file
+   inside a string, char literal, template literal, block comment, or
+   text block. Each of those is a hard lexerror in the driver
+   (`src/compiler/internal/lexer.l`, "End of file in string" etc.), so
+   such a file has no well-defined token stream — e.g. one stray
+   unbalanced `"` inverts string/code sense for the whole rest of the
+   file, and "formatting" the inverted regions shreds real string
+   content. `formatLPC` throws instead of producing output. This gate
+   exists because the token-equivalence check below cannot catch it:
+   input and output mis-lex identically, so both sides compare clean.
+2. **Token-sequence equivalence** — the output re-tokenizes to exactly
    the input's token kinds and spellings; the formatter cannot change
    what the compiler sees.
-2. **Literal byte-identity** — every string/template/heredoc/char/
+3. **Literal byte-identity** — every string/template/heredoc/char/
    comment/directive token's content is byte-identical.
-3. **Idempotency** — formatting the output again reproduces it
+4. **Idempotency** — formatting the output again reproduces it
    exactly.
 
-Deliberately malformed fixtures that are not valid text (the two
-raw-byte bad-UTF-8 compiler fixtures under
-`testsuite/single/tests/compiler/fail/`) are excluded by
-`testsuite/format.sh`; anything the tokenizer cannot fully understand
-is refused rather than guessed at.
+Deliberately malformed fixtures under
+`testsuite/single/tests/compiler/fail/` are excluded by
+`testsuite/format.sh`: the two raw-byte bad-UTF-8 fixtures (not valid
+text), and the three deliberately-unterminated EOF-lexerror fixtures
+(`eof_in_string.lpc`, `eof_in_comment.lpc`, `bad_at_block.lpc`) that
+guarantee 1 refuses by design; anything the tokenizer cannot fully
+understand is refused rather than guessed at.
 
 Beyond the built-in gates, formatter changes are validated against the
 real driver: the whole reformatted testsuite must still pass

--- a/testsuite/format.sh
+++ b/testsuite/format.sh
@@ -14,9 +14,19 @@
 # similar raw-invalid-byte fixture is added later, add it BOTH there and
 # here. See AGENTS.md section 7.
 #
+# The three EOF-lexerror fixtures (eof_in_string / eof_in_comment /
+# bad_at_block) are deliberately-unterminated sources whose brokenness
+# is the point -- the driver hard-errors on them at lex time, and the
+# formatter REFUSES such input by design (formatLPC throws; see
+# docs/lpc/formatter.md "Safety guarantees"), so they must not be fed
+# to it. If a new deliberately-unterminated fail fixture is added, add
+# it here too.
+#
 # Every write is guarded by format-corpus.mjs: a file is only touched if
-# the output is token-sequence-equivalent to the input and idempotent;
-# anything else is reported and left alone, and the script exits nonzero.
+# the input lexes cleanly (no unterminated string/char/template/comment/
+# text block) and the output is token-sequence-equivalent to the input
+# and idempotent; anything else is reported and left alone, and the
+# script exits nonzero.
 set -euo pipefail
 
 SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
@@ -25,10 +35,16 @@ REPO_ROOT="$(cd -- "${SCRIPT_DIR}/.." && pwd)"
 EXCLUDES=(
   "testsuite/single/tests/compiler/fail/bad_utf8_string.lpc"
   "testsuite/single/tests/compiler/fail/bad_utf8_arrayblock.lpc"
+  "testsuite/single/tests/compiler/fail/eof_in_string.lpc"
+  "testsuite/single/tests/compiler/fail/eof_in_comment.lpc"
+  "testsuite/single/tests/compiler/fail/bad_at_block.lpc"
 )
 
 cd -- "${REPO_ROOT}"
 
+EXCLUDE_ARGS=()
+for x in "${EXCLUDES[@]}"; do EXCLUDE_ARGS+=(-e "${x}"); done
+
 find testsuite \( -name '*.lpc' -o -name '*.c' \) -type f | sort |
-  grep -Fxv -e "${EXCLUDES[0]}" -e "${EXCLUDES[1]}" |
+  grep -Fxv "${EXCLUDE_ARGS[@]}" |
   node "${REPO_ROOT}/tools/lpc-syntax/bin/format-corpus.mjs" "$@"

--- a/tools/lpc-syntax/README.md
+++ b/tools/lpc-syntax/README.md
@@ -128,6 +128,15 @@ gaining a space and stringizing to a different string. Both of these were
 real bugs found in this tool that the JS-level self-checks reported as
 clean.
 
+One recurring instance of the class is now gated up front: the tokenizer
+flags any token that hits end-of-file unterminated (string, char,
+template, block comment, text block — each a hard driver lexerror), and
+`formatLPC` refuses such input outright. Before that gate, a 1990s file
+shipped with one stray unbalanced `"` had its string/code sense inverted
+for the whole rest of the file and was silently rewritten into shredded
+garbage — token-equivalent and idempotent on both sides, because both
+sides mis-lexed identically.
+
 The only way to catch that class of bug is to validate against an
 independent ground truth: **build the actual FluffOS driver and run the
 real LPC testsuite against the reformatted corpus**:

--- a/tools/lpc-syntax/bin/format-corpus.mjs
+++ b/tools/lpc-syntax/bin/format-corpus.mjs
@@ -64,7 +64,20 @@ for (const f of files) {
     console.error(`LITERAL CONTENT CHANGED, refusing to write: ${f}`);
     continue;
   }
-  if (formatLPC(out) !== out) {
+  // The idempotency pass re-formats the candidate OUTPUT; formatLPC also
+  // throws if its input does not lex cleanly (unterminated string/char/
+  // template/comment/text block -- a driver lexerror). Input passing that
+  // same gate above does not prove the output does, so a throw here is a
+  // refusal for this file, not a crash of the whole run.
+  let again;
+  try {
+    again = formatLPC(out);
+  } catch (e) {
+    errors++;
+    console.error(`FORMAT ERROR (output does not re-lex cleanly), refusing to write: ${f}: ${e.message}`);
+    continue;
+  }
+  if (again !== out) {
     errors++;
     console.error(`NOT IDEMPOTENT, refusing to write: ${f}`);
     continue;

--- a/tools/lpc-syntax/format.mjs
+++ b/tools/lpc-syntax/format.mjs
@@ -20,7 +20,25 @@ const MAX_MULTILINE_INDENT = 16;
 export function formatLPC(source, options = {}) {
   const printWidth = options.printWidth > 0 ? options.printWidth : DEFAULT_PRINT_WIDTH;
   const indentUnit = ' '.repeat(options.indentSize > 0 ? options.indentSize : DEFAULT_INDENT_SIZE);
-  const rawToks = tokenize(source).filter((t) => t.kind !== 'whitespace');
+  const allToks = tokenize(source);
+  // REFUSE input that does not lex cleanly: an unterminated
+  // string/char/template/comment/text block is a hard driver lexerror
+  // ("End of file in string" etc., src/compiler/internal/lexer.l), and
+  // everything after the unmatched opener is nonsense tokens -- e.g. one
+  // stray '"' flips string/code sense for the whole rest of the file, so
+  // "formatting" it shreds real string content (CJK text space-separated,
+  // '\n' escapes torn into '\ n'). The corpus token-equivalence/idempotency
+  // self-check CANNOT catch this class: input and output mis-lex
+  // identically, so both sides compare clean. Throwing here is the gate --
+  // format-corpus.mjs reports the file and leaves it byte-identical.
+  const bad = allToks.find((t) => t.unterminated);
+  if (bad) {
+    throw new Error(
+      `unterminated ${bad.kind} starting at line ${bad.line}` +
+      ' (driver lexerror at EOF; the rest of the file does not lex cleanly)' +
+      ' -- refusing to format');
+  }
+  const rawToks = allToks.filter((t) => t.kind !== 'whitespace');
   const toks = maskStringizeArguments(rawToks, source, collectStringizeMacros(rawToks));
   const lines = [];
   let cur = [];

--- a/tools/lpc-syntax/test.mjs
+++ b/tools/lpc-syntax/test.mjs
@@ -276,10 +276,13 @@ check('trailing "//" comment forces a line break before following code',
         const twice = formatLPC(once);
         return once === twice && !once.split('\n').some((l) => /\/\/note.+\S/.test(l));
       })());
-check('formatter is stable on a source that swallows to EOF (unterminated construct)',
+check('a source that swallows to EOF (unterminated construct) is REFUSED,'
+      + ' not formatted: formatLPC throws (driver ground truth: "End of'
+      + ' file in string" is a hard lexerror, so the tokenization past the'
+      + ' opener is nonsense and any reformatting of it is corruption)',
       (() => {
-        const once = formatLPC('void f() {\n  "\n}\n');
-        return formatLPC(once) === once;
+        try { formatLPC('void f() {\n  "\n}\n'); return false; }
+        catch (e) { return /unterminated string/.test(e.message); }
       })());
 check('case/default label colon has no leading space (unlike ternary/mapping colons)',
       formatLPC('int f(int x) { switch (x) { case 1: return 1; default: return 0; } }\n')
@@ -1351,6 +1354,65 @@ check('a leading comment glued to the next token on its source line stays'
         const src = 'mixed a = ({ 1_000_000, /*x*/ 2_000_000, 3_000_000 });\n';
         const p1 = formatLPC(src, { printWidth: 40 });
         return p1 === formatLPC(p1, { printWidth: 40 }) && p1.includes('/*x*/ 2_000_000,');
+      })());
+
+// A file with PRE-EXISTING broken quoting -- one stray unbalanced '"'
+// somewhere, common in 1990s mudlib archives that shipped files that
+// never compiled -- used to be silently rewritten into shredded garbage:
+// past the stray quote the tokenizer's string/code sense is inverted, so
+// real string content lexes as code tokens (every CJK char a separate
+// 'unknown', '\n' escapes torn into '\ n') and the formatter re-spaces
+// them. The driver (lexer.l) hard-errors on such a file ("End of file in
+// string" at <<EOF>>), so it has NO well-defined lex -- the only correct
+// behavior is refusal. Invisible to the corpus token-equivalence +
+// idempotency self-check (input and output mis-lex identically -- same
+// blind spot as the "(::" and "'''" tokenizer fixes); the gate is the
+// tokenizer's `unterminated` flag plus formatLPC throwing on it, which
+// format-corpus.mjs turns into report-and-leave-byte-identical. Found as
+// 200+ corrupted files in the same ~91-real-world-mudlib corpus scan.
+check('broken quoting (stray unbalanced \'"\') is REFUSED: the tokenizer'
+      + ' flags the EOF-swallowing token `unterminated` and formatLPC'
+      + ' throws instead of shredding the inverted string/code regions',
+      (() => {
+        // Real-world shape: a key string missing its closing quote, CJK
+        // string content with escape sequences following it.
+        const broken = 'void create() {\n'
+                     + '  set("short, "棋苑");\n'
+                     + '  set("long", "一张桌子。\\n");\n'
+                     + '}\n';
+        // Tokenizer ground truth: exactly one flagged token, the final
+        // string, and its span runs to end-of-input.
+        const flagged = tokenize(broken).filter((t) => t.unterminated);
+        if (flagged.length !== 1 || flagged[0].kind !== 'string' ||
+            flagged[0].end !== broken.length) return false;
+        try { formatLPC(broken); return false; }
+        catch (e) { if (!/unterminated string/.test(e.message)) return false; }
+        // The balanced sibling lexes clean and still formats fine.
+        const fixed = broken.replace('"short, "', '"short", "');
+        if (tokenize(fixed).some((t) => t.unterminated)) return false;
+        const out = formatLPC(fixed);
+        return formatLPC(out) === out && out.includes('\\n');
+      })());
+check('every EOF-swallowing construct is refused the same way (driver'
+      + ' lexerrors: string, char, template, block comment, text block)',
+      (() => {
+        const cases = [
+          ['string s = "abc;\n', 'string'],
+          ["int c = 'x;\n", 'char'],
+          ['string s = `abc;\n', 'template'],
+          ['/* never ends\nint x;\n', 'comment'],
+          ['string s = @END\nbody line\n', 'textblock'],
+        ];
+        for (const [src, kind] of cases) {
+          const flagged = tokenize(src).filter((t) => t.unterminated);
+          if (flagged.length !== 1 || flagged[0].kind !== kind) return false;
+          try { formatLPC(src); return false; }
+          catch (e) { if (!e.message.includes(`unterminated ${kind}`)) return false; }
+        }
+        // Terminated siblings carry no flag.
+        return !tokenize('string s = "abc";\nint c = \'x\';\n/* ok */\n'
+                         + 'string t = `tpl`;\nstring u = @END\nbody\nEND\n')
+                  .some((t) => t.unterminated);
       })());
 
 // --- lint ---------------------------------------------------------------------

--- a/tools/lpc-syntax/tokenizer.mjs
+++ b/tools/lpc-syntax/tokenizer.mjs
@@ -5,6 +5,21 @@
 // Token kinds: comment, directive, string, template, textblock, char,
 // number, keyword, type, modifier, efunkw, identifier, operator,
 // punctuation, functional, whitespace, unknown.
+//
+// A spanning token that reaches end-of-input without its terminator
+// (string missing its closing '"', char literal missing its closing
+// "'", template literal missing its closing '`', '/*' comment missing
+// its '*/', text block missing its terminator line) is emitted with
+// `unterminated: true`. Driver ground truth
+// (src/compiler/internal/lexer.l): every one of these is a hard
+// lexerror at <<EOF>> ("End of file in string" / "End of file in a
+// comment" / "End of file in template literal" / lpc_lex_char_error /
+// heredoc-terminator error) -- the driver never assigns such a file a
+// meaning, so consumers that rewrite source (format.mjs) must treat the
+// flag as "this tokenization is nonsense past the open point" and
+// refuse. One real-world stray '"' flips string/code sense for the
+// whole rest of the file and the damage is invisible to any self-check
+// that re-tokenizes its own output with this same tokenizer.
 
 import { readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
@@ -227,8 +242,10 @@ export function tokenize(src) {
     }
     if (c === '/' && src[i + 1] === '*') {
       let j = src.indexOf('*/', i + 2);
-      j = j < 0 ? src.length : j + 2;
+      const closed = j >= 0;
+      j = closed ? j + 2 : src.length;
       push('comment', src.slice(i, j));
+      if (!closed) toks[toks.length - 1].unterminated = true;
       i = j;
       continue;
     }
@@ -264,11 +281,14 @@ export function tokenize(src) {
       if (m) end = j + m.index + term.length;
       else end = src.length;
       push('textblock', src.slice(i, end));
+      if (!m) toks[toks.length - 1].unterminated = true;
       i = end;
       continue;
     }
 
-    // strings
+    // strings -- the loop exits either ON the closing quote (j indexes
+    // it, j < length) or past end-of-input; the latter is the driver's
+    // "End of file in string" lexerror, flagged for consumers.
     if (c === '"') {
       let j = i + 1;
       while (j < src.length && src[j] !== '"') {
@@ -276,6 +296,7 @@ export function tokenize(src) {
         j++;
       }
       push('string', src.slice(i, Math.min(j + 1, src.length)));
+      if (j >= src.length) toks[toks.length - 1].unterminated = true;
       i = Math.min(j + 1, src.length);
       continue;
     }
@@ -285,9 +306,10 @@ export function tokenize(src) {
     if (c === '`') {
       let j = i + 1;
       let frag = '`';
+      let closed = false;
       while (j < src.length) {
         if (src[j] === '\\') { frag += src.slice(j, j + 2); j += 2; continue; }
-        if (src[j] === '`') { frag += '`'; j++; break; }
+        if (src[j] === '`') { frag += '`'; j++; closed = true; break; }
         if (src[j] === '$' && src[j + 1] === '{') {
           push('template', frag + '${');
           i = j + 2;
@@ -314,6 +336,7 @@ export function tokenize(src) {
         j++;
       }
       push('template', frag);
+      if (!closed) toks[toks.length - 1].unterminated = true;
       i = j;
       continue;
     }
@@ -323,7 +346,15 @@ export function tokenize(src) {
     // notably `'''` is a VALID quote-char literal, not an empty `''`).
     if (c === "'") {
       const j = skipCharSpan(src, i);
-      push('char', src.slice(i, j));
+      const span = src.slice(i, j);
+      push('char', span);
+      // A char literal without its closing quote is a driver lexerror
+      // whether it hits EOF ("End of file in char") or not (push-back
+      // recovery, compile still fails): flag it so formatLPC refuses the
+      // file (skipCharSpan ends the span without the close in that case).
+      if (!(span.length >= 2 && span.endsWith("'"))) {
+        toks[toks.length - 1].unterminated = true;
+      }
       i = j;
       continue;
     }


### PR DESCRIPTION
…g them

A file with a PRE-EXISTING stray unbalanced '"' -- 1990s mudlib archives ship many that never compiled -- was silently rewritten into garbage: past the stray quote the tokenizer's string/code sense inverts, so real string content lexes as code tokens (every CJK character a separate 'unknown' token the formatter space-separates, '\n' escapes torn into '\ n') and everything the formatter renders from those tokens shreds. 200+ real files across a 91-mudlib corpus scan were corrupted this way.

Driver-lexer ground truth (src/compiler/internal/lexer.l): hitting EOF inside a string, template literal, block comment, char literal, or text block is a hard lexerror ("End of file in string" / "End of file in a comment" / "End of file in template literal" / lpc_lex_char_error / heredoc-terminator error). Such a file has NO well-defined token stream, so per the documented safety contract (docs/lpc/formatter.md) the only correct behavior is refusal: report, leave byte-identical, exit nonzero. No speculative "fixed" formatting is invented.

Root cause of the silence: the corpus safety net (token-sequence equivalence + literal byte-identity + idempotency) re-tokenizes the output with the same tokenizer, and input and output mis-lex IDENTICALLY -- the same self-check blind spot as the "(::" (d64c3fa4) and "'''" (fd3f8b53) fixes; neither of those branches affects this bug (verified: shredding reproduces with both merged). Unlike those two, this is not a tokenizer decision that can be corrected -- the input itself is lexically meaningless past the stray quote -- so the fix is a new gate rather than a lexing change:

- tokenizer.mjs: any spanning token that reaches end-of-input without its terminator (string/char/template/'/*' comment/text block) is
  emitted with `unterminated: true`, mirroring the driver's <<EOF>>
  lexerrors one-for-one. Directive-embedded unterminated quotes stay unflagged (line-bounded by design; legal per the driver).
- format.mjs: formatLPC throws up front when any token carries the flag ("unterminated string starting at line N ... refusing to format"), which format-corpus.mjs already turns into FORMAT ERROR + leave-untouched + nonzero exit. This closes the whole class for this failure mode: no token comparison is involved, so identical mis-lex on both sides can no longer pass.
- bin/format-corpus.mjs: the idempotency re-format of the candidate OUTPUT is now inside a try -- a throw there is a per-file refusal, not a crash of the whole run (input passing the gate does not prove the output would).
- testsuite/format.sh: exclude the three deliberately-unterminated EOF-lexerror fail fixtures (eof_in_string / eof_in_comment / bad_at_block) alongside the two raw-byte bad-UTF-8 ones -- their brokenness is the point and the formatter now refuses them by design. --check goes from 779 to 776 files; errors (0) and the one pre-existing wouldChange (testsuite/tmp_eval_file.c) are unchanged vs master.
- test.mjs: regression tests -- a minimal unbalanced-quote fixture in the real-world shape (missing close quote on a key string, CJK + \n escape content following) must flag exactly the EOF-swallowing string token and make formatLPC throw, its balanced sibling must still format; all five EOF-swallowing constructs are refused the same way, terminated siblings unflagged. The old "formatter is stable on a source that swallows to EOF" check asserted the superseded behavior and now asserts the refusal. All three fail against the pre-fix code (verified by swapping master's files in).
- docs/lpc/formatter.md, README.md: document the clean-lex gate as safety guarantee #1 and the fixture exclusions.

Verified on the three sample corruptions from the corpus scan (beimeixiakexing2001 qiyuan3.lpc, xinkuangxiangkongjian2 god_weapon.lpc, xiyangzaixian3 vendor_sale.lpc -- 57/387/363 double quotes, all odd counts): master shreds all three and reports the run clean; with this fix all three are refused with FORMAT ERROR, left byte-identical, exit 1.

node tools/lpc-syntax/test.mjs: all pass.
testsuite/format.sh --check: 776 files, 0 errors, 1 pre-existing unrelated wouldChange (testsuite/tmp_eval_file.c, identical to master's 779-file baseline modulo the three by-design exclusions).


Claude-Session: https://claude.ai/code/session_01VyQCUoTo1Z93Py9aVFHQi1