### PR TITLE
docs: document the third argument (flag) of function_exists()

### DIFF
--- a/docs/efun/system/function_exists.md
+++ b/docs/efun/system/function_exists.md
@@ -8,9 +8,10 @@ title: system / function_exists
     function_exists()  -  find  the  file containing a given function in an
     object
 
-### SYNOPSYS
+### SYNOPSIS
 
     string function_exists( string str, object ob );
+    string function_exists( string str, object ob, int flag );
 
 ### DESCRIPTION
 
@@ -19,6 +20,11 @@ title: system / function_exists
     the function is defined by an inherited object.
 
     0 is returned if the function was not defined.
+
+    By default, functions that cannot be called from outside the object
+    (protected and private functions) are treated as not defined. If
+    'flag' is specified and is nonzero, such functions are reported as
+    well.
 
     Note that function_exists() does not check shadows.
 


### PR DESCRIPTION
The EN page for `function_exists()` only shows the two-argument form, but the efun accepts an optional third `flag` argument: when nonzero, protected and private functions are reported as well (see `function_exists()` in `src/vm/internal/base/interpret.cc`). The zh-CN page already documents this.

This adds the three-argument form to the synopsis, describes the flag's behaviour, and fixes the "SYNOPSYS" heading typo to match the other efun pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)