### PR TITLE
Remove per-svalue heap allocation from the VM's hot paths

### DIFF
--- a/src/base/internal/md.cc
+++ b/src/base/internal/md.cc
@@ -42,8 +42,8 @@ std::map<int, std::vector<std::string>> md_refjournal;
 }  // namespace
 #endif
 
-void md_record_ref_journal(md_node_t* node, bool is_ref, int current_ref, std::string desc) {
 #ifdef DEBUGMALLOC_EXTENSIONS
+void md_record_ref_journal(md_node_t* node, bool is_ref, int current_ref, std::string_view desc) {
   auto id = node->id;
   auto it = md_refjournal.find(id);
   if (it == md_refjournal.end()) {
@@ -52,11 +52,9 @@ void md_record_ref_journal(md_node_t* node, bool is_ref, int current_ref, std::s
   auto entry = fmt::format(FMT_STRING("{:s}: {:s}, ref={:d}\n"), is_ref ? "REF" : "UNREF", desc,
                            current_ref);
   md_refjournal[id].push_back(entry);
-#endif
 }
 
 void md_print_ref_journal(md_node_t* node, outbuffer_t* outbuf) {
-#ifdef DEBUGMALLOC_EXTENSIONS
   auto id = node->id;
   auto it = md_refjournal.find(id);
   if (it == md_refjournal.end()) {
@@ -65,8 +63,8 @@ void md_print_ref_journal(md_node_t* node, outbuffer_t* outbuf) {
   for (auto& entry : it->second) {
     outbuf_add(outbuf, entry.c_str());
   }
-#endif
 }
+#endif
 
 namespace {
 void clear_ref_journal(md_node_t* node) {

--- a/src/base/internal/md.h
+++ b/src/base/internal/md.h
@@ -5,6 +5,7 @@
 
 #include <inttypes.h>
 #include <string>
+#include <string_view>
 
 #include "base/internal/options_incl.h"
 #include "outbuf.h"
@@ -97,7 +98,33 @@ int MDfree(md_node_t*);
 void set_tag(const void*, int);
 #endif
 
-void md_record_ref_journal(md_node_t* node, bool is_ref, int current_ref, std::string desc);
+/* The ref journal is a DEBUGMALLOC_EXTENSIONS-only diagnostic, but its call
+ * sites sit in the hottest paths in the VM (assign_svalue_no_free(),
+ * int_free_svalue(), int_ref_string(), ...) and pass __CURRENT_FILE_LINE__,
+ * a ~50-character literal.
+ *
+ * Taking `desc` as std::string BY VALUE made every one of those call sites
+ * pay a strlen + operator new + memcpy + free per call -- an unconditional
+ * heap round-trip on every refcounted svalue assignment and release, even
+ * in production builds where the function body compiles to nothing. Removing
+ * it (this change plus the macro below) cut total retired instructions by
+ * ~33% on an otherwise allocation-free numeric LPC workload.
+ *
+ * Take a string_view (never allocates, and the argument is always a literal
+ * or an already-materialized string), and compile the call away entirely
+ * when the journal is not built in. */
+#ifdef DEBUGMALLOC_EXTENSIONS
+void md_record_ref_journal(md_node_t* node, bool is_ref, int current_ref, std::string_view desc);
 void md_print_ref_journal(md_node_t* node, outbuffer_t* outbuf);
+#else
+/* Compile the call away ENTIRELY, arguments included -- an empty inline
+ * function is not enough. Several call sites build their description by
+ * concatenation ("ref_string: " + std::string(desc), stralloc.cc), which
+ * still allocates twice per call when the argument is evaluated, and
+ * int_ref_string()/int_free_string() run on every shared-string ref and
+ * release in the VM. */
+#define md_record_ref_journal(...) ((void)0)
+inline void md_print_ref_journal(md_node_t* /*node*/, outbuffer_t* /*outbuf*/) {}
+#endif
 
 #endif

--- a/src/vm/internal/base/interpret.cc
+++ b/src/vm/internal/base/interpret.cc
@@ -2189,6 +2189,19 @@ void eval_instruction(char* p) {
     Tracer::begin(*csp->trace_id, EventCategory::LPC_FUNCTION, std::move(trace_context));
   }
 
+  /* Both of these are read-only runtime config: they are populated once from
+   * the config file at boot (see the table in base/internal/rc.cc) and are
+   * never written again. They live in the global config_int[] array, so the
+   * compiler cannot hoist the loads itself -- every opcode in the switch below
+   * may call out to code it cannot see through, forcing a reload and a branch
+   * on each of the two per dispatched instruction. Caching them in locals
+   * measured as ~8% of total runtime on an interpreter-bound workload.
+   *
+   * debug_level is deliberately NOT hoisted: the set_debug_level() efun can
+   * change it from LPC in the middle of this very loop. */
+  const bool trace_code = CONFIG_INT(__RC_TRACE_CODE__) != 0;
+  const bool trace_instr = CONFIG_INT(__RC_TRACE_INSTR__) != 0;
+
   while (true) {
     if (debug_level & DBG_LPC) {
       char* f;
@@ -2198,7 +2211,7 @@ void eval_instruction(char* p) {
       show_lpc_line(f, l);
     }
     instruction = EXTRACT_UCHAR(pc++);
-    if (CONFIG_INT(__RC_TRACE_CODE__)) {
+    if (trace_code) {
       real_instruction = instruction;
       /* real EFUN is stored as an short after F_EFUN0 - F_EFUNV instructions */
       if (instruction >= F_EFUN0 && instruction <= F_EFUNV) {
@@ -2225,7 +2238,7 @@ void eval_instruction(char* p) {
      * LPC must return a value. This does not apply to control
      * instructions, like F_JUMP.
      */
-    if (CONFIG_INT(__RC_TRACE_INSTR__)) {
+    if (trace_instr) {
       ScopedTracer _tracer_ins(instrs[instruction].name ? instrs[instruction].name : "unknown");
     }
 

--- a/src/vm/internal/base/svalue.h
+++ b/src/vm/internal/base/svalue.h
@@ -110,12 +110,48 @@ struct ref_t {
 
 void copy_some_svalues(svalue_t*, svalue_t*, int);
 void assign_svalue(svalue_t*, svalue_t*);
+
+/* NOTE: an inline T_NUMBER/T_REAL fast path here (`*to = *from` in the header,
+ * delegating only refcounted sources out of line) is worth ~4% on an
+ * interpreter-bound workload and is functionally correct -- but do NOT add one
+ * without first fixing array_t/class layout. Those use the legacy
+ * `svalue_t item[1]` flexible-array idiom, so once the whole-struct store is
+ * inlined into a caller that can see the allocation, -fsanitize=object-size
+ * reports every item[i>0] write as "store ... with insufficient space for an
+ * object of type 'struct svalue_t'" (e.g. slice_array(), array.cc). The store
+ * is legal -- int_allocate_empty_array() reserves the trailing slots -- but the
+ * declared bound of 1 makes UBSan disagree, and the out-of-line call boundary
+ * is the only reason the existing code does not trip it. That would fail the
+ * RelWithDebInfo+sanitizer CI job. Real flexible array members would unblock
+ * this. */
 void assign_svalue_no_free(svalue_t*, svalue_t*);
 
 #ifdef DEBUG
 #define free_svalue(x, y) int_free_svalue(x, y)
 #else
-#define free_svalue(x, y) int_free_svalue(x)
+/* Also declared in machine.h, which includes this header before getting to it. */
+void int_free_svalue(svalue_t*);
+
+/* int_free_svalue() is called several million times on an interpreter-bound
+ * workload -- roughly once per dispatched opcode that drops a stack slot -- and
+ * it is not inlined across the call boundary. It only has real work to do for a
+ * value that owns something: a string, a refcounted
+ * pointer, or an error handler (which it invokes). For every other type --
+ * T_NUMBER and T_REAL above all -- the entire body reduces to marking the slot
+ * T_FREED, and outside DEBUG builds nothing ever reads that bit back:
+ * assign_svalue_no_free() clears it on overwrite, sprintf.cc masks it out with
+ * (type & ~T_FREED), and the only remaining readers -- the "*freed*" type name
+ * in interpret.cc and the double-free fatal in svalue.cc -- are both #ifdef
+ * DEBUG. So skipping the call outright is unobservable here.
+ *
+ * DEBUG builds keep calling the out-of-line version unconditionally, so the
+ * double-free detection that depends on the bit being set keeps working. */
+inline void free_svalue_maybe_refed(svalue_t* v) {
+  if (v->type & (T_STRING | T_REFED | T_ERROR_HANDLER)) {
+    int_free_svalue(v);
+  }
+}
+#define free_svalue(x, y) free_svalue_maybe_refed(x)
 #endif
 
 // commonly used svalue.


### PR DESCRIPTION
A user reported [nightmare-residuum's `planet.c::query_noise()`](https://github.com/michaelprograms/nightmare-residuum/blob/main/lib/daemon/planet.c#L86-L303) (4D simplex noise planet generation) as slow. This adds a benchmark for that workload and fixes the driver-level costs it exposed. **The LPC is unmodified — every gain here is in the driver**, and applies to any allocation-light LPC, not just this workload.

## The benchmark

`testsuite/bench/` carries the measured code extracted from the mudlib (noise.c's 4D simplex kernel, planet.c's `query_noise`), driven by `/command/bench` via a new `-fbench[:edge]` master flag. It reports the kernel, one octave stack, and a full planet grid, plus a deterministic sample tuple used to prove behaviour is unchanged.

For the record on the LPC side: the kernel is simply large — ~21 `noise_simplex_4d_permutation` calls per tile at ~1,900 opcodes each, ≈40,000 opcodes/tile. I initially assumed the mapping lookups dominated; a hoisted-lookup diagnostic variant showed they were only ~14%. There is no single hot spot in the LPC to fix, which is what pushed this to the driver.

## What was actually slow

callgrind put ~20% of runtime in `operator new` / `free` / `strlen` / `memcpy` / `std::string` — on a workload that allocates nothing.

`md_record_ref_journal()` is a `DEBUGMALLOC_EXTENSIONS`-only diagnostic whose entire body is `#ifdef`'d out of production builds — but it took its description as `std::string` **by value**. Every call site therefore paid a strlen + `operator new` + memcpy + free to hand a ~50-character `__CURRENT_FILE_LINE__` literal to an empty function. Those call sites are `assign_svalue_no_free()`, `int_free_svalue()`, `int_ref_string()` and `int_free_string()`: once per refcounted svalue assignment and release, and once per shared-string ref/unref, **across the whole VM**.

Four call sites in `stralloc.cc` also built their argument by concatenation (`"ref_string: " + std::string(desc)`), which allocates twice more even when the callee is an empty inline — so the non-DEBUGMALLOC declaration is now a variadic macro that discards its arguments unevaluated rather than an empty inline function. Every argument at every call site is a pure read (`PTR_TO_NODET` is pointer arithmetic, `MSTR_REF`/`->refs` are loads), so discarding them unevaluated changes nothing observable.

Two smaller changes:

- `eval_instruction()` re-read `CONFIG_INT(__RC_TRACE_CODE__)` and `CONFIG_INT(__RC_TRACE_INSTR__)` from the global `config_int[]` array on every dispatched instruction. Both are boot-time-only config, but the opcode bodies call out to code the compiler cannot see through, so it must reload them each iteration; they are now hoisted into locals. `debug_level` is deliberately left alone — `set_debug_level()` can change it from LPC inside this very loop.
- `free_svalue()` now tests for an owning type inline and only calls `int_free_svalue()` for strings, refcounted pointers and error handlers. For every other type the out-of-line body just sets `T_FREED`, and outside DEBUG builds nothing reads that bit back. DEBUG builds still always call out, keeping their double-free detection intact.

## Results

Measured on the new benchmark (RelWithDebInfo, same machine, A/B against a pristine build):

| | before | after | |
|---|---|---|---|
| retired instructions (callgrind) | 4,520,240,337 | 2,968,862,756 | −34% |
| `query_noise` per tile | ~203 µs | ~129 µs | 1.57× |
| simplex kernel call | 9,469 ns | 5,819 ns | 1.63× |

## One thing deliberately left out

`svalue.h` gained a comment recording why the matching inline fast path for `assign_svalue_no_free()` is **not** here: it works and is worth ~4%, but inlining the whole-struct store lets `-fsanitize=object-size` see through to `array_t`'s legacy `svalue_t item[1]` flexible-array member and report every `item[i>0]` write, which would fail the RelWithDebInfo+sanitizer CI job. Real flexible array members would unblock it.

## Validation

LPC testsuite ×3 (randomized order), 326/326 GTest, Debug+ASan/UBSan with the DEBUGMALLOC ref-count checker ×2, and RelWithDebInfo+ASan/UBSan — all clean, with the benchmark's sample tuple bit-identical throughout.

## Related

Two follow-on PRs came out of profiling the same workload and are independent of this one: string ASCII/size caching, and diagnostic-rendering I/O.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MN9sz4nvGgBZw9oZiei3XR

---
_Generated by [Claude Code](https://claude.ai/code/session_01MN9sz4nvGgBZw9oZiei3XR)_