### PR TITLE
feat(wasm): enable the pcre package on the WebAssembly target

### DIFF
--- a/.github/actions/build-wasm/action.yml
+++ b/.github/actions/build-wasm/action.yml
@@ -26,8 +26,11 @@ inputs:
   icu-ver:
     description: ICU release version cross-built for wasm (feeds the deps cache key).
     default: '74-2'
+  pcre-ver:
+    description: PCRE (8.x) release version cross-built for wasm (feeds the deps cache key).
+    default: '8.45'
   deps-prefix:
-    description: Install prefix for the wasm-cross-built dependencies (ICU).
+    description: Install prefix for the wasm-cross-built dependencies (ICU, PCRE).
     default: /opt/wasm-deps
 
 runs:
@@ -58,20 +61,22 @@ runs:
         sudo mkdir -p "${{ inputs.deps-prefix }}"
         sudo chown "$USER" "${{ inputs.deps-prefix }}"
 
-    # ICU cross-built for wasm32; ~10 minutes on a miss, so cache on the
-    # resolved emsdk + upstream versions (bump the -vN suffix to invalidate).
-    - name: Cache wasm dependencies (ICU)
+    # ICU + PCRE cross-built for wasm32; ~10 minutes on a miss, so cache on
+    # the resolved emsdk + upstream versions (bump the -vN suffix to
+    # invalidate).
+    - name: Cache wasm dependencies (ICU, PCRE)
       id: wasm-deps
       uses: actions/cache@v4
       with:
         path: ${{ inputs.deps-prefix }}
-        key: wasm-deps-emsdk${{ steps.emver.outputs.version }}-icu${{ inputs.icu-ver }}-v3
+        key: wasm-deps-emsdk${{ steps.emver.outputs.version }}-icu${{ inputs.icu-ver }}-pcre${{ inputs.pcre-ver }}-v3
 
     - name: Build wasm dependencies
       if: steps.wasm-deps.outputs.cache-hit != 'true'
       shell: bash
       run: |
         WORK="$RUNNER_TEMP/wasm-deps-build" ICU_VER="${{ inputs.icu-ver }}" \
+          PCRE_VER="${{ inputs.pcre-ver }}" \
           tools/wasm/build-deps.sh
 
     - name: Build driver (native tools + wasm)

--- a/docs/build-wasm.md
+++ b/docs/build-wasm.md
@@ -39,8 +39,9 @@ and isn't supported) see
 
 ## 1. Build the WASM dependencies (once)
 
-The driver needs a static WASM build of **ICU** (Unicode: grapheme
-iteration, charset conversion) — the only cross-built dependency:
+The driver needs static WASM builds of **ICU** (Unicode: grapheme
+iteration, charset conversion) and **PCRE** (classic 8.x, for the pcre
+package's efuns) — the two cross-built dependencies:
 
 ```bash
 tools/wasm/build-deps.sh          # installs into /opt/wasm-deps
@@ -50,7 +51,9 @@ tools/wasm/build-deps.sh          # installs into /opt/wasm-deps
 This is fully scripted, including the ICU cross-compile quirks (the
 `mh-unknown` platform file, and generating the data archive as C source
 with the host `genccode` because `pkgdata` cannot emit wasm objects).
-It only runs once; re-runs are no-ops.
+PCRE is a plain `emconfigure`/`emmake` static build (UTF-8 + Unicode
+properties on, JIT off — wasm has no executable data pages). It only
+runs once; re-runs are no-ops.
 
 The ICU data archive is **trimmed to break-iterator data** so the
 driver stays small (`fluffos.wasm` is ~3.6MB raw, ~0.8MB brotli) —
@@ -120,8 +123,8 @@ node tools/wasm/run-testsuite.js         # boots testsuite/, runs -ftest
 Exit code 0 plus `Checks succeeded.` is the pass signal — the same gate
 CI uses (see the `wasm` job in `.github/workflows/ci.yml`). Tests for
 packages that don't exist on this target (sockets, external, db, ffi,
-pcre, crypto, async, compress) skip themselves via `#ifdef __PACKAGE_*__`
-guards.
+crypto, async, compress) skip themselves via `#ifdef __PACKAGE_*__`
+guards; the pcre package is on, so its tests run for real.
 
 ## 6. Embedding API (custom frontends)
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -54,14 +54,15 @@ if (EMSCRIPTEN)
   set(PACKAGE_EXTERNAL OFF)  # posix_spawn + socketpair
   set(PACKAGE_FFI OFF)       # libffi/dlopen
   set(PACKAGE_SOCKETS OFF)   # BSD sockets
-  set(PACKAGE_PCRE OFF)      # libpcre not cross-built (yet)
+  # pcre stays ON: build-deps.sh cross-builds a static libpcre into the
+  # wasm-deps prefix, which CMAKE_FIND_ROOT_PATH below lets FindPCRE see.
   set(MARCH_NATIVE OFF)
   set(USE_JEMALLOC OFF)
   set(STATIC OFF)
 
-  # Cross-built static ICU (see tools/wasm/build-deps.sh).
+  # Cross-built static ICU + PCRE (see tools/wasm/build-deps.sh).
   set(FLUFFOS_WASM_DEPS "/opt/wasm-deps" CACHE PATH
-      "Prefix containing wasm-built static ICU")
+      "Prefix containing wasm-built static ICU/PCRE")
   list(APPEND CMAKE_FIND_ROOT_PATH "${FLUFFOS_WASM_DEPS}")
   if (NOT ICU_ROOT)
     set(ICU_ROOT "${FLUFFOS_WASM_DEPS}")

--- a/src/wasm/README.md
+++ b/src/wasm/README.md
@@ -119,6 +119,7 @@ save files etc.) is the natural next step — see §5.
 | OpenSSL, `net/tls.cc` | **removed** | no TLS endpoint to terminate (the page/browser owns TLS); the `sys_reload_tls` efun does not exist on this target; 2 struct fields typedef'd via `net/net_compat.h` |
 | libtelnet, `net/telnet.cc`, `net/msp.cc`, mssp | **kept** | pure C / portable; the page speaks telnet |
 | ICU (uc + data) | **kept** (cross-built) | core string handling: grapheme iteration, charset conversion, sprintf width |
+| libpcre (classic 8.x) | **kept** (cross-built) | pcre package efuns; plain C, JIT off (no executable pages in wasm) |
 | zlib | **removed** | nothing on this target needs it: MCCP + the compress package are off, and the core's gzip'd file support is gated behind `HAVE_ZLIB` (compressed `save_object` degrades to a plain save; `write_file` flag 2 errors; reads use stdio) |
 | `thirdparty/crypt` (musl crypt) | **kept** | pure C |
 | backward-cpp | **removed** | no native unwinder in wasm |
@@ -139,7 +140,7 @@ Package matrix (`src/CMakeLists.txt` forces these under `EMSCRIPTEN`):
 | db | off | MySQL/SQLite/PG client libs |
 | crypto | off | OpenSSL EVP (see §5: sha1 stays) |
 | ffi | off | libffi + dlopen |
-| pcre | off | libpcre not cross-built yet (regexp package efuns; core regexp stays) |
+| **pcre** | **on** | libpcre 8.x cross-built into the wasm-deps prefix by `tools/wasm/build-deps.sh`; all `pcre_*` efuns work |
 
 DNS (`packages/core/dns.cc`): the resolver half is a synthetic resolver
 (`dns_stub.cc`) — `resolve()` keeps the native call/return shapes but
@@ -247,8 +248,8 @@ order:
    mudlib's write paths (`/data`, save files, logs) and
    `FS.syncfs()` on a timer + on `visibilitychange`, so player data
    survives page reloads.
-3. **More packages.** PCRE cross-builds with emconfigure (or switch the
-   pcre package to PCRE2, which has better wasm support). `crypto` can
+3. **More packages.** PCRE is **done** (cross-built by
+   `tools/wasm/build-deps.sh`, package on). `crypto` can
    come back once OpenSSL's libcrypto is cross-built (or be rebased onto
    smaller portable digests). `async` can return as synchronous fallbacks
    (the efuns' contracts allow completing "later" on the next tick).
@@ -260,8 +261,9 @@ order:
    bytes out per socket id). Inter-mud protocols would then work.
 5. **Size/latency budget — done.** ICU data is trimmed to brkitr only
    (§3.1), DWARF is dropped at link (§3.2), MCCP/compress are off:
-   `fluffos.wasm` is ~3.6MB raw and **~0.8MB brotli** (~1.0MB gzip)
-   over the wire, plus ~110KB of JS glue. Remaining knobs if more is
+   `fluffos.wasm` is ~3.6MB raw (libpcre included, +~210KB) and
+   **~0.8MB brotli** (~1.1MB gzip) over the wire, plus ~110KB of JS
+   glue. Remaining knobs if more is
    ever needed: strip the name section (`--profiling-funcs` costs
    ~0.4MB raw for readable stack traces) and `-Oz` on the code
    (~1.7MB of the raw size is code).
@@ -277,9 +279,9 @@ order:
   connections, and `resolve()` resolves everything to 127.0.0.1
   synthetically (native callback shape, next tick).
 - Disabled-package efuns (`socket_*`, `external_start`, `db_*`, ffi,
-  async I/O, PCRE efuns, `compress*`/`uncompress*`) don't exist; their
+  async I/O, `compress*`/`uncompress*`) don't exist; their
   testsuite files skip themselves via `__PACKAGE_*__` guards and the
-  suite passes clean.
+  suite passes clean. (PCRE efuns exist — the pcre package is on.)
 - No zlib: gzip'd `write_file` (flag 2) raises an error, compressed
   `save_object` falls back to a plain-text save, and `.gz` files are
   not transparently decompressed by `read_file`/`restore_object`.

--- a/tools/wasm/build-deps.sh
+++ b/tools/wasm/build-deps.sh
@@ -1,12 +1,14 @@
 #!/usr/bin/env bash
 #
-# build-deps.sh -- cross-build the WASM driver's static dependency (ICU)
-# with Emscripten, into an install prefix. (zlib is not used on the wasm
-# target: MCCP, the compress package and gzip'd file support are off.)
+# build-deps.sh -- cross-build the WASM driver's static dependencies
+# (ICU, PCRE) with Emscripten, into an install prefix. (zlib is not used
+# on the wasm target: MCCP, the compress package and gzip'd file support
+# are off.)
 #
 # Produces under $PREFIX (default /opt/wasm-deps):
 #   lib/libicuuc.a lib/libicui18n.a lib/libicudata.a
 #   include/unicode/*.h ...
+#   lib/libpcre.a include/pcre.h   (pcre package efuns)
 #
 # Requirements: emcc/emconfigure/emmake on PATH, a native C/C++
 # toolchain (ICU cross-builds need native ICU tools first), curl.
@@ -15,6 +17,7 @@
 #   PREFIX     install prefix            (default /opt/wasm-deps)
 #   WORK       scratch build directory   (default <prefix>-build)
 #   ICU_VER    ICU release               (default 74-2)
+#   PCRE_VER   PCRE (8.x) release        (default 8.45, the final one)
 #   ICU_KEEP   extra icupkg keep-patterns for the ICU data trim, space
 #              separated (default: none beyond the built-ins below)
 #
@@ -36,12 +39,14 @@ set -euo pipefail
 PREFIX=${PREFIX:-/opt/wasm-deps}
 WORK=${WORK:-${PREFIX}-build}
 ICU_VER=${ICU_VER:-74-2}
+PCRE_VER=${PCRE_VER:-8.45}
 NPROC=$(nproc 2>/dev/null || echo 4)
 
 ICU_VER_U=${ICU_VER//-/_}   # 74_2
 ICU_MAJOR=${ICU_VER%%-*}    # 74
 
-if [ -f "$PREFIX/lib/libicuuc.a" ] && [ -f "$PREFIX/lib/libicudata.a" ]; then
+if [ -f "$PREFIX/lib/libicuuc.a" ] && [ -f "$PREFIX/lib/libicudata.a" ] &&
+   [ -f "$PREFIX/lib/libpcre.a" ]; then
   echo "wasm deps already present in $PREFIX; nothing to do."
   exit 0
 fi
@@ -123,6 +128,34 @@ if [ ! -f "$PREFIX/lib/libicuuc.a" ] || [ ! -f "$PREFIX/lib/libicudata.a" ]; the
     emcc -O2 -I"$WORK/icu/source/common" -c "$(basename "${DAT%.dat}")_dat.c" \
          -o icudata.o &&
     emar rcs "$PREFIX/lib/libicudata.a" icudata.o)
+fi
+
+# ---------------- PCRE (classic 8.x -- what src/packages/pcre links) ----------------
+if [ ! -f "$PREFIX/lib/libpcre.a" ]; then
+  echo "=== PCRE $PCRE_VER ==="
+  cd "$WORK"
+  if [ ! -d "pcre-$PCRE_VER" ]; then
+    curl -fsSL -o pcre.tbz2 \
+      "https://downloads.sourceforge.net/project/pcre/pcre/$PCRE_VER/pcre-$PCRE_VER.tar.bz2"
+    tar xjf pcre.tbz2
+  fi
+
+  # Plain C, no host tools needed (the default chartables come from the
+  # shipped pcre_chartables.c.dist -- --enable-rebuild-chartables would
+  # need a host-run dftables, so leave it off). JIT stays off: wasm has
+  # no executable data pages. UTF-8 + \p{...} properties are on because
+  # the driver compiles every pattern with PCRE_UTF8.
+  mkdir -p pcre-build-wasm
+  (cd pcre-build-wasm &&
+    CFLAGS="-O2" emconfigure "../pcre-$PCRE_VER/configure" \
+      --host=wasm32-unknown-none \
+      --enable-static --disable-shared \
+      --disable-cpp \
+      --enable-utf --enable-unicode-properties \
+      --prefix="$PREFIX" >/dev/null &&
+    emmake make -j"$NPROC" libpcre.la >/dev/null &&
+    emmake make install-libLTLIBRARIES \
+                 install-nodist_includeHEADERS >/dev/null)
 fi
 
 echo


### PR DESCRIPTION
Cross-build classic libpcre 8.45 (the library src/packages/pcre links) with emconfigure/emmake into the wasm-deps prefix and stop forcing PACKAGE_PCRE off under EMSCRIPTEN, so all pcre_* efuns exist in the browser driver. Mudlibs whose boot-critical code (e.g. simul_efuns doing ANSI handling with pcre_replace) calls these no longer fail to boot on wasm.

- tools/wasm/build-deps.sh: new PCRE section following the ICU pattern (idempotent re-run guard extended, PCRE_VER override). Static, UTF-8 + Unicode properties on (the driver compiles every pattern with PCRE_UTF8), JIT off (no executable pages in wasm), default chartables (no host-run dftables needed).
- src/CMakeLists.txt: drop the forced PACKAGE_PCRE OFF; FindPCRE locates the static lib through CMAKE_FIND_ROOT_PATH -> wasm-deps.
- .github/actions/build-wasm: pcre-ver input feeds the deps cache key (old ICU-only caches no longer match) and PCRE_VER reaches build-deps.sh.
- docs/build-wasm.md, src/wasm/README.md: pcre moved out of the absent-package lists; deps/build notes updated.

Verified: wasm LPC testsuite passes with the 9 pcre efun tests now active (621 OK / 0 failed, same as native); native rebuild + testsuite unaffected. fluffos.wasm grows 3,390,869 -> 3,604,494 bytes (+209KB raw, ~0.84MB brotli over the wire).


Claude-Session: https://claude.ai/code/session_01VyQCUoTo1Z93Py9aVFHQi1