### PR TITLE
docs: document that shuffle() reorders its argument array in place

### DIFF
--- a/docs/efun/arrays/shuffle.md
+++ b/docs/efun/arrays/shuffle.md
@@ -5,7 +5,7 @@ title: arrays / shuffle
 
 ### NAME
 
-    shuffle() - Rearrange the elements in the array in random order
+    shuffle() - rearrange the elements of an array in random order
 
 ### SYNOPSIS
 
@@ -13,4 +13,34 @@ title: arrays / shuffle
 
 ### DESCRIPTION
 
-    Shuffle the array and return.
+    Rearranges the elements of `arr` into a random order.
+
+    The shuffle happens in place: `arr` itself is reordered, not a copy
+    of it.  Every variable holding a reference to that array sees the
+    new order after the call.
+
+### RETURN VALUE
+
+    Returns `arr` itself -- the same array that was passed in, after
+    shuffling -- not a shuffled copy.  The return value is a convenience
+    for use in expressions; ignoring it changes nothing, since the
+    argument array has already been reordered by the time the call
+    returns.
+
+    An array with fewer than two elements is returned unchanged.
+
+### EXAMPLE
+
+```c
+mixed *a = ({ 1, 2, 3, 4, 5 });
+mixed *b = shuffle(a);
+// a itself has been reordered; b is that same array, not a copy.
+
+// To keep the original order intact, shuffle a copy instead:
+mixed *c = shuffle(a[0..]);
+// the range expression builds a new array, so a is untouched
+```
+
+### SEE ALSO
+
+    element_of(3), sort_array(3), random(3)


### PR DESCRIPTION
The `shuffle()` doc page never mentioned its most important behavior: the array you pass in is itself mutated. `f_shuffle()` runs an in-place Fisher–Yates swap on the argument `array_t` and simply leaves that same array on the stack as the return value — so the return is the argument array, not a shuffled copy. (The zh-CN translation already warned about this; the English page did not.)

This rewrites `docs/efun/arrays/shuffle.md`:

- DESCRIPTION states the shuffle happens in place and that every reference to the array sees the new order
- New RETURN VALUE section: returns `arr` itself, ignoring it changes nothing, and arrays with fewer than two elements come back unchanged
- New EXAMPLE showing the shared-array effect, plus the `shuffle(a[0..])` idiom for shuffling a copy
- SEE ALSO in the standard `name(3)` format (`element_of`, `sort_array`, `random`)

Doc-only change; sidebar unaffected (`gen_sidebar.py --check` passes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)