### PR TITLE
websocket: drain output before driver-initiated close

### DIFF
--- a/src/net/websocket.cc
+++ b/src/net/websocket.cc
@@ -143,15 +143,13 @@ void websocket_send_text(struct lws* wsi, const char* data, size_t len) {
 void close_websocket_context(struct lws_context* context) { lws_context_destroy(context); }
 
 void close_user_websocket(struct lws* wsi) {
-  lws_set_timeout(wsi, pending_timeout::PENDING_FLUSH_STORED_SEND_BEFORE_CLOSE, LWS_TO_KILL_ASYNC);
+  bool close_from_writable = false;
   switch (lws_get_protocol(wsi)->id) {
     case WS_TELNET: {
       auto pss = reinterpret_cast<ws_telnet_session*>(lws_wsi_user(wsi));
       if (pss) {
-        if (evbuffer_get_length(pss->buffer) > 0) {
-          // try flush before closing.
-          lws_callback_on_writable(wsi);
-        }
+        pss->close_after_flush = true;
+        close_from_writable = true;
         pss->user = nullptr;
       }
       break;
@@ -159,10 +157,8 @@ void close_user_websocket(struct lws* wsi) {
     case WS_ASCII: {
       auto pss = reinterpret_cast<ws_ascii_session*>(lws_wsi_user(wsi));
       if (pss) {
-        if (evbuffer_get_length(pss->buffer) > 0) {
-          // try flush before closing.
-          lws_callback_on_writable(wsi);
-        }
+        pss->close_after_flush = true;
+        close_from_writable = true;
         pss->user = nullptr;
       }
       break;
@@ -170,4 +166,17 @@ void close_user_websocket(struct lws* wsi) {
     default:
       break;
   }
+
+  if (close_from_writable) {
+    // The application-side evbuffer is outside lws, so an async kill can win
+    // before the requested writable callback moves these final bytes into lws.
+    // Give the application buffer a bounded drain; the protocol callback closes
+    // as soon as it is empty, while this timeout covers a permanently choked peer.
+    lws_set_timeout(wsi, pending_timeout::PENDING_FLUSH_STORED_SEND_BEFORE_CLOSE, 5);
+    lws_callback_on_writable(wsi);
+    return;
+  }
+
+  lws_set_timeout(wsi, pending_timeout::PENDING_FLUSH_STORED_SEND_BEFORE_CLOSE,
+                  LWS_TO_KILL_ASYNC);
 }

--- a/src/net/ws_ascii.cc
+++ b/src/net/ws_ascii.cc
@@ -91,6 +91,7 @@ int ws_ascii_callback(struct lws* wsi, enum lws_callback_reasons reason, void* u
 
       pss->user = ip;
       pss->buffer = evbuffer_new();
+      pss->close_after_flush = false;
 
       ip->iflags |= HANDSHAKE_COMPLETE;
       ip->lws = wsi;
@@ -174,6 +175,10 @@ int ws_ascii_callback(struct lws* wsi, enum lws_callback_reasons reason, void* u
       // Data still queued: request the next writeable callback.
       if (evbuffer_get_length(pss->buffer) > 0) {
         lws_callback_on_writable(wsi);
+      }
+      if (pss->close_after_flush && evbuffer_get_length(pss->buffer) == 0) {
+        lws_close_reason(wsi, LWS_CLOSE_STATUS_NORMAL, nullptr, 0);
+        return -1;
       }
       break;
     }

--- a/src/net/ws_ascii.h
+++ b/src/net/ws_ascii.h
@@ -11,6 +11,7 @@ struct ws_ascii_session {
   struct interactive_t* user;
 
   struct evbuffer* buffer;
+  bool close_after_flush;
 };
 
 int ws_ascii_callback(struct lws* wsi, enum lws_callback_reasons reason, void* user, void* in,

--- a/src/net/ws_telnet.cc
+++ b/src/net/ws_telnet.cc
@@ -141,6 +141,7 @@ int ws_telnet_callback(struct lws* wsi, enum lws_callback_reasons reason, void* 
 
       pss->user = ip;
       pss->buffer = evbuffer_new();
+      pss->close_after_flush = false;
 
       ip->iflags |= HANDSHAKE_COMPLETE;
       ip->lws = wsi;
@@ -235,6 +236,10 @@ int ws_telnet_callback(struct lws* wsi, enum lws_callback_reasons reason, void* 
       // queued data always has a callback requested.
       if (evbuffer_get_length(pss->buffer) > 0) {
         lws_callback_on_writable(wsi);
+      }
+      if (pss->close_after_flush && evbuffer_get_length(pss->buffer) == 0) {
+        lws_close_reason(wsi, LWS_CLOSE_STATUS_NORMAL, nullptr, 0);
+        return -1;
       }
       break;
     }

--- a/src/net/ws_telnet.h
+++ b/src/net/ws_telnet.h
@@ -11,6 +11,7 @@ struct ws_telnet_session {
   struct interactive_t* user;
 
   struct evbuffer* buffer;
+  bool close_after_flush;
 };
 
 int ws_telnet_callback(struct lws* wsi, enum lws_callback_reasons reason, void* user, void* in,

--- a/tools/ws-smoke.js
+++ b/tools/ws-smoke.js
@@ -38,13 +38,14 @@
 //   * a live full-screen TUI (`tuidemo dashboard`): alternate screen,
 //     sustained frame updates, clean quit
 //   * a driver-initiated close while the connection is choked (destruct
-//     the interactive mid-backpressure): teardown must release the
-//     session resources even though the driver side is already gone --
-//     an interim revision leaked a pending session timer here, a
-//     use-after-free that aborted the driver on the ASan CI job
-//   * an `ascii`-subprotocol connection with the same bursts, sent as
-//     TEXT frames (ws_ascii.cc rejects binary frames outright) through
-//     ws_ascii.cc's twin drain loop
+//     the interactive mid-backpressure): all queued output must arrive
+//     before close, and teardown must release the session resources even
+//     though the driver side is already gone -- an interim revision leaked
+//     a pending session timer here, a use-after-free that aborted the driver
+//     on the ASan CI job
+//   * an `ascii`-subprotocol connection with the same bursts and
+//     close-after-flush check, sent as TEXT frames (ws_ascii.cc rejects
+//     binary frames outright) through ws_ascii.cc's twin drain loop
 //   * a TLS (`wss`) telnet connection: banner, then the same forced
 //     backpressure through the TLS partial-write path
 //
@@ -98,6 +99,18 @@ const BURST_CMD = 'eval write(repeat_string("x", 5000) + "|END|"); return "done"
 const BACKPRESSURE_BURST_CMD =
   'eval for (int i=0;i<600;i++) write(repeat_string("x", 8000)); write("|END|"); return "done"';
 
+// Keep the marker split in the source so the echoed command cannot satisfy
+// the close-flush assertion. The output is intentionally large enough to
+// leave the application-side websocket buffer choked when the interactive
+// is destructed.
+const CLOSE_BACKPRESSURE_BURST_CMD =
+  'eval for (int i=0;i<600;i++) write(repeat_string("x", 8000)); ' +
+  'write("|CLOSE-" + "FLUSH|"); return "done"';
+
+const CLOSE_TIMEOUT_BURST_CMD =
+  'eval for (int i=0;i<600;i++) write(repeat_string("x", 8000)); ' +
+  'write("|TIMEOUT-" + "CLOSE|"); return "done"';
+
 // ---- tiny websocket client (RFC6455 client side, no deps) ---------------
 
 class WSClient {
@@ -112,6 +125,7 @@ class WSClient {
     this._onFrame = null;
     this._pending = [];
     this.onClose = () => {};
+    this.closeCode = null;
     this.established = false;
     this.negotiated = null;
     const key = crypto.randomBytes(16).toString('base64');
@@ -158,7 +172,12 @@ class WSClient {
       const payload = this.buf.slice(off, off + len);
       this.buf = this.buf.slice(off + len);
       if (opcode === 0x9) { this.sendFrame(0xA, payload); continue; }  // ping -> pong
-      if (opcode === 0x8) { this.sock.destroy(); this.onClose(); return; }
+      if (opcode === 0x8) {
+        this.closeCode = payload.length >= 2 ? payload.readUInt16BE(0) : 1005;
+        this.sock.destroy();
+        this.onClose();
+        return;
+      }
       if (opcode === 0x1 || opcode === 0x2 || opcode === 0x0) {
         if (this._onFrame) this._onFrame(payload);
         else this._pending.push(payload);
@@ -349,21 +368,59 @@ async function main() {
   ws.close();
 
   // 5b. driver-initiated close while choked: destruct the interactive while
-  //     its output is backpressured. LWS_CALLBACK_CLOSED must release the
-  //     session resources even though pss->user is already nulled -- an
-  //     interim revision leaked a pending session timer on this path, a
-  //     use-after-free on the freed wsi/pss. On the ASan CI job such a bug
-  //     aborts the driver deterministically (the follow-up connection below
-  //     then fails); plain builds may survive it silently.
+  //     its output is backpressured. The application-side evbuffer must drain
+  //     before lws closes, and LWS_CALLBACK_CLOSED must release the session
+  //     resources even though pss->user is already nulled. An interim
+  //     revision leaked a pending session timer on this path, a use-after-free
+  //     on the freed wsi/pss. On the ASan CI job such a bug aborts the driver
+  //     deterministically (the follow-up connection below then fails); plain
+  //     builds may survive it silently.
   const wsD = await connectWS(plain, 'telnet', false);
   const sd = telnetSession(wsD);
+  let destructClosed = false;
+  wsD.onClose = () => { destructClosed = true; };
   await waitFor(() => sd.text.length > 50, 15000);
+  sd.text = '';
   wsD.sock.pause();
-  sd.sendText(BACKPRESSURE_BURST_CMD + '\r\n');
+  sd.sendText(CLOSE_BACKPRESSURE_BURST_CMD + '\r\n');
   await sleep(1000);
   sd.sendText('eval destruct(this_player()); return "bye"\r\n');
-  await sleep(2000);
+  await sleep(1000);
+  wsD.sock.resume();
+  const gotCloseFlush = await waitFor(
+    () => sd.text.includes('|CLOSE-FLUSH|'),
+    20000);
+  const gotDriverClose = await waitFor(() => destructClosed, 10000);
+  check('driver-initiated close flushes choked output before teardown',
+        gotCloseFlush && gotDriverClose && wsD.closeCode === 1000 &&
+          sd.text.length > 4700000,
+        `${sd.text.length} chars; closed ${gotDriverClose}; code ${wsD.closeCode}`);
   wsD.close();
+
+  // A peer that remains choked cannot hold the driver-side session forever.
+  // Keep this socket paused beyond close_user_websocket()'s five-second
+  // application-buffer deadline. The final marker must remain behind the
+  // choked window and the connection must be gone when reads resume.
+  const wsTimeout = await connectWS(plain, 'telnet', false);
+  const timeoutSession = telnetSession(wsTimeout);
+  let timeoutClosed = false;
+  wsTimeout.onClose = () => { timeoutClosed = true; };
+  await waitFor(() => timeoutSession.text.length > 50, 15000);
+  timeoutSession.text = '';
+  wsTimeout.sock.pause();
+  timeoutSession.sendText(CLOSE_TIMEOUT_BURST_CMD + '\r\n');
+  await sleep(1000);
+  timeoutSession.sendText(
+    'eval destruct(this_player()); return "bye"\r\n');
+  await sleep(6000);
+  wsTimeout.sock.resume();
+  const gotBoundedClose = await waitFor(() => timeoutClosed, 10000);
+  check('driver bounds close flushing for a permanently choked peer',
+        gotBoundedClose &&
+          !timeoutSession.text.includes('|TIMEOUT-CLOSE|'),
+        `${timeoutSession.text.length} chars; closed ${gotBoundedClose}`);
+  wsTimeout.close();
+
   const wsE = await connectWS(plain, 'telnet', false);
   const se = telnetSession(wsE);
   check('driver survives destruct-while-choked (teardown UAF regression)',
@@ -392,6 +449,26 @@ async function main() {
   const gotAsciiBackpressure = await waitFor(() => asciiText.includes('|END|'), 20000);
   check('ascii: recovers from genuine backpressure (lws wedge regression)',
         gotAsciiBackpressure && asciiText.length > 4700000, asciiText.length + ' chars');
+
+  asciiText = '';
+  let asciiDestructClosed = false;
+  wsA.onClose = () => { asciiDestructClosed = true; };
+  wsA.sock.pause();
+  wsA.sendText(CLOSE_BACKPRESSURE_BURST_CMD + '\n');
+  await sleep(1000);
+  wsA.sendText('eval destruct(this_player()); return "bye"\n');
+  await sleep(1000);
+  wsA.sock.resume();
+  const gotAsciiCloseFlush = await waitFor(
+    () => asciiText.includes('|CLOSE-FLUSH|'),
+    20000);
+  const gotAsciiDriverClose = await waitFor(
+    () => asciiDestructClosed,
+    10000);
+  check('ascii: driver-initiated close flushes choked output before teardown',
+        gotAsciiCloseFlush && gotAsciiDriverClose &&
+          wsA.closeCode === 1000 && asciiText.length > 4700000,
+        `${asciiText.length} chars; closed ${gotAsciiDriverClose}; code ${wsA.closeCode}`);
   wsA.close();
 
   // 7. TLS websocket: banner, then forced backpressure through the TLS


### PR DESCRIPTION
`close_user_websocket()` currently starts an asynchronous kill before requesting a writable callback. The protocol output buffer is application-owned and sits outside libwebsockets, so under real socket backpressure the kill can win before the callback moves the final bytes into lws.

That truncates queued output during a driver-initiated close and prevents the peer from receiving a normal WebSocket close frame. The same behavior affects the `telnet` and `ascii` subprotocols.

**Fix:**

- Track a pending close-after-flush state in each WebSocket session.
- Give the application buffer a bounded five-second drain window.
- Close with status 1000 from the writable callback as soon as the buffer is empty.
- Keep the asynchronous-kill fallback for unknown protocols.

**Regression coverage:**

Extend `tools/ws-smoke.js` to pause the peer, queue a 4.8 MB burst with a final marker, destruct the interactive, resume the peer, and require the complete burst plus close status 1000 for both WebSocket subprotocols. A permanently paused peer also verifies that the five-second bound still tears the session down.

Against unmodified `master` (`19ffcc7a`), the new close-flush checks failed for both protocols (`18/20` checks passed): each connection received only part of the burst and no close status. With this change, all `20/20` WebSocket smoke checks pass.

Additional validation in an Ubuntu 24.04 Debug build:

- Native CTest suite: 326/326 passed
- LPC testsuite: passed
