### PR TITLE
docs: document the third argument (scroll_lines) of ed_start()

### DIFF
--- a/docs/efun/ed/ed_start.md
+++ b/docs/efun/ed/ed_start.md
@@ -9,7 +9,8 @@ title: ed / ed_start
 
 ### SYNOPSIS
 
-    string ed_start(string file | void, int restricted | void)
+    string ed_start(string file | void, int restricted | void,
+                    int scroll_lines | void)
 
 ### DESCRIPTION
 
@@ -21,6 +22,13 @@ title: ed / ed_start
 
     If restricted is 1, the commands that change which file is being edited
     will be disabled.
+
+    If scroll_lines is nonzero, it sets the number of lines displayed by the
+    editor's scrolling commands (such as 'z').  The default is 20.
+
+    When ed_start() is called with exactly two arguments, a second argument
+    equal to 1 is treated as 'restricted'; any other value is treated as
+    'scroll_lines'.
 
     Only one ed session can be active per object at a time.
 

--- a/docs/i18n/zh-CN/docusaurus-plugin-content-docs/current/efun/ed/ed_start.md
+++ b/docs/i18n/zh-CN/docusaurus-plugin-content-docs/current/efun/ed/ed_start.md
@@ -9,7 +9,8 @@ title: ed / ed_start
 
 ### SYNOPSIS
 
-    string ed_start(string file | void, int restricted | void)
+    string ed_start(string file | void, int restricted | void,
+                    int scroll_lines | void)
 
 ### DESCRIPTION
 
@@ -21,6 +22,13 @@ title: ed / ed_start
 
     If restricted is 1, the commands that change which file is being edited
     will be disabled.
+
+    If scroll_lines is nonzero, it sets the number of lines displayed by the
+    editor's scrolling commands (such as 'z').  The default is 20.
+
+    When ed_start() is called with exactly two arguments, a second argument
+    equal to 1 is treated as 'restricted'; any other value is treated as
+    'scroll_lines'.
 
     Only one ed session can be active per object at a time.
 


### PR DESCRIPTION
The `ed_start` doc page only shows the two-argument form, but the efun spec in `src/packages/core/core.spec` declares three:

```
string ed_start(string | void, int | void, int | void);
```

`f_ed_start()` in `src/packages/core/ed.cc` shows the third argument sets the number of lines used by the editor's scrolling commands (such as `z`), defaulting to 20. This documents that, along with the two-argument disambiguation rule (a second argument of exactly 1 is treated as `restricted`; any other value is treated as `scroll_lines`).

The zh-CN page is currently a verbatim English copy of the EN page, so it receives the same update to keep them in sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)