### PR TITLE
compiler: coerce return <expr>; to the function's declared return type (fixes #1331)

### DIFF
--- a/src/compiler/internal/grammar_rules_loops.cc
+++ b/src/compiler/internal/grammar_rules_loops.cc
@@ -222,6 +222,33 @@ void rule_return_expr(parse_node_t** result, parse_node_t* expr) {
     p = get_two_types(p, end, expr->type, exact_types);
     yyerror(buf);
   }
+
+  /* Coerce the returned value to the function's declared return type, the
+   * same way rule_expr_assign() coerces an '='/op= RHS to a declared-type
+   * lvalue (grammar_rules_exprs.cc) -- otherwise a function declared
+   * `int` whose return expression is actually a float (e.g. `return
+   * sqrt(x);`) hands back a genuine T_REAL svalue at runtime: compatible_types()
+   * intentionally treats int/float as compatible (so the yyerror above never
+   * fires for this), and nothing else enforced the declared type. A caller
+   * doing `int_var += that_call()` then hit F_ADD_EQ's untyped-lvalue
+   * promotion path meant only for mixed/mapping slots (issue #1331) --
+   * silently promoting a genuinely int-declared variable to float.
+   * Exact-equality checks (matching rule_expr_assign()'s convention, not a
+   * TYPE_MOD_ARRAY-inclusive form) correctly exclude array return types
+   * (`int *`/`float *`) -- this is scalar-only, same as the op= coercion. */
+  if (exact_types == TYPE_REAL && (expr->type == TYPE_NUMBER || expr->kind == NODE_NUMBER)) {
+    /* The second disjunct mirrors do_promotions()'s own check
+     * (compiler.cc): CREATE_NUMBER() gives a literal `0` node type
+     * TYPE_ANY, not TYPE_NUMBER (0 doubles as LPC's untyped "nil" across
+     * every type), so `float f() { return 0; }` would otherwise miss this
+     * branch entirely and fall through to the literal-zero fast path
+     * below unpromoted -- which returns an int-typed T_NUMBER 0 at
+     * runtime, not a T_REAL 0.0. */
+    expr = promote_to_float(expr);
+  } else if (exact_types == TYPE_NUMBER && expr->type == TYPE_REAL) {
+    expr = promote_to_int(expr);
+  }
+
   if (IS_NODE(expr, NODE_NUMBER, 0)) {
     CREATE_RETURN(*result, 0);
   } else {

--- a/testsuite/single/tests/operators/return_type_coercion.lpc
+++ b/testsuite/single/tests/operators/return_type_coercion.lpc
@@ -1,0 +1,92 @@
+// A function's `return <expr>;` is coerced to its declared return type,
+// mirroring compound_assign_float.lpc's coverage of '='/op= coercion
+// (rule_expr_assign, grammar_rules_exprs.cc): rule_return_expr()
+// (grammar_rules_loops.cc) applies the same int<->float promotion so a
+// function declared `int` whose body's return expression actually
+// evaluates to a float hands back a genuinely truncated int, not a real.
+//
+// Before this fix, compatible_types() intentionally treats int/float as
+// mutually compatible (so no compile error), but nothing coerced the
+// value -- the function genuinely returned a T_REAL svalue despite its
+// `int` declaration. A caller doing `int_var += that_call()` then hit
+// F_ADD_EQ's untyped-lvalue promotion path (meant only for mixed/mapping
+// slots) and silently promoted a genuinely int-declared variable to
+// float -- issue #1331.
+
+int returns_declared_int_from_float_body() {
+  // sqrt() returns a float; nothing here declares an intermediate
+  // variable that would trigger the assignment-side coercion.
+  return sqrt(4.0) * 1.5;  // 2.0 * 1.5 = 3.0 (real) -> must truncate to int 3
+}
+
+float returns_declared_float_from_int_body() {
+  return 5;  // reverse direction: int literal into a float-declared return
+}
+
+int returns_int_literal_zero() {
+  return 0;  // must still compile to the F_RETURN_ZERO fast path
+}
+
+float returns_float_literal_zero() {
+  // The tricky case: CREATE_NUMBER() gives a literal `0` node type
+  // TYPE_ANY (0 doubles as LPC's untyped "nil"), not TYPE_NUMBER, so this
+  // must still be recognized and promoted to a real 0.0 -- not silently
+  // fall through to the int-returning F_RETURN_ZERO fast path.
+  return 0;
+}
+
+int *returns_typed_array() {
+  // Array return types (TYPE_MOD_ARRAY set) must not be touched by the
+  // scalar int<->float coercion.
+  return ({ 1, 2, 3 });
+}
+
+mixed returns_mixed_holding_float() {
+  // An untyped (mixed) return has no declared type to enforce -- no
+  // coercion, same as a mixed variable in compound_assign_float.lpc.
+  return 1.5;
+}
+
+// The exact shape from issue #1331: a declared-int helper whose body
+// leaks a float, called directly into a declared-int lvalue's +=.
+int heat_close() {
+  return (10.0 - sqrt(4.0)) * 1.0;  // 8.0 (real) -> must truncate to int 8
+}
+
+void do_tests() {
+  int i = returns_declared_int_from_float_body();
+  ASSERT_EQ(1, intp(i));
+  ASSERT_EQ(3, i);
+
+  float f = returns_declared_float_from_int_body();
+  ASSERT_EQ(1, floatp(f));
+  ASSERT_EQ(5.0, f);
+
+  ASSERT_EQ(1, intp(returns_int_literal_zero()));
+  ASSERT_EQ(0, returns_int_literal_zero());
+
+  ASSERT_EQ(1, floatp(returns_float_literal_zero()));
+  ASSERT_EQ(0.0, returns_float_literal_zero());
+
+  ASSERT_EQ(({ 1, 2, 3 }), returns_typed_array());
+
+  ASSERT_EQ(1, floatp(returns_mixed_holding_float()));
+
+  // The reported regression: a genuinely int-declared local must stay int
+  // across += against a call whose body leaks a float.
+  int total = 0;
+  total += heat_close();
+  ASSERT_EQ(1, intp(total));
+  ASSERT_EQ(8, total);
+
+  // ... and must therefore still work with int-only operators afterward
+  // (this is exactly what broke mudlib-wide in #1331: a promoted-to-real
+  // value later hit switch()/%/array-index, which reject non-int).
+  switch (total) {
+    case 8:
+      break;
+    default:
+      ASSERT2(0, "total must be exactly the int 8 to match this switch case");
+  }
+  ASSERT_EQ(0, total % 4);
+}

--- a/testsuite/std/percent.lpc
+++ b/testsuite/std/percent.lpc
@@ -1,9 +1,13 @@
-int percent(int num, int den) {
+// Genuinely polymorphic: with a float argument this returns a float, with
+// int arguments it returns a truncated int -- declared `mixed`, not `int`,
+// so the compiler doesn't coerce the float branch's result back to int
+// (see AGENTS.md's note on rule_return_expr()'s return-type coercion).
+mixed percent(mixed num, mixed den) {
   if (floatp(num) || floatp(den)) return num * 100.0 / den;
   else return num * 100 / den;
 }
 
-int percent_of(int percent, int base) {
+mixed percent_of(mixed percent, mixed base) {
   if (floatp(percent) || floatp(base)) return percent * base / 100.0;
   else return percent * base / 100;
 }


### PR DESCRIPTION
Fixes #1331.

## The bug

A function declared `int` whose `return` expression actually evaluates to a `float` (e.g. `return sqrt(x);`) genuinely hands back a `T_REAL` svalue at runtime, despite its declared type. `compatible_types()` intentionally treats `int`/`float` as compatible (no compile error), and — unlike `=`/op= assignment, which #1303 already coerces to a declared-type lvalue — nothing enforced the declared type at the `return` statement itself.

A caller doing `int_var += that_call()` then hits `F_ADD_EQ`'s untyped-lvalue promotion path (meant only for `mixed`/mapping slots) and silently promotes a genuinely `int`-declared variable to `float`. This is exactly the reporter's own example:

```lpc
int heat_close(...) { return (range - sqrt(dist_sq)) * ...; }
...
int_var += heat_close(...);   // int_var silently becomes a float
```

...cascading into `switch()`/array-index/`%` errors mudlib-wide, and corrupting save files with real-valued ints. I reproduced this directly against current master before writing the fix — see [the issue comment](https://github.com/fluffos/fluffos/issues/1331#issuecomment-5099998671).

## The fix

`rule_return_expr()` (`grammar_rules_loops.cc`) now applies the same int↔float promotion `rule_expr_assign()` already applies to an assignment RHS (`grammar_rules_exprs.cc`), scoped identically:
- Exact-equality type checks (matching the op= precedent) correctly exclude array return types (`int *`) — this is scalar-only.
- Untyped (`mixed`) returns are untouched — no declared type, nothing to enforce.

One nuance the assignment precedent doesn't have to deal with: `CREATE_NUMBER()` gives a literal `0` node type `TYPE_ANY`, not `TYPE_NUMBER` (`0` doubles as LPC's untyped "nil" across every type), so `float f() { return 0; }` needs the same `|| kind == NODE_NUMBER` fallback `do_promotions()` already uses (`compiler.cc`) — otherwise it falls through unpromoted to the `F_RETURN_ZERO` fast path, which always returns an int-typed `0` regardless of the function's declared type. I found this the hard way — my first pass missed it and a targeted test caught it immediately.

### A real conflict this surfaced

`testsuite/std/percent.lpc`'s `percent()`/`percent_of()` were declared `int` but are *intentionally* polymorphic (float args in → float result out; int args in → truncated int result out) — exactly the kind of declared-type "escape hatch" this fix closes. Running the full suite caught this immediately (2 failing checks). I redeclared them `mixed` to honestly reflect their actual contract — this changes nothing for any caller, since the compiler applies zero coercion to a `mixed`-declared function's return in the first place. This existing, passing testsuite file was itself proof that this pattern needs an honest `mixed` type, not `int` while quietly relying on the driver not enforcing it.

## Tests

`testsuite/single/tests/operators/return_type_coercion.lpc` — mirrors `compound_assign_float.lpc`'s coverage style for the op= case. Covers: int-declared/float-body, float-declared/int-body (reverse direction), int/float literal-zero (the `F_RETURN_ZERO` fast-path edge case), array return types (unaffected), `mixed` returns (unaffected), and the exact `int_var += declared_int_function()` shape from the issue, including the downstream `switch()`/`%` checks that were the actual mudlib-visible symptom.

Verified to **fail on the unfixed binary** (9 failed checks) via a worktree with just this commit reverted; passes on the fix.

## Validation

- Full LPC testsuite ×3 (randomized order): `Checks succeeded.`
- 373 GTests (RelWithDebInfo): all pass.
- Debug+ASan: full LPC suite clean, GTests clean (one pre-existing, unrelated leak surfaced in `RcTest`/`read_config()`/`rc.cc` — a real one-shot startup routine only re-entered repeatedly by the test harness; zero code-path overlap with this change, not touched here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rw2P1MKGnjV8gn6CDuuyzQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rw2P1MKGnjV8gn6CDuuyzQ)_