### PR TITLE
Fix object-refcount over-decrement bugs behind #1327's corruption crashes

### DIFF
--- a/src/comm.cc
+++ b/src/comm.cc
@@ -793,6 +793,14 @@ void remove_interactive(object_t* ob, int dested) {
     set_eval(max_eval_cost);
     safe_apply(APPLY_NET_DEAD, ob, 0, ORIGIN_DRIVER);
     restore_command_giver();
+    /* net_dead() may have exec()'d the connection into a different object
+     * (the classic linkdead-ghost idiom). exec() already released `ob`'s
+     * interactive reference and moved it (ip->ob, plus a counted ref) to
+     * the new body -- the teardown below must release the CURRENT owner's
+     * reference, not decrement `ob`'s again (that drained a live object to
+     * ref 0: issue #1327's "ref count 0, but not destructed" fatal) nor
+     * leave the new body's ->interactive pointing at the freed ip. */
+    ob = ip->ob;
   }
 
 #ifndef NO_SNOOP
@@ -887,6 +895,7 @@ static int call_function_interactive(interactive_t* i, char* str) {
   }
 
   if ((ob->flags & O_DESTRUCTED) || bad_init_call) {
+    bool const ob_destructed = (ob->flags & O_DESTRUCTED) != 0;
     /* Sorry, the object has selfdestructed (or the call is disallowed)! */
     free_object(&sent->ob, "call_function_interactive");
     free_sentence(sent);
@@ -896,6 +905,14 @@ static int call_function_interactive(interactive_t* i, char* str) {
     i->carryover = nullptr;
     i->num_carry = 0;
     i->input_to = nullptr;
+    if (ob_destructed) {
+      /* The sentence ref freed above may have been the destructed target's
+       * LAST reference (its creation ref was released by an earlier
+       * destruct sweep) -- `ob` can be freed memory now, so we must not
+       * reach the mode-restore code below that reads ob->flags. It would
+       * be a no-op for a destructed object anyway. */
+      return 0;
+    }
     ret = 0;
   } else {
     /*

--- a/src/packages/core/add_action.cc
+++ b/src/packages/core/add_action.cc
@@ -632,7 +632,11 @@ static int remove_action(svalue_t* act, const char* verb) {
 void remove_sent(object_t* ob, object_t* user) {
   sentence_t** s;
 
-  if (!(user->flags & O_ENABLE_COMMANDS)) {
+  /* Gate on the list, not on O_ENABLE_COMMANDS: sentences can outlive the
+   * flag (disable_commands does not clear user->sent, and command() makes
+   * any object a command giver), and skipping them here left sentences
+   * whose s->ob dangled after the defining object was destructed. */
+  if (!user->sent) {
     return;
   }
 

--- a/src/packages/core/efuns_main.cc
+++ b/src/packages/core/efuns_main.cc
@@ -137,6 +137,16 @@ void f_bind() {
     error("Master object denied permission to bind() function pointer.\n");
   }
 
+  /* valid_bind() ran arbitrary LPC: if it destructed the new owner, the
+   * destruct sweep (remove_object_from_stack) already released the stack's
+   * ref and zeroed our argument slot -- storing `ob` into hdr.owner below
+   * would create an uncounted reference whose eventual free_object() in
+   * dealloc_funp() over-decrements a ref we no longer hold. Check the slot,
+   * not ob->flags: ob may already be deallocated memory. */
+  if (sp->type != T_OBJECT) {
+    error("New owner was destructed during valid_bind().\n");
+  }
+
   new_fp = reinterpret_cast<funptr_t*>(DMALLOC(sizeof(funptr_t), TAG_FUNP, "f_bind"));
   *new_fp = *old_fp;
   new_fp->hdr.ref = 1;
@@ -2476,7 +2486,7 @@ void f_sizeof() {
       free_array(sp->u.arr);
       break;
     case T_MAPPING:
-      i = sp->u.map->count;
+      i = MAP_COUNT(sp->u.map);
       free_mapping(sp->u.map);
       break;
     case T_BUFFER:

--- a/src/packages/core/sprintf.cc
+++ b/src/packages/core/sprintf.cc
@@ -458,11 +458,11 @@ void svalue_to_string(svalue_t* obj, outbuffer_t* outbuf, int indent, int traili
       outbuf_add(outbuf, " :)");
       break;
     case T_MAPPING:
-      if (!(obj->u.map->count)) {
+      if (!MAP_COUNT(obj->u.map)) {
         outbuf_add(outbuf, "([ ])");
       } else {
         outbuf_add(outbuf, "([ /* sizeof() == ");
-        outbuf_addv(outbuf, "%u", obj->u.map->count);
+        outbuf_addv(outbuf, "%u", MAP_COUNT(obj->u.map));
         outbuf_add(outbuf, " */\n");
         for (i = 0; i <= obj->u.map->table_size; i++) {
           mapping_node_t* elm;

--- a/src/packages/develop/checkmemory.cc
+++ b/src/packages/develop/checkmemory.cc
@@ -648,7 +648,7 @@ void check_all_blocks(int flag) {
         DEBUG_CHECK(query_heart_beat(ob) == 0, "Driver BUG: object with heartbeat not in hb table");
       }
     }
-    for (ob = obj_list_destruct; ob; ob = ob->next_all) {
+    for (ob = obj_list_destruct; ob; ob = ob->next_destruct) {
       if ((ob->flags & O_HEART_BEAT) != 0) {
         DEBUG_CHECK(query_heart_beat(ob) == 0, "Driver BUG: object with heartbeat not in hb table");
       }
@@ -744,7 +744,7 @@ void check_all_blocks(int flag) {
       ob->extra_ref++;
     }
     /* objects on obj_list_destruct still have a ref too */
-    for (ob = obj_list_destruct; ob; ob = ob->next_all) {
+    for (ob = obj_list_destruct; ob; ob = ob->next_destruct) {
       ob->extra_ref++;
     }
 
@@ -820,7 +820,7 @@ void check_all_blocks(int flag) {
               if (!tmp) {
                 tmp = obj_list_destruct;
                 while (tmp && tmp != ob) {
-                  tmp = tmp->next_all;
+                  tmp = tmp->next_destruct;
                 }
               }
 #ifdef DEBUG

--- a/src/packages/dwlib/dwlib.cc
+++ b/src/packages/dwlib/dwlib.cc
@@ -689,7 +689,7 @@ void f_roulette_wheel() {
 
   // Loop through the mapping, adding up the weights.
   j = m->table_size;
-  if (!j || !m->count) {
+  if (!j || !MAP_COUNT(m)) {
     error("empty mapping in roulette_wheel.\n");
   }
   num = 0;

--- a/src/tests/test_lpc.cc
+++ b/src/tests/test_lpc.cc
@@ -319,3 +319,35 @@ TEST_F(DriverTest, MidChainFreeKeepsObjListDestructWalkable) {
   RunGuarded([&] { free_object(&c, "MidChainFreeKeepsObjListDestructWalkable"); });
   RunGuarded([&] { free_object(&a, "MidChainFreeKeepsObjListDestructWalkable"); });
 }
+
+// Regression test for an object-ref over-decrement in the destruct sweep:
+// the obj_list_destruct queue used to ride on next_all/prev_all, which DEBUG
+// builds immediately reuse for the obj_list_dangling leak-hunting list.
+// Once a sweep left a still-referenced survivor behind (its next_all now
+// encoding the dangling chain), the NEXT sweep's next_all walk strayed from
+// the fresh queue into the dangling chain and ran destruct2() -- and its
+// free_object() -- on the survivor a second time, deallocating an object
+// other holders still referenced (issue #1327's corruption class). The
+// queue now rides its own next_destruct link.
+TEST_F(DriverTest, SweepDoesNotRevisitSurvivorsOfPreviousSweep) {
+  object_t* a = nullptr;
+  object_t* b = nullptr;
+  RunGuarded([&] { a = load_object_from_source("void bump() {}\n", "lifecycle_sweep_a", 0); });
+  RunGuarded([&] { b = load_object_from_source("void bump() {}\n", "lifecycle_sweep_b", 0); });
+  ASSERT_NE(a, nullptr);
+  ASSERT_NE(b, nullptr);
+
+  // Simulate an LPC variable still referencing a across its destruct.
+  add_ref(a, "SweepDoesNotRevisitSurvivorsOfPreviousSweep");
+
+  RunGuarded([&] { destruct_object(a); });
+  RunGuarded([&] { remove_destructed_objects(); });  // a survives: we hold a ref
+
+  RunGuarded([&] { destruct_object(b); });
+  RunGuarded([&] { remove_destructed_objects(); });  // must not destruct2(a) again
+
+  // Releasing our reference must be the deallocating drop; on the unfixed
+  // binary the second sweep already freed a and this is a use-after-free
+  // (caught by ASan) / double dealloc.
+  RunGuarded([&] { free_object(&a, "SweepDoesNotRevisitSurvivorsOfPreviousSweep"); });
+}

--- a/src/vm/internal/base/interpret.cc
+++ b/src/vm/internal/base/interpret.cc
@@ -166,7 +166,10 @@ void kill_ref(ref_t* ref) {
        global_ref_list at this point, so matching it would wrongly keep
        the mapping locked and leak its deferred nodes. */
     while (r) {
-      if (r != ref && r->sv.u.map == ref->sv.u.map) {
+      /* the type check matters: refs whose sv is not a mapping (foreach
+       * loop refs, killed refs) carry unrelated or uninitialized u data
+       * that could alias this mapping's address */
+      if (r != ref && r->sv.type == T_MAPPING && r->sv.u.map == ref->sv.u.map) {
         break;
       }
       r = r->next;
@@ -175,9 +178,19 @@ void kill_ref(ref_t* ref) {
       unlock_mapping(ref->sv.u.map);
     }
   }
-  if (ref->lvalue) {
-    free_svalue(&ref->sv, "kill_ref");
-  }
+  /* Release the ref's own sv unconditionally: a foreach mapping ref
+   * carries its counted mapping there even while lvalue is still null
+   * (before the first iteration), and every other state holds either a
+   * counted owner (F_MAKE_REF, lvalue set) or an uncounted tag
+   * (T_NUMBER / T_LVALUE_BYTE) for which this is a no-op. */
+  free_svalue(&ref->sv, "kill_ref");
+  /* Clear the stale tag: when the last T_REF svalue holding this ref_t is
+   * later freed, free_svalue() re-enters kill_ref, and the MAP_LOCKED
+   * check above must not re-read the (possibly already deallocated)
+   * mapping through ref->sv. */
+  ref->sv.type = T_NUMBER;
+  ref->sv.subtype = 0;
+  ref->sv.u.number = 0;
   if (ref->next) {
     ref->next->prev = ref->prev;
   }
@@ -1392,9 +1405,18 @@ void pop_control_stack() {
     playerchanged = 0;
     safe_call_efun_callback(&ftc, 0);
     object_t* cgo = command_giver;
+    /* Hold cgo across restore_command_giver(): the restore frees the
+     * command_giver ref, which could be cgo's last -- set_command_giver()
+     * below would then add_ref freed memory. */
+    if (playerchanged && cgo) {
+      add_ref(cgo, "pop_control_stack: playerchanged");
+    }
     restore_command_giver();
     if (playerchanged) {
       set_command_giver(cgo);
+      if (cgo) {
+        free_object(&cgo, "pop_control_stack: playerchanged");
+      }
     }
     outoftime = s;
     free_svalue(&(stuff->func), "pop_stack");
@@ -1809,6 +1831,11 @@ void setup_fake_frame(funptr_t* fun) {
   csp->function_index_offset = function_index_offset;
   csp->variable_index_offset = variable_index_offset;
   csp->num_local_variables = 0;
+  /* push_control_stack() clears this; the fake frame must too, or an efun
+   * that registers per-frame state against csp (f_defer via an FP_EFUN
+   * funptr) reads and chains onto whatever stale defer_list pointer the
+   * reused control-stack slot still holds. */
+  csp->defers = nullptr;
 
   pc = reinterpret_cast<char*>(&fake_program);
   caller_type = ORIGIN_FUNCTION_POINTER;
@@ -2332,6 +2359,14 @@ void eval_instruction(char* p) {
       case F_KILL_REFS: {
         int num = EXTRACT_UCHAR(pc++);
         while (num--) {
+          /* An error unwind inside this call's argument list (e.g. a catch()
+           * argument evaluated after a ref) has restore_context() kill refs
+           * belonging to the surviving frame too, so the compiler's count
+           * can exceed what is still on the list -- guard against walking
+           * off the end. */
+          if (!global_ref_list) {
+            break;
+          }
           kill_ref(global_ref_list);
         }
         break;
@@ -3069,6 +3104,23 @@ void eval_instruction(char* p) {
           /* foreach guarantees our target remains valid */
           ref->lvalue = nullptr;
           ref->sv.type = T_NUMBER;
+          ref->sv.u.number = 0;
+          if (flags & FOREACH_MAPPING) {
+            /* F_NEXT_FOREACH aims this ref at interior mapping-node value
+             * slots, so lock the mapping exactly like F_MAKE_REF does:
+             * node deletion in the loop body (map_delete, reclaim) then
+             * defers to locked_map_nodes instead of recycling the node the
+             * ref still points into (a write-through would corrupt
+             * whichever mapping reused it). Carrying the mapping as the
+             * ref's own counted sv makes kill_ref() -- reached from both
+             * the loop-variable's eventual release and any error unwind --
+             * perform the matching unlock and ref drop. */
+            mapping_t* m = (sp - 3)->u.map;
+            ref->sv.type = T_MAPPING;
+            ref->sv.u.map = m;
+            m->ref++;
+            m->count |= MAP_LOCKED;
+          }
           STACK_INC;
           sp->type = T_REF;
           sp->u.ref = ref;
@@ -3196,10 +3248,17 @@ void eval_instruction(char* p) {
         stack_in_use_as_temporary--;
 #endif
         if (sp->type == T_REF) {
-          sp->u.ref->lvalue = nullptr;
+          ref_t* r = sp->u.ref;
+          r->lvalue = nullptr;
 
-          if (!(--sp->u.ref->ref)) {
-            FREE(sp->u.ref);
+          if (!(--r->ref)) {
+            /* Normally unreachable (the loop variable still holds a ref),
+             * but if reached the ref must die through kill_ref() so its sv
+             * -- for a mapping ref loop, the counted mapping whose
+             * MAP_LOCKED this loop holds -- is released and the ref is
+             * unlinked from global_ref_list; a bare FREE left both
+             * dangling. */
+            kill_ref(r);
           }
         }
         if ((sp - 1)->type == T_LVALUE) {
@@ -3776,7 +3835,11 @@ void eval_instruction(char* p) {
         lv_owner_type = T_MAPPING;
         lv_owner = reinterpret_cast<refed_t*>(m);
 #endif
-        free_mapping(m);
+        /* Drop the stack's ref WITHOUT the possible dealloc (matching
+         * push_indexed_lvalue's mapping branch): free_mapping() on a ref-1
+         * temporary (e.g. f()->key = v) would free the node the lvalue
+         * above points into before the assignment writes through it. */
+        m->ref--;
         break;
       }
       case F_INDEX:

--- a/src/vm/internal/base/mapping.cc
+++ b/src/vm/internal/base/mapping.cc
@@ -215,7 +215,11 @@ void unlock_mapping(mapping_t* m) {
       /* take it out of the locked list ... */
       tmp = *mn;
       *mn = (*mn)->next;
-      /* and add it to the free list */
+      /* and add it to the free list -- with both slots zeroed, upholding
+       * new_map_node()'s invariant that free-list nodes carry no stale
+       * svalues (free_node's unlocked branch does the same) */
+      tmp->values[0] = const0u;
+      tmp->values[1] = const0u;
       tmp->next = free_nodes;
       free_nodes = tmp;
     } else {
@@ -233,6 +237,9 @@ void free_node(mapping_t* m, mapping_node_t* mn) {
   } else {
     free_svalue(mn->values + 1, "free_node");
     *(mn->values + 1) = const0u;
+    /* callers free the key before calling free_node; clear the stale tag
+     * so free-list nodes never carry a dangling-looking svalue */
+    *(mn->values) = const0u;
     mn->next = free_nodes;
     free_nodes = mn;
   }
@@ -366,7 +373,7 @@ static mapping_t* copyMapping(mapping_t* m) {
     FREE((char*)newmap);
     error("copyMapping 2 - out of memory.\n");
   }
-  newmap->count = m->count;
+  newmap->count = MAP_COUNT(m); /* never copy the MAP_LOCKED bit */
   total_mapping_nodes += MAP_COUNT(m);
   memset(c, 0, k * sizeof(mapping_node_t*));
   total_mapping_size +=
@@ -542,6 +549,12 @@ svalue_t* find_for_insert(mapping_t* m, svalue_t* lv, int doTheFree) {
         debug(mapping, "mapping.c: found %p\n", (void*)(n->values));
         if (doTheFree) {
           free_svalue(n->values + 1, "find_for_insert");
+          /* Zero the slot: the value's ref is gone, but the mapping is
+           * still live LPC-visible data. If the caller runs arbitrary LPC
+           * before overwriting the slot (allocate_mapping2's callback) and
+           * that LPC error()s, the unwind frees the mapping -- and a stale
+           * populated slot here would be freed a SECOND time. */
+          *(n->values + 1) = const0u;
         }
         return n->values + 1;
       }

--- a/src/vm/internal/base/object.cc
+++ b/src/vm/internal/base/object.cc
@@ -2026,20 +2026,26 @@ void dealloc_object(object_t* ob, const char* from) {
     FREE((char*)ob->obname);
     SETOBNAME(ob, nullptr);
   }
-#ifdef DEBUG
-  // obj_list_destruct (destruct_object()'s "not yet swept by
-  // remove_destructed_objects()" queue, simulate.cc) is NOT gated by
-  // DEBUG, unlike obj_list_dangling below -- but in a DEBUG build the two
-  // lists happen to share this object's next_all/prev_all storage
-  // (destruct_object() pushes onto both, one right after the other, so
-  // the two chains are always structurally identical until something is
-  // unlinked). The neighbor fixup the obj_list_dangling unlink below
-  // performs therefore already keeps the underlying chain correct for
-  // obj_list_destruct's own forward walk too; only its separate head
-  // *variable* needs updating here.
+  // Unlink from the destruct queue if this object is still awaiting its
+  // remove_destructed_objects() sweep -- an early drop to ref 0 (e.g.
+  // reclaim_objects() freeing a stray reference to a destructed object)
+  // reaches here first, and leaving it queued would have the sweep call
+  // destruct2() on freed memory (an ASan-confirmed heap-use-after-free).
+  // The queue lives on its own next_destruct link, so this unlink can
+  // never disturb next_all/prev_all (which DEBUG builds use below for the
+  // obj_list_dangling leak-hunting list).
   if (obj_list_destruct == ob) {
-    obj_list_destruct = ob->next_all;
+    obj_list_destruct = ob->next_destruct;
+  } else if (obj_list_destruct) {
+    for (object_t* q = obj_list_destruct; q->next_destruct; q = q->next_destruct) {
+      if (q->next_destruct == ob) {
+        q->next_destruct = ob->next_destruct;
+        break;
+      }
+    }
   }
+  ob->next_destruct = nullptr;
+#ifdef DEBUG
   prev_all = ob->prev_all;
   if (prev_all) {
     prev_all->next_all = ob->next_all;
@@ -2055,27 +2061,6 @@ void dealloc_object(object_t* ob, const char* from) {
   ob->next_all = 0;
   ob->prev_all = 0;
   tot_dangling_object--;
-#else
-  // No obj_list_dangling bookkeeping exists in this build to perform the
-  // equivalent neighbor fixup as a side effect (see the DEBUG branch
-  // above), so unlink from obj_list_destruct explicitly here. Otherwise a
-  // later destruct_object() call anywhere in the driver can dereference
-  // this object's now-freed address via a stale obj_list_destruct head or
-  // a neighbor's stale next_all/prev_all -- a real, ASan-confirmed
-  // heap-use-after-free (reachable via reclaim_objects() freeing a stray
-  // reference to a destructed object still queued mid-chain, or simply an
-  // object whose only reference drops immediately after destruct()).
-  if (obj_list_destruct == ob) {
-    obj_list_destruct = ob->next_all;
-    if (obj_list_destruct) {
-      obj_list_destruct->prev_all = nullptr;
-    }
-  } else if (ob->prev_all) {
-    ob->prev_all->next_all = ob->next_all;
-    if (ob->next_all) {
-      ob->next_all->prev_all = ob->prev_all;
-    }
-  }
 #endif
   tot_alloc_object--;
   FREE((char*)ob);

--- a/src/vm/internal/base/object.h
+++ b/src/vm/internal/base/object.h
@@ -89,6 +89,10 @@ struct object_t {
                                stale index-based pointers fail cleanly */
   struct object_t* next_all;
   struct object_t* prev_all;
+  struct object_t* next_destruct; /* obj_list_destruct queue link (destruct_object() ->
+                                     remove_destructed_objects()). Dedicated field: the queue
+                                     must never alias next_all/prev_all, which DEBUG builds
+                                     reuse for the obj_list_dangling leak-hunting list. */
 #ifndef NO_ENVIRONMENT
   struct object_t* next_inv;
   struct object_t* contains;

--- a/src/vm/internal/base/svalue.cc
+++ b/src/vm/internal/base/svalue.cc
@@ -173,15 +173,23 @@ void int_free_svalue(svalue_t* v)
     }
 #endif
     /* TODO: Set to 0 on condition that REF overflow to negative. */
+    bool reached_zero = false;
     if (v->u.refed->ref > 0) {
       v->u.refed->ref--;
+      reached_zero = (v->u.refed->ref == 0);
 #ifdef DEBUGMALLOC_EXTENSIONS
       if (v->u.refed != (void*)&the_null_array && v->u.refed != (void*)&null_buf) {
         md_record_ref_journal(PTR_TO_NODET(v->u.refed), false, v->u.refed->ref, tag);
       }
 #endif  // DEBUGMALLOC_EXTENSIONS
     }
-    if (v->u.refed->ref == 0) {
+    /* Only deallocate when THIS call performed the 1 -> 0 decrement. The
+     * underflow guard above used to suppress just the decrement while the
+     * unconditional `ref == 0` check still ran the dealloc -- so a second
+     * aliased svalue freeing an already-deallocated value (ref reads 0 from
+     * freed memory) triggered a second dealloc instead of containing the
+     * corruption. */
+    if (reached_zero) {
       switch (v->type) {
         case T_OBJECT:
           dealloc_object(v->u.ob, "free_svalue");
@@ -285,7 +293,7 @@ json svalue_to_json_summary(const svalue_t* obj, int depth) {
     }
     case T_MAPPING: {
       json res = json::object();
-      auto limit = std::min(5u, obj->u.map->count);
+      auto limit = std::min(5u, MAP_COUNT(obj->u.map));
       for (int i = 0; i < obj->u.map->table_size; i++) {
         mapping_node_t* elm;
         for (elm = obj->u.map->table[i]; elm; elm = elm->next) {
@@ -301,8 +309,8 @@ json svalue_to_json_summary(const svalue_t* obj, int depth) {
           }
         }
       }
-      if (obj->u.map->count > 4) {
-        res["_sizeof"] = std::to_string(obj->u.map->count);
+      if (MAP_COUNT(obj->u.map) > 4) {
+        res["_sizeof"] = std::to_string(MAP_COUNT(obj->u.map));
       }
       return res;
     }

--- a/src/vm/internal/simulate.cc
+++ b/src/vm/internal/simulate.cc
@@ -1546,12 +1546,16 @@ void destruct_object(object_t* ob) {
   ob->next_inv = nullptr;
   ob->contains = nullptr;
 #endif
-  ob->next_all = obj_list_destruct;
-  if (obj_list_destruct) {
-    obj_list_destruct->prev_all = ob;
-  }
-  ob->prev_all = nullptr;
+  /* Queue for the remove_destructed_objects() sweep via the queue's own
+   * dedicated link. The queue used to ride on next_all/prev_all, which DEBUG
+   * builds immediately reuse below for the obj_list_dangling leak-hunting
+   * list -- so once a sweep left a still-referenced survivor behind, the
+   * next sweep's next_all walk strayed into the dangling chain and ran
+   * destruct2() (an object-ref decrement) on already-swept objects. */
+  ob->next_destruct = obj_list_destruct;
   obj_list_destruct = ob;
+  ob->next_all = nullptr;
+  ob->prev_all = nullptr;
   set_heart_beat(ob, 0);
   ob->flags |= O_DESTRUCTED;
   /* moved this here from destruct2() -- see comments in destruct2() */

--- a/src/vm/internal/vm.cc
+++ b/src/vm/internal/vm.cc
@@ -150,11 +150,18 @@ void remove_destructed_objects() {
   }
 
   if (obj_list_destruct) {
-    object_t *ob, *next;
-    for (ob = obj_list_destruct; ob; ob = next) {
-      next = ob->next_all;
+    /* Detach the whole queue up front: destruct2() frees object variables,
+     * which can re-enter destruct_object() -- those pushes must land on a
+     * fresh queue for the next sweep instead of being dropped when the head
+     * is cleared afterwards. Each object is unlinked before its destruct2()
+     * so a still-referenced survivor keeps no stale queue link. */
+    object_t* ob = obj_list_destruct;
+    obj_list_destruct = nullptr;
+    object_t* next;
+    for (; ob; ob = next) {
+      next = ob->next_destruct;
+      ob->next_destruct = nullptr;
       destruct2(ob);
     }
-    obj_list_destruct = nullptr;
   }
 } /* remove_destructed_objects() */

--- a/testsuite/inherit/master/valid.lpc
+++ b/testsuite/inherit/master/valid.lpc
@@ -99,8 +99,16 @@ int valid_read(string, mixed, string) {
   return 1;
 }
 
-int valid_bind() {
+// Tests can register a hook object to observe valid_bind() (and, e.g.,
+// destruct the prospective owner mid-bind -- see
+// tests/efuns/bind_destruct_owner.lpc). No hook = stock allow-all behavior.
+private object bind_hook;
+
+public void set_bind_hook(object ob) { bind_hook = ob; }
+
+int valid_bind(object binder, object old_owner, object new_owner) {
   inherit_called++;
+  if (bind_hook) return bind_hook->valid_bind_hook(binder, old_owner, new_owner);
   // This is really unsafe, but testsuite uses it to test bind()
   return 1;
 }

--- a/testsuite/single/tests/compiler/anon_func_bad_type_scope_leak.lpc
+++ b/testsuite/single/tests/compiler/anon_func_bad_type_scope_leak.lpc
@@ -65,6 +65,6 @@ void do_tests() {
   // A legitimate typed anonymous function literal, the construct this
   // whole code path exists for, must still work correctly (not just avoid
   // crashing) -- see also single/tests/compiler/firstclass_functions.lpc.
-  function f = (function (int a, int b) { return a + b; });
+  function f = (function(int a, int b) { return a + b; });
   ASSERT_EQ(7, f(3, 4));
 }

--- a/testsuite/single/tests/compiler/embedded_nul_hang.lpc
+++ b/testsuite/single/tests/compiler/embedded_nul_hang.lpc
@@ -42,7 +42,7 @@
 // exactly the way a corrupted/crafted real .lpc file could contain one
 // even though save_object()'s own format never does.
 private void assert_nul_rejected(string path, string pre, string post,
-                                 string why) {
+  string why) {
   buffer nul = allocate_buffer(1);
   rm(path + ".c");
   if (strlen(pre)) write_buffer(path + ".c", 0, pre);

--- a/testsuite/single/tests/efuns/allocate_mapping_callback_throw.lpc
+++ b/testsuite/single/tests/efuns/allocate_mapping_callback_throw.lpc
@@ -1,0 +1,34 @@
+// allocate_mapping(keys, callback) with a DUPLICATE key re-finds the existing
+// node, and find_for_insert() frees the old value before the callback runs.
+// The freed-but-still-populated slot then sat in live mapping data while the
+// callback executed: a callback that error()s made the unwind free the
+// half-built mapping and release that value a SECOND time -- an object-ref
+// over-decrement of issue #1327's class (on a Debug build the fatal
+// "ref count 0, but not destructed" fires right here). find_for_insert() now
+// zeroes the slot after freeing it.
+
+object ob;
+int calls;
+
+mixed cb(mixed key) {
+  if (calls++) {
+    error("boom");
+  }
+  return ob;
+}
+
+void do_tests() {
+  mixed err;
+
+  calls = 0;
+  ob = clone_object("/clone/testob1");
+
+  err = catch(allocate_mapping(({ "dup", "dup" }), (: cb :)));
+  ASSERT(err);
+
+  // The clone must still be alive with a sane refcount: releasing our
+  // reference must not be a second deallocation.
+  ASSERT(objectp(ob));
+  destruct(ob);
+  ob = 0;
+}

--- a/testsuite/single/tests/efuns/bind_destruct_owner.lpc
+++ b/testsuite/single/tests/efuns/bind_destruct_owner.lpc
@@ -1,0 +1,31 @@
+// bind() runs the valid_bind() master apply -- arbitrary LPC -- and then used
+// to store the new owner into the funptr from a raw pointer captured BEFORE
+// that apply. If valid_bind() destructed the new owner, the destruct sweep
+// (remove_object_from_stack) had already released the VM stack's reference,
+// so the funptr held an uncounted owner reference; its eventual dealloc
+// over-decremented a reference belonging to someone else (issue #1327's
+// corruption class). bind() must instead error out cleanly.
+
+object target;
+
+int valid_bind_hook(object binder, object old_owner, object new_owner) {
+  if (target && new_owner == target) {
+    destruct(target);
+  }
+  return 1;
+}
+
+void do_tests() {
+  mixed err;
+
+  target = clone_object("/clone/testob1");
+  "/single/master"->set_bind_hook(this_object());
+  err = catch(bind((: $1 + $2 :), target));
+  "/single/master"->set_bind_hook(0);
+
+  // The unfixed driver completed the bind against the destructed owner (and
+  // silently corrupted its refcount); the fix reports a clean error.
+  ASSERT(err);
+
+  target = 0;
+}

--- a/testsuite/single/tests/operators/foreach_ref_mapping.lpc
+++ b/testsuite/single/tests/operators/foreach_ref_mapping.lpc
@@ -1,0 +1,36 @@
+// foreach (key, ref value in mapping) aims the ref at the mapping node's
+// value slot. Deleting the iterated key used to send that node straight to
+// the global free list (the loop never set MAP_LOCKED), so the very next
+// mapping insert anywhere recycled it -- and the loop's write through the
+// ref then landed in the OTHER mapping's value slot. The loop now locks the
+// mapping like f(ref m[key]) does, deferring node frees until the ref dies.
+
+void do_tests() {
+  mapping m, other;
+  string *seen = ({});
+
+  // Basic in-place mutation through the ref still works.
+  m = ([ "a": 1, "b": 2 ]);
+  foreach (string k, mixed ref v in m) {
+    v = v * 10;
+  }
+  ASSERT_EQ(10, m["a"]);
+  ASSERT_EQ(20, m["b"]);
+
+  // Deleting the iterated key must not let writes through the ref corrupt
+  // an unrelated mapping that recycles the node.
+  m = ([ "a": 1, "b": 2 ]);
+  other = ([]);
+  foreach (string k, mixed ref v in m) {
+    seen += ({ k });
+    map_delete(m, k);
+    other["x" + k] = 42;
+    v = 99;
+  }
+  ASSERT_EQ(2, sizeof(seen));
+  ASSERT_EQ(0, sizeof(m));
+  ASSERT_EQ(2, sizeof(other));
+  foreach (string k2, mixed val in other) {
+    ASSERT_EQ(42, val);
+  }
+}


### PR DESCRIPTION
Issue #1327 reported two crashes on the v2026.07.17 build, both downstream
signatures of an object-ref over-decrement: a live object drained to ref 0
(dealloc_object "ref count 0, but not destructed" during a soul daemon's
global assignment) and an already-deallocated object freed again from a
mapping value (free_prog segfault on a dangling ob->prog). The primary
suspected origin -- the default-arguments closure-fill push_svalue() stack
corruption, present only in that build window (86d13cd..d917178/2d317e4)
and directly evidenced by #1295's garbage T_OBJECT stack slot -- is already
fixed on master. This commit fixes every further defect of the same class
found by auditing the implicated paths (command processing, applies,
mapping machinery, object lifecycle):

- remove_interactive(): when net_dead() exec()s the connection into a
  different body (the classic linkdead-ghost idiom), the teardown released
  the OLD body's interactive ref a second time -- draining a live object to
  ref 0, the exact #1327 fatal -- and freed the interactive_t the new body
  still pointed at. Re-resolve the owner from ip->ob after the apply.

- Destruct queue: obj_list_destruct rode on next_all/prev_all, which DEBUG
  builds immediately reuse for the obj_list_dangling leak list -- once a
  sweep left a still-referenced survivor, the next sweep's next_all walk
  strayed into the dangling chain and destruct2()'d (= ref-decremented)
  survivors a second time; non-DEBUG builds kept stale queue links that a
  later dealloc_object() wrote through (gap in b67f59e). The queue now has
  its own dedicated next_destruct link; the sweep detaches it up front and
  clears each link before destruct2().

- allocate_mapping(keys, callback) with a duplicate key double-freed the
  previous value when the callback threw: find_for_insert() freed the slot
  but left it populated, and the unwind freed it again. The slot is now
  zeroed; unlock_mapping()/free_node() uphold the same free-list invariant.

- foreach (k, ref v in mapping) never set MAP_LOCKED, so map_delete of the
  iterated key sent the node to the global free list while the ref still
  pointed into it -- the next mapping insert anywhere recycled the node and
  writes through the ref corrupted the other mapping's value. The loop now
  locks the mapping exactly like f(ref m[k]), carrying the mapping as the
  ref's counted sv so kill_ref() unlocks on every exit path including error
  unwinds. Exposed pre-existing raw m->count readers (sizeof(), sprintf %O,
  copyMapping, dwlib, svalue debug dump) that included the MAP_LOCKED bit;
  they now use MAP_COUNT().

- bind(): the new owner was stored into the funptr from a raw pointer
  captured before the valid_bind() master apply; if that LPC destructed the
  owner, the destruct sweep had already released the stack's ref and the
  funptr's eventual dealloc over-decremented. Now errors out cleanly.

- call_function_interactive(): the destructed-target branch freed what
  could be the target's last reference, then read ob->flags/ob->interactive
  from freed memory. Return before the mode-restore code.

- kill_ref(): re-entry through the last T_REF svalue's free re-read a freed
  mapping via the stale sv (now zeroed after release, and sv is released
  unconditionally); the other-refs scan now type-checks r->sv before
  comparing u.map against uninitialized/unrelated data.

- F_KILL_REFS: guard against walking off the end of global_ref_list when a
  catch() inside the same argument list made restore_context() kill refs
  the compiler's count still expects (null deref).

- F_MAP_MEMBER_LVALUE: free_mapping() on a ref-1 temporary deallocated the
  mapping while handing out an lvalue into it; use the same non-deallocating
  decrement as push_indexed_lvalue's mapping branch.

- setup_fake_frame(): csp->defers was left uninitialized, so f_defer()
  reached through an FP_EFUN funptr chained onto a stale defer_list pointer
  from the reused control-stack slot.

- int_free_svalue(): the ref-underflow guard suppressed the decrement but
  still ran the dealloc branch, turning an aliased free of an
  already-deallocated value into a guaranteed second dealloc. Deallocate
  only when this call performed the 1 -> 0 decrement.

- pop_control_stack() defers: hold a ref on the captured command_giver
  across restore_command_giver() before set_command_giver() re-refs it.

- remove_sent(): gate on user->sent instead of O_ENABLE_COMMANDS --
  sentences outlive the flag (disable_commands does not clear user->sent,
  and command() makes any object a command giver), and skipping them left
  sentences whose s->ob dangled after the definer was destructed.

Regression tests: efuns/bind_destruct_owner.lpc (with a valid_bind hook in
the testsuite master), efuns/allocate_mapping_callback_throw.lpc,
operators/foreach_ref_mapping.lpc, and a GTest
(SweepDoesNotRevisitSurvivorsOfPreviousSweep) pinning the destruct queue.
Validated: full LPC suite x3 (randomized order) + 321 GTests on
RelWithDebInfo, plus a Debug+ASan suite run.

Fixes #1327 (hardening; the reported build's primary corruption source was
fixed by d917178/2d317e4).

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Rw2P1MKGnjV8gn6CDuuyzQ