### PR TITLE
websocket: drain output before driver-initiated close (supersedes #1338)

### DIFF
--- a/src/net/websocket.cc
+++ b/src/net/websocket.cc
@@ -143,15 +143,13 @@ void websocket_send_text(struct lws* wsi, const char* data, size_t len) {
 void close_websocket_context(struct lws_context* context) { lws_context_destroy(context); }
 
 void close_user_websocket(struct lws* wsi) {
-  lws_set_timeout(wsi, pending_timeout::PENDING_FLUSH_STORED_SEND_BEFORE_CLOSE, LWS_TO_KILL_ASYNC);
+  bool close_from_writable = false;
   switch (lws_get_protocol(wsi)->id) {
     case WS_TELNET: {
       auto pss = reinterpret_cast<ws_telnet_session*>(lws_wsi_user(wsi));
       if (pss) {
-        if (evbuffer_get_length(pss->buffer) > 0) {
-          // try flush before closing.
-          lws_callback_on_writable(wsi);
-        }
+        pss->close_after_flush = true;
+        close_from_writable = true;
         pss->user = nullptr;
       }
       break;
@@ -159,10 +157,8 @@ void close_user_websocket(struct lws* wsi) {
     case WS_ASCII: {
       auto pss = reinterpret_cast<ws_ascii_session*>(lws_wsi_user(wsi));
       if (pss) {
-        if (evbuffer_get_length(pss->buffer) > 0) {
-          // try flush before closing.
-          lws_callback_on_writable(wsi);
-        }
+        pss->close_after_flush = true;
+        close_from_writable = true;
         pss->user = nullptr;
       }
       break;
@@ -170,4 +166,17 @@ void close_user_websocket(struct lws* wsi) {
     default:
       break;
   }
+
+  if (close_from_writable) {
+    // The application-side evbuffer is outside lws, so an async kill can win
+    // before the requested writable callback moves these final bytes into lws.
+    // Give the application buffer a bounded drain; the protocol callback closes
+    // as soon as it is empty, while this timeout covers a permanently choked peer.
+    lws_set_timeout(wsi, pending_timeout::PENDING_FLUSH_STORED_SEND_BEFORE_CLOSE, 5);
+    lws_callback_on_writable(wsi);
+    return;
+  }
+
+  lws_set_timeout(wsi, pending_timeout::PENDING_FLUSH_STORED_SEND_BEFORE_CLOSE,
+                  LWS_TO_KILL_ASYNC);
 }

--- a/src/net/websocket.cc
+++ b/src/net/websocket.cc
@@ -172,6 +172,15 @@ void close_user_websocket(struct lws* wsi) {
     // before the requested writable callback moves these final bytes into lws.
     // Give the application buffer a bounded drain; the protocol callback closes
     // as soon as it is empty, while this timeout covers a permanently choked peer.
+    //
+    // The session is also done READING: input that arrives during the drain
+    // window is discarded by the protocol callbacks' nulled-pss->user guards
+    // (LWS_CALLBACK_RECEIVE breaks instead of hard-closing, which would
+    // truncate the very output this drain exists to flush). Note that
+    // lws_rx_flow_control() is NOT the way to express that here: with the
+    // libevent event lib, flipping POLLIN on a live wsi desyncs the fd
+    // watcher and starves POLLOUT, stalling the drain until the deadline
+    // kills it.
     lws_set_timeout(wsi, pending_timeout::PENDING_FLUSH_STORED_SEND_BEFORE_CLOSE, 5);
     lws_callback_on_writable(wsi);
     return;

--- a/src/net/ws_ascii.cc
+++ b/src/net/ws_ascii.cc
@@ -144,14 +144,19 @@ int ws_ascii_callback(struct lws* wsi, enum lws_callback_reasons reason, void* u
         // Hold back a trailing incomplete UTF-8 sequence so a codepoint is
         // never split across ws messages. evbuffer_copyout() does not drain,
         // so the held-back bytes stay at the front of pss->buffer and go out
-        // with the next write.
-        auto new_numbytes = static_cast<ev_ssize_t>(u8_truncate(&buf[LWS_PRE], numbytes));
-        if (new_numbytes == 0) {
-          // Only an incomplete codepoint is buffered; the exit below keeps
-          // a writeable callback requested until the rest of it arrives.
-          break;
+        // with the next write. Skip the hold-back once the user is gone
+        // (close-after-flush drain, like the telnet twin): the rest of the
+        // codepoint can never arrive, and holding it back would spin the
+        // writeable callback until the drain deadline.
+        if (pss->user) {
+          auto new_numbytes = static_cast<ev_ssize_t>(u8_truncate(&buf[LWS_PRE], numbytes));
+          if (new_numbytes == 0) {
+            // Only an incomplete codepoint is buffered; the exit below keeps
+            // a writeable callback requested until the rest of it arrives.
+            break;
+          }
+          numbytes = new_numbytes;
         }
-        numbytes = new_numbytes;
 #ifdef DEBUG
         if (!u8_validate(&buf[LWS_PRE], numbytes)) {
           char buf1[sizeof(buf) + 1] = {};
@@ -177,8 +182,19 @@ int ws_ascii_callback(struct lws* wsi, enum lws_callback_reasons reason, void* u
         lws_callback_on_writable(wsi);
       }
       if (pss->close_after_flush && evbuffer_get_length(pss->buffer) == 0) {
-        lws_close_reason(wsi, LWS_CLOSE_STATUS_NORMAL, nullptr, 0);
-        return -1;
+        // Choked with an empty buffer can mean permessage-deflate is still
+        // draining the last message's compressed tail -- see the telnet twin.
+        // Close only once lws has nothing left in flight.
+        if (!lws_send_pipe_choked(wsi)) {
+          // One-shot, exactly like the telnet twin: a second -1 from an
+          // already-queued WRITEABLE callback aborts the close handshake
+          // into an immediate close(fd), and a late client byte then RSTs
+          // away every kernel-buffered undelivered byte.
+          pss->close_after_flush = false;
+          lws_close_reason(wsi, LWS_CLOSE_STATUS_NORMAL, nullptr, 0);
+          return -1;
+        }
+        lws_callback_on_writable(wsi);
       }
       break;
     }
@@ -198,8 +214,11 @@ int ws_ascii_callback(struct lws* wsi, enum lws_callback_reasons reason, void* u
         return -1;
       }
       auto ip = pss->user;
-      if (!ip) {  // we are already disconnected
-        return -1;
+      if (!ip) {
+        // Driver-initiated close pending: discard input instead of
+        // hard-closing, or one keystroke from the peer would truncate the
+        // close-after-flush drain -- see the telnet twin.
+        break;
       }
       comm_text_received(ip, (const char*)in, len);
       break;

--- a/src/net/ws_ascii.cc
+++ b/src/net/ws_ascii.cc
@@ -91,6 +91,7 @@ int ws_ascii_callback(struct lws* wsi, enum lws_callback_reasons reason, void* u
 
       pss->user = ip;
       pss->buffer = evbuffer_new();
+      pss->close_after_flush = false;
 
       ip->iflags |= HANDSHAKE_COMPLETE;
       ip->lws = wsi;
@@ -174,6 +175,10 @@ int ws_ascii_callback(struct lws* wsi, enum lws_callback_reasons reason, void* u
       // Data still queued: request the next writeable callback.
       if (evbuffer_get_length(pss->buffer) > 0) {
         lws_callback_on_writable(wsi);
+      }
+      if (pss->close_after_flush && evbuffer_get_length(pss->buffer) == 0) {
+        lws_close_reason(wsi, LWS_CLOSE_STATUS_NORMAL, nullptr, 0);
+        return -1;
       }
       break;
     }

--- a/src/net/ws_ascii.h
+++ b/src/net/ws_ascii.h
@@ -11,6 +11,7 @@ struct ws_ascii_session {
   struct interactive_t* user;
 
   struct evbuffer* buffer;
+  bool close_after_flush;
 };
 
 int ws_ascii_callback(struct lws* wsi, enum lws_callback_reasons reason, void* user, void* in,

--- a/src/net/ws_telnet.cc
+++ b/src/net/ws_telnet.cc
@@ -141,6 +141,7 @@ int ws_telnet_callback(struct lws* wsi, enum lws_callback_reasons reason, void* 
 
       pss->user = ip;
       pss->buffer = evbuffer_new();
+      pss->close_after_flush = false;
 
       ip->iflags |= HANDSHAKE_COMPLETE;
       ip->lws = wsi;
@@ -235,6 +236,10 @@ int ws_telnet_callback(struct lws* wsi, enum lws_callback_reasons reason, void* 
       // queued data always has a callback requested.
       if (evbuffer_get_length(pss->buffer) > 0) {
         lws_callback_on_writable(wsi);
+      }
+      if (pss->close_after_flush && evbuffer_get_length(pss->buffer) == 0) {
+        lws_close_reason(wsi, LWS_CLOSE_STATUS_NORMAL, nullptr, 0);
+        return -1;
       }
       break;
     }

--- a/src/net/ws_telnet.cc
+++ b/src/net/ws_telnet.cc
@@ -238,8 +238,24 @@ int ws_telnet_callback(struct lws* wsi, enum lws_callback_reasons reason, void* 
         lws_callback_on_writable(wsi);
       }
       if (pss->close_after_flush && evbuffer_get_length(pss->buffer) == 0) {
-        lws_close_reason(wsi, LWS_CLOSE_STATUS_NORMAL, nullptr, 0);
-        return -1;
+        // An empty application buffer is not the whole story: choked here can
+        // mean permessage-deflate still holds the compressed tail of the last
+        // message (tx_draining_ext) -- entering the close states makes lws
+        // drop that drain on the floor, truncating the final message. Only
+        // close once lws has nothing left in flight; re-arm otherwise (lws
+        // services the extension drain itself and calls back when done).
+        if (!lws_send_pipe_choked(wsi)) {
+          // One-shot: an already-queued second WRITEABLE callback can land
+          // before lws processes this close. Returning -1 again then
+          // re-enters the close path in LRS_RETURNED_CLOSE and
+          // short-circuits the close handshake into an immediate close(fd);
+          // with kernel-buffered output still undelivered, any late client
+          // byte hitting the closed fd triggers an RST that purges it all.
+          pss->close_after_flush = false;
+          lws_close_reason(wsi, LWS_CLOSE_STATUS_NORMAL, nullptr, 0);
+          return -1;
+        }
+        lws_callback_on_writable(wsi);
       }
       break;
     }
@@ -254,8 +270,12 @@ int ws_telnet_callback(struct lws* wsi, enum lws_callback_reasons reason, void* 
         break;
       }
       auto ip = pss->user;
-      if (!ip) {  // we are already disconnected
-        return -1;
+      if (!ip) {
+        // Driver-initiated close pending: the interactive is gone but the
+        // close-after-flush drain may still be running. Discard the input
+        // instead of hard-closing, or one keystroke from the peer would
+        // truncate the flush; the drain deadline still bounds the session.
+        break;
       }
       comm_telnet_received(ip, (const char*)in, len);
       break;

--- a/src/net/ws_telnet.h
+++ b/src/net/ws_telnet.h
@@ -11,6 +11,7 @@ struct ws_telnet_session {
   struct interactive_t* user;
 
   struct evbuffer* buffer;
+  bool close_after_flush;
 };
 
 int ws_telnet_callback(struct lws* wsi, enum lws_callback_reasons reason, void* user, void* in,

--- a/src/www/AGENTS.md
+++ b/src/www/AGENTS.md
@@ -76,6 +76,36 @@ rules and once-bitten lessons.
   use-after-free (the pending timer fired on the freed wsi/pss). Any new
   per-session resource must be released on BOTH sides of that
   `pss->user` check.
+* **Driver-initiated close is close-AFTER-FLUSH, with four invariants**
+  (`close_user_websocket()` sets `pss->close_after_flush` + a 5s
+  `PENDING_FLUSH_STORED_SEND_BEFORE_CLOSE` drain deadline; the writable
+  handlers close with status 1000 once drained). Breaking any of these
+  reproduced real truncation:
+  1. **Close only when the evbuffer is empty AND `!lws_send_pipe_choked()`.**
+     Choked-with-empty-buffer means permessage-deflate still holds the
+     compressed tail of the final message (`tx_draining_ext`) — entering
+     the lws close states DISCARDS that drain ("defeat tx draining" in
+     `ops-ws.c`), truncating the final message for every pmd client,
+     i.e. every real browser. Re-arm the writable callback instead; lws
+     services the extension drain itself and calls back when done.
+  2. **The close is ONE-SHOT: clear `close_after_flush` before the
+     `return -1`.** A second already-queued WRITEABLE callback can land
+     before lws processes the first close; returning -1 again re-enters
+     the close path in `LRS_RETURNED_CLOSE` and degrades the clean
+     close handshake into an immediate `close(fd)`. On a socket whose
+     autotuned kernel buffers still hold undelivered output (easy on a
+     connection that already moved megabytes), any late client byte
+     hitting the closed fd triggers an RST that purges ALL in-flight
+     data — a flaky ~30% truncation that only reproduced on a REUSED
+     high-throughput connection, never a fresh one.
+  3. **`LWS_CALLBACK_RECEIVE` with a nulled `pss->user` must DISCARD
+     (break), never `return -1`.** During the drain window a real player
+     keeps typing; hard-closing on that input truncates the very flush
+     the close is waiting for.
+  4. **Do not use `lws_rx_flow_control()` to "stop reading" during the
+     drain.** With the libevent event lib, flipping POLLIN on a live wsi
+     stalls POLLOUT servicing too — the drain freezes and the deadline
+     kills the session (observed directly; both subprotocols).
 * **Multiple stale ws connections skew debugging**: each test run that
   doesn't quit cleanly leaves the driver processing net-dead teardown;
   restart `driver etc/config.test` between debugging sessions and watch
@@ -86,8 +116,11 @@ rules and once-bitten lessons.
 * Any change to these pages, `telnet.js`, or `src/net/ws_*.cc` must keep
   `node tools/ws-smoke.js` green (CI runs it: boots the real driver,
   telnet + ascii subprotocols, SGA switch, multi-window bursts,
-  paused-socket backpressure bursts on plain AND TLS ports, a
-  destruct-while-choked teardown check, TUI frames, clean quit). It
+  paused-socket backpressure bursts on plain AND TLS ports,
+  destruct-while-choked close-flush checks with mid-drain client input,
+  a permessage-deflate close-vs-extension-drain sweep (the only pmd
+  coverage anywhere — the hand-rolled client must opt in), a bounded
+  close-deadline check, TUI frames, clean quit). It
   exists because GTest + the LPC suite exercise **zero** websocket
   client traffic. The backpressure checks are what actually regression-
   guard the lws output wedge above — verified to fail (all three) on the

--- a/tools/ws-smoke.js
+++ b/tools/ws-smoke.js
@@ -42,10 +42,25 @@
 //     before close, and teardown must release the session resources even
 //     though the driver side is already gone -- an interim revision leaked
 //     a pending session timer here, a use-after-free that aborted the driver
-//     on the ASan CI job
+//     on the ASan CI job. The client also SENDS input during the drain
+//     window: once a close is pending the driver must stop reading (input
+//     is discarded), because the LWS_CALLBACK_RECEIVE null-user guard used
+//     to hard-close the wsi, truncating the very flush the close waits for
 //   * an `ascii`-subprotocol connection with the same bursts and
 //     close-after-flush check, sent as TEXT frames (ws_ascii.cc rejects
 //     binary frames outright) through ws_ascii.cc's twin drain loop
+//   * a permessage-deflate connection (the only pmd coverage anywhere --
+//     browsers negotiate it, this hand-rolled client must opt in): a
+//     destruct right behind an incompressible burst, swept across sizes so
+//     the final 2048-byte drain window is guaranteed (at least once) to
+//     compress to more than pm-deflate's 1024-byte tx buffer and leave the
+//     extension mid-drain (tx_draining_ext) exactly when the application
+//     buffer empties. Closing at that instant makes lws discard the
+//     drain -- the compressed tail of the final message, and the marker
+//     with it -- so the close must wait until lws_send_pipe_choked()
+//     clears. Chromium speaks h1+pmd, Firefox h2+pmd; a test matrix
+//     without pmd has shipped "works in the test client, dies in the
+//     browser" bugs twice before (see src/www/AGENTS.md)
 //   * a TLS (`wss`) telnet connection: banner, then the same forced
 //     backpressure through the TLS partial-write path
 //
@@ -56,6 +71,7 @@
 
 const net = require('net');
 const tls = require('tls');
+const zlib = require('zlib');
 const fs = require('fs');
 const path = require('path');
 const crypto = require('crypto');
@@ -114,7 +130,7 @@ const CLOSE_TIMEOUT_BURST_CMD =
 // ---- tiny websocket client (RFC6455 client side, no deps) ---------------
 
 class WSClient {
-  constructor(socket, host, port, subprotocol) {
+  constructor(socket, host, port, subprotocol, offerPmd) {
     this.sock = socket;
     this.buf = Buffer.alloc(0);
     // Frames can arrive (and be parsed) before the caller has a chance to
@@ -128,16 +144,39 @@ class WSClient {
     this.closeCode = null;
     this.established = false;
     this.negotiated = null;
+    this.pmdActive = false;
+    if (offerPmd) {
+      // One persistent raw inflater for the whole connection: RFC 7692
+      // messages are one continuous raw-deflate stream (each message ends
+      // with an elided 00 00 ff ff sync flush), which decodes identically
+      // whether or not the server resets its compression context between
+      // messages -- a reset just means later blocks never reference earlier
+      // history.
+      this._inflater = zlib.createInflateRaw();
+      this._inflater.on('data', (d) => this._deliver(d));
+      // A truncated final message (the very bug the pmd scenario guards)
+      // may leave the stream mid-block; surface that as missing output,
+      // not an unhandled 'error' crash.
+      this._inflater.on('error', () => {});
+      this._msgCompressed = false;
+    }
     const key = crypto.randomBytes(16).toString('base64');
     this.acceptWant = crypto.createHash('sha1')
       .update(key + '258EAFA5-E914-47DA-95CA-C5AB0DC85B11').digest('base64');
     socket.write(
       `GET / HTTP/1.1\r\nHost: ${host}:${port}\r\nUpgrade: websocket\r\n` +
       `Connection: Upgrade\r\nSec-WebSocket-Key: ${key}\r\n` +
-      `Sec-WebSocket-Version: 13\r\nSec-WebSocket-Protocol: ${subprotocol}\r\n\r\n`);
+      `Sec-WebSocket-Version: 13\r\nSec-WebSocket-Protocol: ${subprotocol}\r\n` +
+      (offerPmd ? 'Sec-WebSocket-Extensions: permessage-deflate\r\n' : '') +
+      '\r\n');
     socket.on('data', (d) => this.feed(d));
     socket.on('close', () => this.onClose());
     socket.on('error', () => this.onClose());
+  }
+
+  _deliver(payload) {
+    if (this._onFrame) this._onFrame(payload);
+    else this._pending.push(payload);
   }
 
   feed(d) {
@@ -152,12 +191,15 @@ class WSClient {
       if (!accept || accept[1] !== this.acceptWant) throw new Error('bad Sec-WebSocket-Accept');
       const proto = /sec-websocket-protocol:\s*(\S+)/i.exec(head);
       this.negotiated = proto ? proto[1] : null;
+      this.pmdActive = /sec-websocket-extensions:.*permessage-deflate/i.test(head);
       this.established = true;
     }
     // frames
     for (;;) {
       if (this.buf.length < 2) return;
       const b0 = this.buf[0], b1 = this.buf[1];
+      const fin = !!(b0 & 0x80);
+      const rsv1 = !!(b0 & 0x40);
       const opcode = b0 & 0x0f;
       let len = b1 & 0x7f, off = 2;
       if (len === 126) {
@@ -179,8 +221,23 @@ class WSClient {
         return;
       }
       if (opcode === 0x1 || opcode === 0x2 || opcode === 0x0) {
-        if (this._onFrame) this._onFrame(payload);
-        else this._pending.push(payload);
+        if (this.pmdActive) {
+          // RSV1 marks a compressed message on its FIRST frame only; the
+          // extension tx-drain path splits one message across continuation
+          // frames, which are just further slices of the deflate stream.
+          if (opcode !== 0x0) this._msgCompressed = rsv1;
+          if (this._msgCompressed) {
+            this._inflater.write(payload);
+            // Each complete message elides a trailing 00 00 ff ff sync
+            // flush (RFC 7692 7.2.1); restore it so the inflater emits
+            // everything up to the message boundary.
+            if (fin) this._inflater.write(Buffer.from([0x00, 0x00, 0xff, 0xff]));
+          } else {
+            this._deliver(payload);
+          }
+        } else {
+          this._deliver(payload);
+        }
       }
     }
   }
@@ -220,7 +277,7 @@ class WSClient {
   close() { try { this.sock.destroy(); } catch (_) {} }
 }
 
-function connectWS(port, subprotocol, useTls) {
+function connectWS(port, subprotocol, useTls, offerPmd) {
   return new Promise((resolve, reject) => {
     const to = setTimeout(() => reject(new Error('ws connect timeout')), 15000);
     const sock = useTls
@@ -229,7 +286,7 @@ function connectWS(port, subprotocol, useTls) {
     sock.on('error', (e) => { clearTimeout(to); reject(e); });
     let ws;
     function onUp() {
-      ws = new WSClient(sock, '127.0.0.1', port, subprotocol);
+      ws = new WSClient(sock, '127.0.0.1', port, subprotocol, offerPmd);
       const poll = setInterval(() => {
         if (ws.established) {
           clearInterval(poll); clearTimeout(to);
@@ -386,6 +443,12 @@ async function main() {
   await sleep(1000);
   sd.sendText('eval destruct(this_player()); return "bye"\r\n');
   await sleep(1000);
+  // The close is pending and the drain is choked; a real player often keeps
+  // typing at this point. The driver must stop reading and discard this --
+  // the RECEIVE null-user guard used to hard-close the wsi here, truncating
+  // the flush this whole scenario asserts on.
+  sd.sendText('look\r\n');
+  await sleep(200);
   wsD.sock.resume();
   const gotCloseFlush = await waitFor(
     () => sd.text.includes('|CLOSE-FLUSH|'),
@@ -412,7 +475,10 @@ async function main() {
   await sleep(1000);
   timeoutSession.sendText(
     'eval destruct(this_player()); return "bye"\r\n');
-  await sleep(6000);
+  // Comfortably past the deadline: the timer only starts once the driver
+  // PROCESSES the destruct, so a tight margin here can lose the race on a
+  // loaded CI runner (resume beats the kill and the full drain arrives).
+  await sleep(7000);
   wsTimeout.sock.resume();
   const gotBoundedClose = await waitFor(() => timeoutClosed, 10000);
   check('driver bounds close flushing for a permanently choked peer',
@@ -458,6 +524,10 @@ async function main() {
   await sleep(1000);
   wsA.sendText('eval destruct(this_player()); return "bye"\n');
   await sleep(1000);
+  // Input during the pending-close drain must be discarded, not treated as
+  // a reason to hard-close -- see the telnet twin above.
+  wsA.sendText('look\n');
+  await sleep(200);
   wsA.sock.resume();
   const gotAsciiCloseFlush = await waitFor(
     () => asciiText.includes('|CLOSE-FLUSH|'),
@@ -470,6 +540,55 @@ async function main() {
           wsA.closeCode === 1000 && asciiText.length > 4700000,
         `${asciiText.length} chars; closed ${gotAsciiDriverClose}; code ${wsA.closeCode}`);
   wsA.close();
+
+  // 6b. permessage-deflate close-after-flush: the destruct lands right
+  //     behind an incompressible burst, so the application buffer empties
+  //     while pm-deflate may still hold the compressed tail of the final
+  //     message (tx_draining_ext) -- lws's close path discards that drain,
+  //     so closing at that instant truncates the message. The drain only
+  //     triggers when a drained window's COMPRESSED size exceeds
+  //     pm-deflate's 1024-byte tx buffer, and the final window's size is
+  //     (total output) mod 2048 -- not directly controllable past the
+  //     banner/echo overhead. Sweep burst sizes spaced 375 apart across a
+  //     full 2048 ring: whatever the overhead, at least one attempt's final
+  //     window lands in the drain-triggering range (window width ~650 >
+  //     point spacing 375 after wraparound gap 548), making the sweep a
+  //     deterministic regression rather than an alignment lottery.
+  const pmdSizes = [3300, 3675, 4050, 4425, 4800, 5175];
+  const pmdFailures = [];
+  let pmdNegotiated = false;
+  for (const size of pmdSizes) {
+    const wsP = await connectWS(plain, 'telnet', false, true);
+    if (!wsP.pmdActive) {
+      wsP.close();
+      break;  // pmdNegotiated check below reports it
+    }
+    pmdNegotiated = true;
+    const sp = telnetSession(wsP);
+    let pmdClosed = false;
+    wsP.onClose = () => { pmdClosed = true; };
+    await waitFor(() => sp.text.length > 50, 15000);
+    sp.text = '';
+    // Incompressible payload (uniform random over 94 printable chars,
+    // ~6.55 bits/char, and pm-deflate runs at compression level 1), marker
+    // split so the echoed command can't satisfy the assertion, destruct in
+    // the same eval so the close races the drain of this very output.
+    sp.sendText(
+      `eval string s=""; for(int j=0;j<${size};j++) s+=sprintf("%c",33+random(94)); ` +
+      'write(s+"|PMD-"+"DONE|"); destruct(this_player()); return "bye"\r\n');
+    const pmdSawClose = await waitFor(() => pmdClosed, 15000);
+    const pmdSawMarker = await waitFor(() => sp.text.includes('|PMD-DONE|'), 3000);
+    if (!(pmdSawClose && pmdSawMarker && wsP.closeCode === 1000)) {
+      pmdFailures.push(
+        `size ${size}: ${sp.text.length} chars, marker ${pmdSawMarker}, ` +
+        `closed ${pmdSawClose}, code ${wsP.closeCode}`);
+    }
+    wsP.close();
+  }
+  check('pmd: upgrade negotiates permessage-deflate', pmdNegotiated);
+  check('pmd: driver-initiated close never truncates the extension tx drain',
+        pmdNegotiated && pmdFailures.length === 0,
+        pmdFailures.length ? pmdFailures.join(' | ') : `${pmdSizes.length} burst sizes clean`);
 
   // 7. TLS websocket: banner, then forced backpressure through the TLS
   //    write path (SSL partial writes retry differently --

--- a/tools/ws-smoke.js
+++ b/tools/ws-smoke.js
@@ -38,13 +38,14 @@
 //   * a live full-screen TUI (`tuidemo dashboard`): alternate screen,
 //     sustained frame updates, clean quit
 //   * a driver-initiated close while the connection is choked (destruct
-//     the interactive mid-backpressure): teardown must release the
-//     session resources even though the driver side is already gone --
-//     an interim revision leaked a pending session timer here, a
-//     use-after-free that aborted the driver on the ASan CI job
-//   * an `ascii`-subprotocol connection with the same bursts, sent as
-//     TEXT frames (ws_ascii.cc rejects binary frames outright) through
-//     ws_ascii.cc's twin drain loop
+//     the interactive mid-backpressure): all queued output must arrive
+//     before close, and teardown must release the session resources even
+//     though the driver side is already gone -- an interim revision leaked
+//     a pending session timer here, a use-after-free that aborted the driver
+//     on the ASan CI job
+//   * an `ascii`-subprotocol connection with the same bursts and
+//     close-after-flush check, sent as TEXT frames (ws_ascii.cc rejects
+//     binary frames outright) through ws_ascii.cc's twin drain loop
 //   * a TLS (`wss`) telnet connection: banner, then the same forced
 //     backpressure through the TLS partial-write path
 //
@@ -98,6 +99,18 @@ const BURST_CMD = 'eval write(repeat_string("x", 5000) + "|END|"); return "done"
 const BACKPRESSURE_BURST_CMD =
   'eval for (int i=0;i<600;i++) write(repeat_string("x", 8000)); write("|END|"); return "done"';
 
+// Keep the marker split in the source so the echoed command cannot satisfy
+// the close-flush assertion. The output is intentionally large enough to
+// leave the application-side websocket buffer choked when the interactive
+// is destructed.
+const CLOSE_BACKPRESSURE_BURST_CMD =
+  'eval for (int i=0;i<600;i++) write(repeat_string("x", 8000)); ' +
+  'write("|CLOSE-" + "FLUSH|"); return "done"';
+
+const CLOSE_TIMEOUT_BURST_CMD =
+  'eval for (int i=0;i<600;i++) write(repeat_string("x", 8000)); ' +
+  'write("|TIMEOUT-" + "CLOSE|"); return "done"';
+
 // ---- tiny websocket client (RFC6455 client side, no deps) ---------------
 
 class WSClient {
@@ -112,6 +125,7 @@ class WSClient {
     this._onFrame = null;
     this._pending = [];
     this.onClose = () => {};
+    this.closeCode = null;
     this.established = false;
     this.negotiated = null;
     const key = crypto.randomBytes(16).toString('base64');
@@ -158,7 +172,12 @@ class WSClient {
       const payload = this.buf.slice(off, off + len);
       this.buf = this.buf.slice(off + len);
       if (opcode === 0x9) { this.sendFrame(0xA, payload); continue; }  // ping -> pong
-      if (opcode === 0x8) { this.sock.destroy(); this.onClose(); return; }
+      if (opcode === 0x8) {
+        this.closeCode = payload.length >= 2 ? payload.readUInt16BE(0) : 1005;
+        this.sock.destroy();
+        this.onClose();
+        return;
+      }
       if (opcode === 0x1 || opcode === 0x2 || opcode === 0x0) {
         if (this._onFrame) this._onFrame(payload);
         else this._pending.push(payload);
@@ -349,21 +368,59 @@ async function main() {
   ws.close();
 
   // 5b. driver-initiated close while choked: destruct the interactive while
-  //     its output is backpressured. LWS_CALLBACK_CLOSED must release the
-  //     session resources even though pss->user is already nulled -- an
-  //     interim revision leaked a pending session timer on this path, a
-  //     use-after-free on the freed wsi/pss. On the ASan CI job such a bug
-  //     aborts the driver deterministically (the follow-up connection below
-  //     then fails); plain builds may survive it silently.
+  //     its output is backpressured. The application-side evbuffer must drain
+  //     before lws closes, and LWS_CALLBACK_CLOSED must release the session
+  //     resources even though pss->user is already nulled. An interim
+  //     revision leaked a pending session timer on this path, a use-after-free
+  //     on the freed wsi/pss. On the ASan CI job such a bug aborts the driver
+  //     deterministically (the follow-up connection below then fails); plain
+  //     builds may survive it silently.
   const wsD = await connectWS(plain, 'telnet', false);
   const sd = telnetSession(wsD);
+  let destructClosed = false;
+  wsD.onClose = () => { destructClosed = true; };
   await waitFor(() => sd.text.length > 50, 15000);
+  sd.text = '';
   wsD.sock.pause();
-  sd.sendText(BACKPRESSURE_BURST_CMD + '\r\n');
+  sd.sendText(CLOSE_BACKPRESSURE_BURST_CMD + '\r\n');
   await sleep(1000);
   sd.sendText('eval destruct(this_player()); return "bye"\r\n');
-  await sleep(2000);
+  await sleep(1000);
+  wsD.sock.resume();
+  const gotCloseFlush = await waitFor(
+    () => sd.text.includes('|CLOSE-FLUSH|'),
+    20000);
+  const gotDriverClose = await waitFor(() => destructClosed, 10000);
+  check('driver-initiated close flushes choked output before teardown',
+        gotCloseFlush && gotDriverClose && wsD.closeCode === 1000 &&
+          sd.text.length > 4700000,
+        `${sd.text.length} chars; closed ${gotDriverClose}; code ${wsD.closeCode}`);
   wsD.close();
+
+  // A peer that remains choked cannot hold the driver-side session forever.
+  // Keep this socket paused beyond close_user_websocket()'s five-second
+  // application-buffer deadline. The final marker must remain behind the
+  // choked window and the connection must be gone when reads resume.
+  const wsTimeout = await connectWS(plain, 'telnet', false);
+  const timeoutSession = telnetSession(wsTimeout);
+  let timeoutClosed = false;
+  wsTimeout.onClose = () => { timeoutClosed = true; };
+  await waitFor(() => timeoutSession.text.length > 50, 15000);
+  timeoutSession.text = '';
+  wsTimeout.sock.pause();
+  timeoutSession.sendText(CLOSE_TIMEOUT_BURST_CMD + '\r\n');
+  await sleep(1000);
+  timeoutSession.sendText(
+    'eval destruct(this_player()); return "bye"\r\n');
+  await sleep(6000);
+  wsTimeout.sock.resume();
+  const gotBoundedClose = await waitFor(() => timeoutClosed, 10000);
+  check('driver bounds close flushing for a permanently choked peer',
+        gotBoundedClose &&
+          !timeoutSession.text.includes('|TIMEOUT-CLOSE|'),
+        `${timeoutSession.text.length} chars; closed ${gotBoundedClose}`);
+  wsTimeout.close();
+
   const wsE = await connectWS(plain, 'telnet', false);
   const se = telnetSession(wsE);
   check('driver survives destruct-while-choked (teardown UAF regression)',
@@ -392,6 +449,26 @@ async function main() {
   const gotAsciiBackpressure = await waitFor(() => asciiText.includes('|END|'), 20000);
   check('ascii: recovers from genuine backpressure (lws wedge regression)',
         gotAsciiBackpressure && asciiText.length > 4700000, asciiText.length + ' chars');
+
+  asciiText = '';
+  let asciiDestructClosed = false;
+  wsA.onClose = () => { asciiDestructClosed = true; };
+  wsA.sock.pause();
+  wsA.sendText(CLOSE_BACKPRESSURE_BURST_CMD + '\n');
+  await sleep(1000);
+  wsA.sendText('eval destruct(this_player()); return "bye"\n');
+  await sleep(1000);
+  wsA.sock.resume();
+  const gotAsciiCloseFlush = await waitFor(
+    () => asciiText.includes('|CLOSE-FLUSH|'),
+    20000);
+  const gotAsciiDriverClose = await waitFor(
+    () => asciiDestructClosed,
+    10000);
+  check('ascii: driver-initiated close flushes choked output before teardown',
+        gotAsciiCloseFlush && gotAsciiDriverClose &&
+          wsA.closeCode === 1000 && asciiText.length > 4700000,
+        `${asciiText.length} chars; closed ${gotAsciiDriverClose}; code ${wsA.closeCode}`);
   wsA.close();
 
   // 7. TLS websocket: banner, then forced backpressure through the TLS


### PR DESCRIPTION
Supersedes #1338, carrying its original commit unchanged plus review fixes for three defects found while validating it. Credit to @devaidendale for the base change.

## Base change (from #1338)

`close_user_websocket()` used to start an asynchronous kill before the writable callback could move the application-owned protocol output buffer into lws, truncating queued output on driver-initiated closes and skipping the WebSocket close frame. The fix tracks a close-after-flush state per session, gives the application buffer a bounded five-second drain deadline, and closes with status 1000 from the writable callback once the buffer is empty. The deadline is a hard bound: a peer that never drains is abandoned at five seconds.

## Review fixes added on top

**1. Input during the drain window no longer aborts the flush.** `LWS_CALLBACK_RECEIVE`'s nulled-`pss->user` guard returned -1, so a single client keystroke during the (up to 5s) drain hard-closed the wsi and truncated the very output the close was waiting for — a real player keeps typing after `quit`. Input is now discarded instead; the deadline still bounds the session. Deliberately *not* implemented with `lws_rx_flow_control()`: with the libevent event lib, flipping POLLIN on a live wsi stalls POLLOUT servicing and the drain dies at the deadline (observed directly on both subprotocols).

**2. The close waits out a pending permessage-deflate extension drain.** The buffer-empty close check now also requires `!lws_send_pipe_choked()`. Choked-with-empty-buffer means pm-deflate still holds the compressed tail of the final message (`tx_draining_ext`); entering the lws close states discards that drain (`ops-ws.c` "defeat tx draining"), truncating the final message for every pmd-negotiating client — i.e. every real browser, invisible to any non-pmd test client.

**3. The close is one-shot.** A second already-queued WRITEABLE callback could see empty-buffer/unchoked again and return -1 a second time, re-entering the close path in `LRS_RETURNED_CLOSE` and degrading the clean close handshake into an immediate `close(fd)`. On a socket whose autotuned kernel buffers still held undelivered output, a late client byte hitting the closed fd triggered an RST that purged all in-flight data — a ~30% flaky truncation that only reproduced on a reused high-throughput connection, never a fresh one. `close_after_flush` is now cleared before the `return -1`.

Also: ws_ascii's `u8_truncate` hold-back is skipped once the user is gone (mirroring ws_telnet's gate — the rest of an incomplete codepoint can never arrive post-close, and holding it back busy-spins the writable callback until the deadline), and the four close-after-flush invariants are documented in `src/www/AGENTS.md`.

## Regression coverage (tools/ws-smoke.js)

- The telnet and ascii close-flush scenarios now **type mid-drain** and still require the complete 4.8 MB burst plus close status 1000 (catches fix 1).
- New **permessage-deflate coverage** — the hand-rolled client can now negotiate pmd (persistent raw inflater, RSV1/FIN tracking) — with a close-vs-extension-drain sweep: incompressible bursts at six sizes spaced across a full 2048-byte window ring, so at least one attempt's final drain window is guaranteed to overflow pm-deflate's 1024-byte tx buffer regardless of banner/echo alignment (catches fixes 2 and 3).
- The permanently-choked deadline check keeps the original semantics, with a wider timing margin (the deadline starts when the driver *processes* the destruct, not when the test sends it).

## Validation

- ws-smoke: 22/22, thirteen consecutive runs (RelWithDebInfo, Ubuntu 24.04).
- Unfixed driver (the #1338 head as submitted): 19/22 — all three new checks fail there, none of the pre-existing ones do.
- Full LPC testsuite: `Checks succeeded.`, exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014TX65yYUCStrDqworuFvhh

---
_Generated by [Claude Code](https://claude.ai/code/session_014TX65yYUCStrDqworuFvhh)_