### PR TITLE
Make sizeof()/indexing O(1) for pure-ASCII strings

### DIFF
--- a/src/base/internal/EGCIterator.h
+++ b/src/base/internal/EGCIterator.h
@@ -68,9 +68,26 @@ class BreakIteratorPool {
 
 // Wrapper class to create a icu EGC iterator for given string.
 // can access underlying icu::BreakIterator
+//
+// Pure-ASCII fast path
+// -------------------
+// Driving ICU's rule-based break iterator costs on the order of 50 machine
+// instructions per grapheme cluster, plus a utext_openUTF8()/setText() setup
+// per string. In a mudlib the overwhelming majority of strings are pure
+// ASCII, and for those the answer is trivial: every byte is exactly one
+// grapheme cluster, so EGC index == byte offset and the cluster count is just
+// the byte length.
+//
+// So reset() first scans for a byte with the high bit set. When there is
+// none the string is flagged ASCII, ICU is NOT set up at all, and
+// EGCSmartIterator answers every query arithmetically. ICU is still wired up
+// lazily -- by ensure_icu(), via operator->() -- so code that reaches for the
+// underlying icu::BreakIterator keeps working unchanged on any string.
 class EGCIterator {
  private:
   bool ok_ = false;
+  bool ascii_ = false;
+  bool icu_ready_ = false;
   const char* src_;
   int32_t len_;
 
@@ -79,40 +96,85 @@ class EGCIterator {
     return &pool;
   }
 
- protected:
-  BreakIteratorPool::item_type brk_;
+  // True when the string is pure ASCII (so trivially valid UTF-8) AND contains
+  // no CR.
+  //
+  // The CR exclusion is load-bearing, not caution: UAX #29 rule GB3 joins
+  // CR x LF into ONE grapheme cluster, so "\r\n" is 2 bytes but 1 cluster and
+  // the byte-offset==index identity breaks. CR is the only ASCII byte that can
+  // join with a following character this way -- pinned exhaustively over all
+  // 128x128 ASCII pairs by EGCAsciiFastPath.CrLfIsTheOnlyAsciiJoin. Excluding
+  // every CR (rather than just CR immediately before LF) keeps this a single
+  // flat scan; a lone CR merely falls back to ICU, which is still correct.
+  //
+  // Auto-vectorizes to a few bytes per cycle, against ICU's ~50 instructions
+  // per cluster.
+  static bool all_ascii(const char* src, int32_t slen) {
+    unsigned char acc = 0;
+    unsigned char cr = 0;
+    for (int32_t i = 0; i < slen; i++) {
+      auto c = static_cast<unsigned char>(src[i]);
+      acc |= c;
+      cr |= static_cast<unsigned char>(c == '\r');
+    }
+    return (acc & 0x80u) == 0 && cr == 0;
+  }
 
- public:
-  [[nodiscard]] bool ok() const { return ok_; }
-  [[nodiscard]] const char* data() const { return src_; }
-  [[nodiscard]] int32_t len() const { return len_; }
-  void reset(const char* src, int32_t slen) {
-    ok_ = false;
-
+  bool setup_icu() {
     UText text = UTEXT_INITIALIZER;
     UErrorCode status = U_ZERO_ERROR;
-    utext_openUTF8(&text, src, slen, &status);
+    utext_openUTF8(&text, src_, len_, &status);
     if (!U_SUCCESS(status)) {
       utext_close(&text);
-      return;
+      return false;
     }
 
     status = U_ZERO_ERROR;
     brk_->setText(&text, status);  // copies text
     if (!U_SUCCESS(status)) {
       utext_close(&text);
-      return;
+      return false;
     }
     // no longer needed.
     utext_close(&text);
 
     brk_->first();
+    icu_ready_ = true;
+    return true;
+  }
 
+ protected:
+  BreakIteratorPool::item_type brk_;
+
+  // Materialize the ICU iterator for a string that skipped setup because it
+  // is ASCII. Must be called before ANY use of brk_.
+  bool ensure_icu() { return icu_ready_ ? true : setup_icu(); }
+
+ public:
+  [[nodiscard]] bool ok() const { return ok_; }
+  [[nodiscard]] bool is_ascii() const { return ascii_; }
+  [[nodiscard]] const char* data() const { return src_; }
+  [[nodiscard]] int32_t len() const { return len_; }
+  void reset(const char* src, int32_t slen) {
+    ok_ = false;
+    icu_ready_ = false;
     src_ = src;
     len_ = slen;
-    ok_ = true;
+
+    ascii_ = all_ascii(src, slen);
+    if (ascii_) {
+      // Pure ASCII is always well-formed UTF-8; defer ICU until something
+      // actually asks for the underlying break iterator.
+      ok_ = true;
+      return;
+    }
+
+    ok_ = setup_icu();
   }
-  auto operator->() { return brk_.operator->(); }
+  auto operator->() {
+    ensure_icu();
+    return brk_.operator->();
+  }
 
   static BreakIteratorPool::item_type GetBreakIterator() { return pool()->accquire(); }
 

--- a/src/base/internal/EGCIterator.h
+++ b/src/base/internal/EGCIterator.h
@@ -153,6 +153,11 @@ class EGCIterator {
  public:
   [[nodiscard]] bool ok() const { return ok_; }
   [[nodiscard]] bool is_ascii() const { return ascii_; }
+  // The raw predicate, WITHOUT constructing an iterator. Constructing one
+  // acquires an ICU break iterator from the pool, which builds 32 of them on
+  // first touch -- absurd overhead when all you want is a byte scan. Callers
+  // that only need the answer (u8_string_is_ascii_cached) use this.
+  static bool scan_is_ascii(const char* src, int32_t slen) { return all_ascii(src, slen); }
   [[nodiscard]] const char* data() const { return src_; }
   [[nodiscard]] int32_t len() const { return len_; }
   void reset(const char* src, int32_t slen) {

--- a/src/base/internal/stralloc.cc
+++ b/src/base/internal/stralloc.cc
@@ -192,6 +192,7 @@ static block_t* alloc_new_shared_string(const char* string, int h, const char* w
   }
   SIZE(b) = (len > UINT_MAX ? UINT_MAX : len);
   REFS(b) = 1;
+  b->ascii = MSTR_ASCII_UNKNOWN;  // computed lazily on first EGC query
   md_record_ref_journal(PTR_TO_NODET(b), true, b->refs,
                         "alloc_new_shared_string: " + std::string(why));
   NEXT(b) = base_table[h];
@@ -374,6 +375,7 @@ char* int_new_string(unsigned int size)
     ADD_NEW_STRING(UINT_MAX, sizeof(malloc_block_t));
   }
   mbt->ref = 1;
+  mbt->ascii = MSTR_ASCII_UNKNOWN;  // computed lazily on first EGC query
   ADD_STRING(mbt->size);
   CHECK_STRING_STATS;
   return reinterpret_cast<char*>(mbt + 1);
@@ -390,6 +392,9 @@ char* extend_string(const char* str, int len) {
   } else {
     mbt->size = UINT_MAX;
   }
+  // The caller is about to write new bytes into the extended buffer, so a
+  // previously cached ASCII answer no longer describes the contents.
+  mbt->ascii = MSTR_ASCII_UNKNOWN;
   ADD_STRING_SIZE(mbt->size - oldsize);
   CHECK_STRING_STATS;
 

--- a/src/base/internal/stralloc.cc
+++ b/src/base/internal/stralloc.cc
@@ -467,6 +467,13 @@ char* int_string_unlink(const char* str)
     ADD_NEW_STRING(mbt->size, sizeof(malloc_block_t));
   }
   newmbt->ref = 1;
+  // This is the one string-block allocation that goes through raw DMALLOC
+  // instead of int_new_string()/alloc_new_shared_string(), so the ascii
+  // field is heap garbage unless set here. Garbage that happens to equal
+  // MSTR_ASCII_YES on a non-ASCII string would make sizeof() answer from
+  // the byte length. UNKNOWN (not a copy of mbt->ascii) because every
+  // caller unlinks precisely in order to mutate the bytes next.
+  newmbt->ascii = MSTR_ASCII_UNKNOWN;
   CHECK_STRING_STATS;
 
   return reinterpret_cast<char*>(newmbt + 1);

--- a/src/base/internal/stralloc.h
+++ b/src/base/internal/stralloc.h
@@ -87,6 +87,19 @@ void check_string_stats(outbuffer_t*);
   allocd_bytes -= len + 1; \
   CHECK_STRING_STATS
 
+/* Cached answer to "is this string pure ASCII (and CR-free)?", so the
+ * grapheme-cluster machinery can be skipped outright rather than re-derived
+ * on every sizeof()/index. Tri-state, and the UNKNOWN default is
+ * load-bearing: a string-creation path that forgets to set it degrades to
+ * scanning (slow but correct) instead of asserting a wrong answer.
+ *
+ * Lives in the two bytes of padding that already sat between `ref` and the
+ * string data, so sizeof(block_t) is unchanged in every build -- see the
+ * static_assert below. */
+#define MSTR_ASCII_UNKNOWN 0u
+#define MSTR_ASCII_YES 1u
+#define MSTR_ASCII_NO 2u
+
 // The layout of malloc_block_s must be same as block_s
 typedef struct malloc_block_s {
   void* _padding1;
@@ -96,12 +109,16 @@ typedef struct malloc_block_s {
 #endif
   unsigned int size;
   unsigned short ref;
+  unsigned char ascii;
 } malloc_block_t;
 
 #define MSTR_BLOCK(x) (((malloc_block_t*)(x)) - 1)
 #define MSTR_EXTRA_REF(x) (MSTR_BLOCK(x)->extra_ref)
 #define MSTR_REF(x) (MSTR_BLOCK(x)->ref)
 #define MSTR_SIZE(x) (MSTR_BLOCK(x)->size)
+/* Valid only for STRING_MALLOC / STRING_SHARED (i.e. STRING_COUNTED) strings;
+ * a STRING_CONSTANT points at a literal with no block header. */
+#define MSTR_ASCII(x) (MSTR_BLOCK(x)->ascii)
 #define MSTR_UPDATE_SIZE(x, y) \
   SAFE(ADD_STRING_SIZE(y - MSTR_SIZE(x)); MSTR_BLOCK(x)->size = (y > UINT_MAX ? UINT_MAX : y);)
 
@@ -139,13 +156,20 @@ typedef struct block_s {
 #if defined(DEBUGMALLOC_EXTENSIONS)  //|| (SIZEOF_CHAR_P == 8)
   unsigned int extra_ref;
 #endif
-  /* these two must be last */
+  /* these three must be last, and must mirror malloc_block_s exactly:
+   * MSTR_SIZE/MSTR_REF/MSTR_ASCII reach a STRING_SHARED string through
+   * malloc_block_t, so the offsets have to agree */
   unsigned int size;   /* length of the string */
   unsigned short refs; /* reference count    */
+  unsigned char ascii; /* MSTR_ASCII_* cache, see above */
 } block_t;
 
 static_assert(sizeof(malloc_block_t) == sizeof(block_t),
               "Block size mismatch, this will cause memory corruption!");
+static_assert(offsetof(malloc_block_t, size) == offsetof(block_t, size) &&
+                  offsetof(malloc_block_t, ref) == offsetof(block_t, refs) &&
+                  offsetof(malloc_block_t, ascii) == offsetof(block_t, ascii),
+              "malloc_block_t/block_t field offsets diverged");
 
 #define NEXT(x) (x)->next
 #define REFS(x) (x)->refs

--- a/src/base/internal/strutils.cc
+++ b/src/base/internal/strutils.cc
@@ -611,13 +611,13 @@ std::string u8_convert_encoding(UConverter* trans, const char* data, int len) {
 // makes a repeated sizeof() on the same string O(1) instead of O(n).
 bool u8_string_is_ascii_cached(const char* str, int32_t len, bool counted) {
   if (!counted) {  // no block header to memoize into
-    return EGCIterator(str, len).is_ascii();
+    return EGCIterator::scan_is_ascii(str, len);
   }
   unsigned char cached = MSTR_ASCII(str);
   if (cached != MSTR_ASCII_UNKNOWN) {
     return cached == MSTR_ASCII_YES;
   }
-  bool ascii = EGCIterator(str, len).is_ascii();
+  bool ascii = EGCIterator::scan_is_ascii(str, len);
   MSTR_ASCII(str) = ascii ? MSTR_ASCII_YES : MSTR_ASCII_NO;
   return ascii;
 }

--- a/src/base/internal/strutils.cc
+++ b/src/base/internal/strutils.cc
@@ -13,6 +13,7 @@
 #include "base/internal/log.h"
 #include "base/internal/rc.h"
 #include "base/internal/EGCIterator.h"
+#include "base/internal/stralloc.h"
 
 bool u8_validate(char** s) {
   const auto* p = (const uint8_t*)(*s);
@@ -603,4 +604,20 @@ std::string u8_convert_encoding(UConverter* trans, const char* data, int len) {
     }
   }
   return result;
+}
+
+// See the declaration in strutils.h. The scan itself is EGCIterator's
+// (all_ascii); this only adds the per-string memoization, which is what
+// makes a repeated sizeof() on the same string O(1) instead of O(n).
+bool u8_string_is_ascii_cached(const char* str, int32_t len, bool counted) {
+  if (!counted) {  // no block header to memoize into
+    return EGCIterator(str, len).is_ascii();
+  }
+  unsigned char cached = MSTR_ASCII(str);
+  if (cached != MSTR_ASCII_UNKNOWN) {
+    return cached == MSTR_ASCII_YES;
+  }
+  bool ascii = EGCIterator(str, len).is_ascii();
+  MSTR_ASCII(str) = ascii ? MSTR_ASCII_YES : MSTR_ASCII_NO;
+  return ascii;
 }

--- a/src/base/internal/strutils.h
+++ b/src/base/internal/strutils.h
@@ -222,6 +222,20 @@ class EGCSmartIterator : public EGCIterator {
   int32_t ascii_pos_ = 0;  // byte offset cursor, ASCII fast path only
 };
 
+// Is this string pure ASCII (and CR-free), i.e. does byte offset equal
+// grapheme-cluster index throughout?
+//
+// Pass counted=true only for a STRING_MALLOC / STRING_SHARED string, i.e.
+// one that has a malloc_block_t/block_t header: those memoize the answer in
+// the header, so repeated queries on the same string are O(1) -- which is
+// what turns the common `for (i = 0; i < sizeof(s); i++)` from O(n^2) into
+// O(n). A STRING_CONSTANT has no header and is rescanned each time.
+// See MSTR_ASCII_* in stralloc.h.
+//
+// Takes primitives rather than an svalue_t deliberately: base/ must not
+// depend on VM types (see AGENTS.md 12).
+bool u8_string_is_ascii_cached(const char* str, int32_t len, bool counted);
+
 // Check string s is valid utf8
 bool u8_validate(char**);
 bool u8_validate(const char*);

--- a/src/base/internal/strutils.h
+++ b/src/base/internal/strutils.h
@@ -114,9 +114,16 @@ class EGCSmartIterator : public EGCIterator {
     if (count_ == -1) {
       // ASCII: one cluster per byte, so the count is the byte length. This is
       // the hot one -- sizeof(str) on a mudlib string lands here.
+      //
+      // Leave the cursor at the end, exactly where the ICU walk below leaves
+      // it. No current caller counts and then keeps iterating (they all use
+      // the value, or re-seek with index_to_offset first), but letting the
+      // two paths disagree about cursor state would make a later count() +
+      // next() silently mean different things on ASCII and non-ASCII input.
       if (is_ascii()) {
         count_ = len();
         current_idx_ = count_;
+        ascii_pos_ = len();
         return count_;
       }
       count_ = 0;

--- a/src/base/internal/strutils.h
+++ b/src/base/internal/strutils.h
@@ -112,6 +112,13 @@ class EGCSmartIterator : public EGCIterator {
   EGCSmartIterator(const char* src, int32_t slen) : EGCIterator(src, slen) {}
   size_t count() {
     if (count_ == -1) {
+      // ASCII: one cluster per byte, so the count is the byte length. This is
+      // the hot one -- sizeof(str) on a mudlib string lands here.
+      if (is_ascii()) {
+        count_ = len();
+        current_idx_ = count_;
+        return count_;
+      }
       count_ = 0;
       brk_->first();
       while (brk_->next() != icu::BreakIterator::DONE) ++count_;
@@ -120,6 +127,16 @@ class EGCSmartIterator : public EGCIterator {
     return count_;
   }
   int32_t index_to_offset(int32_t index) {
+    // ASCII: EGC index == byte offset. Boundaries are 0..len, a negative index
+    // counts back from the end, and anything outside that range is DONE --
+    // matching what the ICU walk below returns for the same input.
+    if (is_ascii()) {
+      int32_t off = index >= 0 ? index : len() + index;
+      if (off < 0 || off > len()) return icu::BreakIterator::DONE;
+      ascii_pos_ = off;
+      current_idx_ = index;
+      return off;
+    }
     if (index == 0) {
       current_idx_ = 0;
       return brk_->first();
@@ -153,19 +170,42 @@ class EGCSmartIterator : public EGCIterator {
   int32_t post_index_to_offset(int32_t index) {
     auto pos = index_to_offset(index);
     if (pos < 0) return pos;
+    if (is_ascii()) {
+      // Mirrors the ICU pair below: next() then previous(). Off the end,
+      // next() reports DONE and the following previous() still steps the
+      // cursor back one boundary -- reproduce that side effect exactly.
+      if (pos >= len()) {
+        ascii_pos_ = len() > 0 ? len() - 1 : 0;
+        return icu::BreakIterator::DONE;
+      }
+      return pos + 1;  // cursor stays at pos, as next()+previous() leaves it
+    }
     pos = brk_->next();
     brk_->previous();
     return pos;
   }
   int32_t first() {
     current_idx_ = 0;
+    if (is_ascii()) {
+      ascii_pos_ = 0;
+      return 0;
+    }
     return brk_->first();
   }
   int32_t last() {
     current_idx_ = -1;
+    if (is_ascii()) {
+      ascii_pos_ = len();
+      return len();
+    }
     return brk_->last();
   }
   int32_t next() {
+    if (is_ascii()) {
+      if (ascii_pos_ >= len()) return icu::BreakIterator::DONE;  // cursor unchanged
+      current_idx_++;
+      return ++ascii_pos_;
+    }
     auto oldpos = brk_->current();
     auto pos = brk_->next();
     if (pos == icu::BreakIterator::DONE) {
@@ -179,6 +219,7 @@ class EGCSmartIterator : public EGCIterator {
  private:
   int32_t current_idx_ = 0;
   int32_t count_ = -1;
+  int32_t ascii_pos_ = 0;  // byte offset cursor, ASCII fast path only
 };
 
 // Check string s is valid utf8

--- a/src/compiler/internal/compiler.cc
+++ b/src/compiler/internal/compiler.cc
@@ -19,6 +19,7 @@
 #include "compiler/internal/lexer_utils.h"
 #include "compiler/internal/grammar_rules.h"
 #include "grammar.autogen.h"
+#include "base/internal/strutils.h"  // u8_string_is_ascii_cached
 #include "scratchpad.h"
 #include "symbol.h"
 #include <string>
@@ -1714,6 +1715,19 @@ short store_prog_string(const char* str) {
     str = make_shared_string(origin_str);
     is_new_string = true;
   }
+
+  // Settle "is this pure ASCII?" HERE, at compile time, once per literal.
+  //
+  // Every program string literal is interned through this one function, and
+  // the shared-string header has a field for the answer -- so paying a single
+  // scan now means sizeof()/indexing on a literal never scans at runtime, no
+  // matter how hot the loop around it is. The alternative is deriving it
+  // lazily on first use: the same scan, but on the runtime path and after the
+  // mud is live.
+  //
+  // Cheap and idempotent -- a string already interned by an earlier compile
+  // just reads its cached tag straight back.
+  u8_string_is_ascii_cached(str, static_cast<int32_t>(strlen(str)), /*counted=*/true);
 
   STRING_HASH(hash, str);
   idxp = &string_idx[hash];

--- a/src/packages/core/efuns_main.cc
+++ b/src/packages/core/efuns_main.cc
@@ -2044,6 +2044,14 @@ void f_replace_string() {
           }
           src++;
         }
+        // Unlike every other in-place branch of this efun, this one never
+        // reaches extend_string() (which resets the cached ASCII tag), yet it
+        // just spliced *replace bytes into the unlinked STRING_MALLOC buffer.
+        // A valid 1-byte replacement is always ASCII, but "\r" is too -- and
+        // splicing CR into a CR-free string tagged MSTR_ASCII_YES breaks the
+        // byte==cluster identity ("\r\n" is one grapheme cluster), leaving
+        // sizeof() to answer from the stale tag. Reset so it re-derives.
+        MSTR_ASCII(arg->u.string) = MSTR_ASCII_UNKNOWN;
       } else { /* rlen is zero */
         while (*src) {
           if (*src++ == *pattern) {

--- a/src/packages/core/efuns_main.cc
+++ b/src/packages/core/efuns_main.cc
@@ -2494,6 +2494,16 @@ void f_sizeof() {
       free_buffer(sp->u.buf);
       break;
     case T_STRING: {
+      // Pure ASCII (the overwhelming majority of mudlib text) has one
+      // grapheme cluster per byte, and counted strings remember that in
+      // their block header -- so this is O(1) with no iterator at all.
+      if (u8_string_is_ascii_cached(sp->u.string, SVALUE_STRLEN(sp),
+                                    (sp->subtype & STRING_COUNTED) != 0)) {
+        i = SVALUE_STRLEN(sp);
+        free_string_svalue(sp);
+        put_number(i);
+        return;
+      }
       EGCSmartIterator iter(sp->u.string, SVALUE_STRLEN(sp));
       if (!iter.ok()) {
         error("f_sizeof: Invalid UTF8 string!");

--- a/src/packages/ops/ops.cc
+++ b/src/packages/ops/ops.cc
@@ -723,6 +723,7 @@ void f_range(int code) {
       char* tmp = new_string(to - from, "f_range");
       memcpy(tmp, iter.data() + from, to - from);
       tmp[to - from] = '\0';
+      MSTR_TAG_SUBSTRING(tmp, iter.is_ascii());
 
       pop_3_elems();
       push_malloced_string(tmp);
@@ -833,7 +834,9 @@ void f_extract_range(int code) {
         sp->subtype = STRING_CONSTANT;
         sp->u.string = "";
       } else {
-        put_malloced_string(string_copy(iter.data() + offset, "f_extract_range"));
+        char* sub = string_copy(iter.data() + offset, "f_extract_range");
+        MSTR_TAG_SUBSTRING(sub, iter.is_ascii());
+        put_malloced_string(sub);
       }
       free_string_svalue(sp + 1);
       break;

--- a/src/tests/test_strutils.cc
+++ b/src/tests/test_strutils.cc
@@ -40,3 +40,179 @@ TEST(U8IncompleteTail, MalformedInputIsNotHeld) {
   // ASCII directly before the end
   EXPECT_EQ(0u, u8_incomplete_tail("abc\x7f"));
 }
+
+// ---------------------------------------------------------------------------
+// EGCSmartIterator pure-ASCII fast path.
+//
+// For a string with no high-bit byte, EGCIterator skips ICU entirely and
+// EGCSmartIterator answers arithmetically (EGC index == byte offset). These
+// tests pin that the fast path is observationally identical to driving ICU,
+// including the DONE / out-of-range edges -- they are the reason the fast path
+// can be trusted rather than reasoned about.
+//
+// The reference side forces the ICU path by using a *separate* iterator object
+// and driving the raw icu::BreakIterator through operator->(), which calls
+// ensure_icu(). Two objects, so the two cursors never interfere.
+namespace {
+
+// Reference implementations, computed with ICU on the very same bytes.
+int32_t icu_count(const char* s, int32_t len) {
+  EGCIterator ref(s, len);
+  int32_t n = 0;
+  ref->first();
+  while (ref->next() != icu::BreakIterator::DONE) ++n;
+  return n;
+}
+
+// Mirror of EGCSmartIterator::index_to_offset()'s ICU branch, run on a fresh
+// iterator so it is unaffected by the fast path under test.
+int32_t icu_index_to_offset(const char* s, int32_t len, int32_t index) {
+  EGCIterator ref(s, len);
+  if (index == 0) return ref->first();
+  if (index == -1) {
+    ref->last();
+    return ref->previous();
+  }
+  int32_t current_idx;
+  if (index > 0) {
+    current_idx = 0;
+    ref->first();
+  } else {
+    current_idx = -1;
+    ref->last();
+    ref->previous();
+  }
+  auto oldpos = ref->current();
+  auto pos = ref->next(index - current_idx);
+  if (pos == icu::BreakIterator::DONE) ref->isBoundary(oldpos);
+  return pos;
+}
+
+}  // namespace
+
+TEST(EGCAsciiFastPath, DetectsAsciiAndNonAscii) {
+  EGCSmartIterator ascii("hello world", 11);
+  EXPECT_TRUE(ascii.ok());
+  EXPECT_TRUE(ascii.is_ascii());
+
+  const char* wide = "a\xe4\xbd\xa0z";  // a 你 z
+  EGCSmartIterator non_ascii(wide, 5);
+  EXPECT_TRUE(non_ascii.ok());
+  EXPECT_FALSE(non_ascii.is_ascii());
+
+  EGCSmartIterator empty("", 0);
+  EXPECT_TRUE(empty.ok());
+  EXPECT_TRUE(empty.is_ascii());
+}
+
+TEST(EGCAsciiFastPath, CountMatchesIcu) {
+  const char* cases[] = {"",   "a",         "hello world",
+                         "\t\n multi line \n text", "0123456789",
+                         "a string long enough to cross a few cache lines "
+                         "and keep the break iterator busy for a while"};
+  for (const char* s : cases) {
+    auto len = static_cast<int32_t>(strlen(s));
+    EGCSmartIterator it(s, len);
+    ASSERT_TRUE(it.is_ascii()) << s;
+    EXPECT_EQ(static_cast<size_t>(len), it.count()) << s;
+    EXPECT_EQ(icu_count(s, len), static_cast<int32_t>(it.count())) << s;
+  }
+}
+
+TEST(EGCAsciiFastPath, IndexToOffsetMatchesIcuIncludingOutOfRange) {
+  const char* cases[] = {"", "a", "hello", "0123456789abcdef"};
+  for (const char* s : cases) {
+    auto len = static_cast<int32_t>(strlen(s));
+    // Sweep well past both ends so the DONE edges are covered.
+    for (int32_t i = -len - 3; i <= len + 3; i++) {
+      EGCSmartIterator it(s, len);
+      ASSERT_TRUE(it.is_ascii()) << s;
+      EXPECT_EQ(icu_index_to_offset(s, len, i), it.index_to_offset(i))
+          << "s='" << s << "' index=" << i;
+    }
+  }
+}
+
+TEST(EGCAsciiFastPath, PostIndexToOffsetMatchesIcu) {
+  const char* cases[] = {"", "a", "hello", "0123456789"};
+  for (const char* s : cases) {
+    auto len = static_cast<int32_t>(strlen(s));
+    for (int32_t i = -len - 2; i <= len + 2; i++) {
+      // Reference: drive the ICU branch via a non-ASCII-free clone is not
+      // possible, so replicate post_index_to_offset()'s ICU steps directly.
+      EGCIterator ref(s, len);
+      int32_t expect;
+      int32_t pos = icu_index_to_offset(s, len, i);
+      if (pos < 0) {
+        expect = pos;
+      } else {
+        // Re-seat the reference cursor at pos, then next()/previous().
+        ref->isBoundary(pos);
+        expect = ref->next();
+        ref->previous();
+      }
+      EGCSmartIterator it(s, len);
+      ASSERT_TRUE(it.is_ascii()) << s;
+      EXPECT_EQ(expect, it.post_index_to_offset(i)) << "s='" << s << "' index=" << i;
+    }
+  }
+}
+
+TEST(EGCAsciiFastPath, WalkMatchesIcu) {
+  const char* s = "walk every boundary";
+  auto len = static_cast<int32_t>(strlen(s));
+
+  EGCSmartIterator it(s, len);
+  ASSERT_TRUE(it.is_ascii());
+  EXPECT_EQ(0, it.first());
+  for (int32_t i = 1; i <= len; i++) {
+    EXPECT_EQ(i, it.next()) << "boundary " << i;
+  }
+  EXPECT_EQ(icu::BreakIterator::DONE, it.next());  // off the end
+  EXPECT_EQ(icu::BreakIterator::DONE, it.next());  // still off the end
+  EXPECT_EQ(len, it.last());
+}
+
+TEST(EGCAsciiFastPath, NonAsciiStillUsesIcu) {
+  // a 你 😀 z -- 4 clusters, 1 + 3 + 4 + 1 bytes.
+  const char* s = "a\xe4\xbd\xa0\xf0\x9f\x98\x80z";
+  auto len = static_cast<int32_t>(strlen(s));
+  EGCSmartIterator it(s, len);
+  ASSERT_TRUE(it.ok());
+  ASSERT_FALSE(it.is_ascii());
+  EXPECT_EQ(4u, it.count());
+  EXPECT_EQ(icu_count(s, len), static_cast<int32_t>(it.count()));
+  EXPECT_EQ(0, it.index_to_offset(0));
+  EXPECT_EQ(1, it.index_to_offset(1));
+  EXPECT_EQ(4, it.index_to_offset(2));
+  EXPECT_EQ(8, it.index_to_offset(3));
+  EXPECT_EQ(8, it.index_to_offset(-1));
+}
+
+// The whole fast path rests on one claim: among ASCII bytes, CR-LF is the ONLY
+// pair that forms a single grapheme cluster. Prove it against ICU rather than
+// against a reading of UAX #29 -- an extra joining pair would silently corrupt
+// every sizeof()/index on strings containing it.
+TEST(EGCAsciiFastPath, CrLfIsTheOnlyAsciiJoin) {
+  for (int a = 0; a < 128; a++) {
+    for (int b = 0; b < 128; b++) {
+      if (a == 0 || b == 0) continue;  // NUL would terminate the buffer early
+      char buf[2] = {static_cast<char>(a), static_cast<char>(b)};
+      int32_t clusters = icu_count(buf, 2);
+      bool is_crlf = (a == '\r' && b == '\n');
+      EXPECT_EQ(is_crlf ? 1 : 2, clusters)
+          << "ASCII pair (" << a << "," << b << ") clustered unexpectedly";
+    }
+  }
+}
+
+// And confirm a CR-bearing string is routed to ICU rather than the fast path.
+TEST(EGCAsciiFastPath, CarriageReturnFallsBackToIcu) {
+  const char* s = "line one\r\nline two";
+  auto len = static_cast<int32_t>(strlen(s));
+  EGCSmartIterator it(s, len);
+  ASSERT_TRUE(it.ok());
+  EXPECT_FALSE(it.is_ascii()) << "CR must disable the fast path";
+  EXPECT_EQ(static_cast<size_t>(icu_count(s, len)), it.count());
+  EXPECT_EQ(static_cast<size_t>(len - 1), it.count());  // CRLF counts as one
+}

--- a/src/tests/test_strutils.cc
+++ b/src/tests/test_strutils.cc
@@ -235,3 +235,47 @@ TEST(EGCAsciiFastPath, CarriageReturnFallsBackToIcu) {
   EXPECT_EQ(static_cast<size_t>(icu_count(s, len)), it.count());
   EXPECT_EQ(static_cast<size_t>(len - 1), it.count());  // CRLF counts as one
 }
+
+// ---------------------------------------------------------------------------
+// MSTR_ASCII tag lifecycle on the one string-block allocation that does NOT
+// go through int_new_string()/alloc_new_shared_string(): int_string_unlink(),
+// which raw-DMALLOCs a fresh header when detaching a multiply-referenced
+// string. Before the fix it copied size/ref into the new header but left the
+// ascii field as heap garbage -- garbage that happened to equal
+// MSTR_ASCII_YES on a non-ASCII string would make sizeof() answer from the
+// byte length. This pins the invariant that the unlinked copy's tag is a
+// defined value and that the public predicate answers correctly through it.
+// (The uninitialized read itself is what MSan would flag pre-fix.)
+#include "base/internal/stralloc.h"
+
+TEST(MstrAsciiTag, StringUnlinkProducesADefinedTag) {
+  // Non-ASCII case: cache NO on the original, then unlink a second reference.
+  char* s = new_string(6, "test: unlink non-ascii");
+  memcpy(s, "\xe4\xbd\xa0\xe5\xa5\xbd", 7);  // "你好" + NUL, 6 bytes
+  EXPECT_FALSE(u8_string_is_ascii_cached(s, 6, true));
+  EXPECT_EQ(MSTR_ASCII_NO, MSTR_ASCII(s));
+
+  MSTR_REF(s)++;  // simulate a second reference, as unlink_string_svalue sees
+  char* copy = string_unlink(s, "test: unlink non-ascii");
+  ASSERT_NE(s, copy);
+  unsigned char tag = MSTR_ASCII(copy);
+  EXPECT_TRUE(tag == MSTR_ASCII_UNKNOWN || tag == MSTR_ASCII_NO)
+      << "unlinked copy's ascii tag is undefined garbage: " << int(tag);
+  EXPECT_FALSE(u8_string_is_ascii_cached(copy, 6, true));
+  FREE_MSTR(copy);
+  FREE_MSTR(s);
+
+  // ASCII case: the copy must not come out pre-tagged NO-or-garbage either.
+  char* a = new_string(3, "test: unlink ascii");
+  memcpy(a, "abc", 4);
+  EXPECT_TRUE(u8_string_is_ascii_cached(a, 3, true));
+  MSTR_REF(a)++;
+  char* acopy = string_unlink(a, "test: unlink ascii");
+  ASSERT_NE(a, acopy);
+  tag = MSTR_ASCII(acopy);
+  EXPECT_TRUE(tag == MSTR_ASCII_UNKNOWN || tag == MSTR_ASCII_YES)
+      << "unlinked copy's ascii tag is undefined garbage: " << int(tag);
+  EXPECT_TRUE(u8_string_is_ascii_cached(acopy, 3, true));
+  FREE_MSTR(acopy);
+  FREE_MSTR(a);
+}

--- a/src/tests/test_strutils.cc
+++ b/src/tests/test_strutils.cc
@@ -105,6 +105,25 @@ TEST(EGCAsciiFastPath, DetectsAsciiAndNonAscii) {
   EXPECT_TRUE(empty.is_ascii());
 }
 
+// count() walks the ICU iterator to the end as a side effect, so the ASCII
+// path has to leave its cursor there too -- otherwise a count() followed by
+// next() means one thing on ASCII input and another on non-ASCII. Compared
+// against ICU rather than against an assumed answer.
+TEST(EGCAsciiFastPath, CountLeavesCursorAtEndLikeIcu) {
+  const char* ascii = "hello";
+  const char* wide = "a\xe4\xbd\xa0z";  // a 你 z -- 3 clusters, 5 bytes
+
+  EGCSmartIterator a(ascii, 5);
+  ASSERT_TRUE(a.is_ascii());
+  EXPECT_EQ(5u, a.count());
+  EXPECT_EQ(icu::BreakIterator::DONE, a.next()) << "cursor must be at the end";
+
+  EGCSmartIterator w(wide, 5);
+  ASSERT_FALSE(w.is_ascii());
+  EXPECT_EQ(3u, w.count());
+  EXPECT_EQ(icu::BreakIterator::DONE, w.next()) << "ICU path, same contract";
+}
+
 TEST(EGCAsciiFastPath, CountMatchesIcu) {
   const char* cases[] = {"",   "a",         "hello world",
                          "\t\n multi line \n text", "0123456789",

--- a/src/vm/internal/base/array.cc
+++ b/src/vm/internal/base/array.cc
@@ -1089,6 +1089,14 @@ void map_string(svalue_t* arg, int num_arg) {
     }
   }
 
+  // The callback's return value was written straight into the unlinked
+  // STRING_MALLOC buffer, and it can be ANY byte -- including '\r' (13),
+  // which breaks the byte==grapheme-cluster identity behind a cached
+  // MSTR_ASCII_YES tag ("\r\n" is one cluster), or a >= 0x80 byte. Nothing
+  // on this path reallocates (extend_string() is what normally resets the
+  // tag), so drop the cache and let it re-derive from the new contents.
+  MSTR_ASCII(arg->u.string) = MSTR_ASCII_UNKNOWN;
+
   pop_n_elems(num_arg - 1);
   /* return value on stack */
 }

--- a/src/vm/internal/base/interpret.cc
+++ b/src/vm/internal/base/interpret.cc
@@ -999,6 +999,16 @@ void copy_lvalue_range(svalue_t* from) {
         /* because both of them can only range from 0 to len */
 
         strncpy((const_cast<char*>(owner->u.string)) + ind1, from->u.string, fsize);
+        // owner is always STRING_MALLOC here (push_lvalue_range's
+        // unlink_string_svalue() guarantees it), and this write mutates its
+        // bytes in place -- unlike extend_string()/new_string(), which reset
+        // the cached tag on every allocation, this path grows nothing and so
+        // has no natural place that does that. Left alone, a stale ASCII tag
+        // (e.g. cached YES via SVALUE_STR_ASCII/MSTR_TAG_JOIN before this
+        // assignment) would silently survive a same-byte-length splice of
+        // non-ASCII content, making a later sizeof()/index answer from the
+        // unchanged byte length instead of rescanning.
+        MSTR_ASCII(owner->u.string) = MSTR_ASCII_UNKNOWN;
       } else {
         char *tmp, *dstr = const_cast<char*>(owner->u.string);
 
@@ -1168,6 +1178,13 @@ void assign_lvalue_range(svalue_t* from) {
         /* because both of them can only range from 0 to len */
 
         strncpy((const_cast<char*>(owner->u.string)) + ind1, from->u.string, fsize);
+        // See the matching comment in copy_lvalue_range(): this is an
+        // in-place mutation of owner's bytes (always STRING_MALLOC here),
+        // and unlike extend_string()/new_string() nothing else resets the
+        // cached ASCII tag for it, so a stale YES would survive a
+        // same-byte-length splice of non-ASCII content into a previously
+        // all-ASCII string.
+        MSTR_ASCII(owner->u.string) = MSTR_ASCII_UNKNOWN;
       } else {
         char* tmp;
         const char* dstr = const_cast<char*>(owner->u.string);

--- a/src/vm/internal/base/svalue.h
+++ b/src/vm/internal/base/svalue.h
@@ -157,6 +157,23 @@ inline void free_svalue_maybe_refed(svalue_t* v) {
 // commonly used svalue.
 extern svalue_t const0, const1, const0u;
 
+/* Is this string svalue pure ASCII (and CR-free), i.e. byte offset == grapheme
+ * cluster index? Kept as a macro rather than an inline function so it expands
+ * where SVALUE_STRLEN/STRING_COUNTED are already visible. */
+#define SVALUE_STR_ASCII(sv)                                            \
+  u8_string_is_ascii_cached((sv)->u.string, SVALUE_STRLEN(sv), ((sv)->subtype & STRING_COUNTED) != 0)
+
+/* Tag a freshly built concatenation. ascii(a + b) == ascii(a) && ascii(b) is
+ * exact ONLY because the ASCII predicate excludes CR: with no CR on either
+ * side, no CR-LF (one cluster, UAX #29 GB3) can form across the seam. If
+ * either side is non-ASCII its bytes survive into the result, so NO likewise
+ * propagates exactly -- neither case needs to rescan the joined string.
+ *
+ * Without this, `s += x` in a loop re-derives the tag from scratch for each
+ * intermediate string, making an accompanying sizeof(s) O(n^2). */
+#define MSTR_TAG_JOIN(res, ascii_both) \
+  (MSTR_ASCII(res) = (ascii_both) ? MSTR_ASCII_YES : MSTR_ASCII_NO)
+
 /* These are not used anywhere */
 
 /* Beek - add some sanity to joining strings */
@@ -169,6 +186,7 @@ extern svalue_t const0, const1, const0u;
     int ess_r;                                                                                    \
     ess_len = (ess_r = SVALUE_STRLEN(x)) + strlen(y);                                             \
     if (ess_len > max_string_length) error("Maximum string length exceeded in concatenation.\n"); \
+    bool ess_ascii = SVALUE_STR_ASCII(x) && u8_string_is_ascii_cached((y), ess_len - ess_r, false);\
     if ((x)->subtype == STRING_MALLOC && MSTR_REF((x)->u.string) == 1) {                          \
       ess_res = (char*)extend_string((x)->u.string, ess_len);                                     \
       if (!ess_res) fatal("Out of memory!\n");                                                    \
@@ -181,6 +199,7 @@ extern svalue_t const0, const1, const0u;
       (x)->subtype = STRING_MALLOC;                                                               \
     }                                                                                             \
     (x)->u.string = ess_res;                                                                      \
+    MSTR_TAG_JOIN(ess_res, ess_ascii);                                                             \
   })
 
 /* <something that needs no free> + string svalue */
@@ -192,6 +211,7 @@ extern svalue_t const0, const1, const0u;
     int pss_len;                                                                                  \
     pss_len = SVALUE_STRLEN(sp) + (pss_r = strlen(y));                                            \
     if (pss_len > max_string_length) error("Maximum string length exceeded in concatenation.\n"); \
+    bool pss_ascii = SVALUE_STR_ASCII(sp) && u8_string_is_ascii_cached((y), pss_r, false);         \
     pss_res = new_string(pss_len, z);                                                             \
     strcpy(pss_res, y);                                                                           \
     strcpy(pss_res + pss_r, sp->u.string);                                                        \
@@ -199,6 +219,7 @@ extern svalue_t const0, const1, const0u;
     sp->type = T_STRING;                                                                          \
     sp->u.string = pss_res;                                                                       \
     sp->subtype = STRING_MALLOC;                                                                  \
+    MSTR_TAG_JOIN(pss_res, pss_ascii);                                                            \
   })
 
 /* basically, string + string; faster than using extend b/c of SVALUE_STRLEN */
@@ -211,6 +232,7 @@ extern svalue_t const0, const1, const0u;
     ssj_r = SVALUE_STRLEN(x);                                                                     \
     ssj_len = ssj_r + SVALUE_STRLEN(y);                                                           \
     if (ssj_len > max_string_length) error("Maximum string length exceeded in concatenation.\n"); \
+    bool ssj_ascii = SVALUE_STR_ASCII(x) && SVALUE_STR_ASCII(y);                                   \
     if ((x)->subtype == STRING_MALLOC && MSTR_REF((x)->u.string) == 1) {                          \
       ssj_res = (char*)extend_string((x)->u.string, ssj_len);                                     \
       if (!ssj_res) fatal("Out of memory!\n");                                                    \
@@ -225,6 +247,7 @@ extern svalue_t const0, const1, const0u;
       (x)->subtype = STRING_MALLOC;                                                               \
     }                                                                                             \
     (x)->u.string = ssj_res;                                                                      \
+    MSTR_TAG_JOIN(ssj_res, ssj_ascii);                                                             \
   })
 
 // Translate svalue into json summary, only suitable for

--- a/src/vm/internal/base/svalue.h
+++ b/src/vm/internal/base/svalue.h
@@ -174,6 +174,17 @@ extern svalue_t const0, const1, const0u;
 #define MSTR_TAG_JOIN(res, ascii_both) \
   (MSTR_ASCII(res) = (ascii_both) ? MSTR_ASCII_YES : MSTR_ASCII_NO)
 
+/* Tag a substring (range / extract_range). ASCII propagates ONE WAY only:
+ * every byte of the result came from the source, so an ASCII-and-CR-free
+ * source can only yield an ASCII-and-CR-free substring.
+ *
+ * The converse is FALSE and must not be propagated -- "\u4f60abc"[1..3] is
+ * "abc", perfectly ASCII, from a non-ASCII source. So a non-ASCII source
+ * leaves the result UNKNOWN (new_string()'s default), to be derived lazily
+ * if anyone asks. That asymmetry is why this is not MSTR_TAG_JOIN. */
+#define MSTR_TAG_SUBSTRING(res, src_ascii) \
+  SAFE(if (src_ascii) { MSTR_ASCII(res) = MSTR_ASCII_YES; })
+
 /* These are not used anywhere */
 
 /* Beek - add some sanity to joining strings */

--- a/testsuite/single/tests/efuns/string_ascii_cache.lpc
+++ b/testsuite/single/tests/efuns/string_ascii_cache.lpc
@@ -49,6 +49,36 @@ void do_tests() {
   s += wide;                // grows in place
   ASSERT_EQ(7, sizeof(s));  // 5 + 2 clusters, NOT 5 + 6 bytes
 
+  // --- the CR-LF seam: concatenation propagates the tag as
+  // ascii(a+b) == ascii(a) && ascii(b), which is only exact because a CR
+  // disqualifies a string outright. Joining "...\r" with "\n..." forms one
+  // CRLF cluster ACROSS the seam, so a propagated "both ASCII" would be a
+  // wrong answer here -- both sides must already be tagged non-ASCII. ---
+  s = "a\r";
+  ASSERT_EQ(2, sizeof(s));  // tag it before joining
+  s += "\nb";
+  ASSERT_EQ(3, sizeof(s));  // 'a', CRLF, 'b' -- not 4
+
+  // --- <non-string> + string takes a THIRD concat path in f_add
+  // (SVALUE_STRING_ADD_LEFT, for int/float/object on the left), which builds
+  // the result fresh instead of extending either operand. The left operand is
+  // held in a variable so the expression cannot be constant-folded away before
+  // f_add ever runs.
+  //
+  // Cluster counts here are correct whether or not the tag is propagated -- an
+  // untagged result just gets rescanned. What this pins is the direction that
+  // would NOT be self-correcting: propagating "ASCII" across a seam that forms
+  // a CRLF, which would answer from the byte length and be wrong. ---
+  int n = 12;
+  s = n + "abc";
+  ASSERT_EQ("12abc", s);
+  ASSERT_EQ(5, sizeof(s));
+  s = n + wide;  // non-ASCII on the right must not come back tagged ASCII
+  ASSERT_EQ(2 + sizeof(wide), sizeof(s));
+  n = 1;
+  s = n + "\r\nb";  // '1', CRLF, 'b' -- a propagated "ASCII" would say 4
+  ASSERT_EQ(3, sizeof(s));
+
   // --- non-ASCII, then reduced back to ASCII ---
   s = wide + "xy";
   ASSERT_EQ(4, sizeof(s));

--- a/testsuite/single/tests/efuns/string_ascii_cache.lpc
+++ b/testsuite/single/tests/efuns/string_ascii_cache.lpc
@@ -117,4 +117,43 @@ void do_tests() {
   s = "shared literal";
   ASSERT_EQ(14, sizeof(s));
   ASSERT_EQ(14, sizeof("shared literal"));
+
+  // --- in-place range assignment (same-byte-length replacement) mutates the
+  // string's bytes directly via strncpy in assign_lvalue_range() /
+  // copy_lvalue_range() (interpret.cc), rather than through extend_string()
+  // or new_string() -- the two places that otherwise reset MSTR_ASCII. If
+  // the destination was already tagged ASCII, splicing in non-ASCII bytes of
+  // the SAME byte length would leave a stale cached tag: sizeof() would
+  // answer from the (unchanged) byte length instead of rescanning.
+  //
+  // "a" and "b" are plain string LOCAL VARIABLES (not a literal concat
+  // expression) so the compiler cannot constant-fold "a + b" -- it must go
+  // through the real runtime SVALUE_STRING_JOIN path and allocate a fresh
+  // STRING_MALLOC buffer with ref==1, tagged ASCII via concatenation
+  // propagation. Critically, push_lvalue_range()'s unlink_string_svalue() is
+  // a no-op for an already-unshared (ref==1) STRING_MALLOC string, so the
+  // cached tag survives into the in-place mutation below untouched.
+  //
+  // Covers both C++ implementations of the in-place branch: the
+  // void-statement path (copy_lvalue_range, `s[0..1] = x;` as a full
+  // statement) and the used-as-expression-value path (assign_lvalue_range,
+  // the assignment's result consumed by an enclosing expression). ---
+  {
+    string a = "hello ";
+    string b = "world";
+    s = a + b;                 // fresh STRING_MALLOC, ref==1, tag=ASCII via join
+    ASSERT_EQ(11, sizeof(s));
+    s[0..1] = "\xc3\xa9";       // 2-byte UTF-8 char (é, U+00E9), same byte length as "he"
+    ASSERT_EQ(10, sizeof(s));  // 1 wide cluster + 9 ascii clusters, NOT 11 (stale byte length)
+  }
+  {
+    string a = "hello ";
+    string b = "world";
+    string result;
+    s = a + b;
+    ASSERT_EQ(11, sizeof(s));
+    result = (s[0..1] = "\xc3\xa9");  // used as a value -> assign_lvalue_range
+    ASSERT_EQ("\xc3\xa9", result);
+    ASSERT_EQ(10, sizeof(s));
+  }
 }

--- a/testsuite/single/tests/efuns/string_ascii_cache.lpc
+++ b/testsuite/single/tests/efuns/string_ascii_cache.lpc
@@ -156,4 +156,36 @@ void do_tests() {
     ASSERT_EQ("\xc3\xa9", result);
     ASSERT_EQ(10, sizeof(s));
   }
+
+  // --- replace_string()'s single-byte in-place branch (pattern length 1,
+  // replacement length 1) writes the replacement byte straight into the
+  // unlinked buffer and, alone among the in-place branches, never reaches
+  // extend_string() -- so nothing resets the cached ASCII tag. Every valid
+  // 1-byte replacement is ASCII, but "\r" is the one that breaks the
+  // byte==cluster identity: splicing it in front of an existing "\n" forms a
+  // single CRLF cluster while the byte length is unchanged.
+  //
+  // The argument is a runtime `a + b` temp: a fresh STRING_MALLOC with
+  // ref==1, tagged ASCII by concat propagation, which unlink_string_svalue()
+  // passes through untouched -- exactly the shape that carries a stale tag
+  // out of the efun. ---
+  {
+    string a = "xy";
+    string b = "\nz";
+    s = replace_string(a + b, "y", "\r");  // "x\r\nz": 4 bytes, 3 clusters
+    ASSERT_EQ(3, sizeof(s));               // 'x', CRLF, 'z' -- not 4
+  }
+
+  // --- map() over a string (map_string) writes each callback return value
+  // straight into the unlinked buffer -- any byte, including '\r' -- and
+  // never reallocates, so nothing on that path resets the cached ASCII tag
+  // either. Same stale-tag shape as above: ASCII-tagged ref==1 temp in,
+  // CR spliced in place, byte length unchanged. ---
+  {
+    string a = "xy";
+    string b = "\nz";
+    s = map(a + b, (: $1 == 'y' ? 13 : 0 :));  // 'y' -> '\r'
+    ASSERT_EQ("x\r\nz", s);
+    ASSERT_EQ(3, sizeof(s));  // 'x', CRLF, 'z' -- not 4
+  }
 }

--- a/testsuite/single/tests/efuns/string_ascii_cache.lpc
+++ b/testsuite/single/tests/efuns/string_ascii_cache.lpc
@@ -1,0 +1,90 @@
+// sizeof() on a string counts grapheme clusters. Pure-ASCII strings take a
+// fast path that answers from the byte length, and counted strings memoize
+// "am I ASCII?" in their block header (MSTR_ASCII_*, src/base/internal/
+// stralloc.h) so repeat queries are O(1).
+//
+// These tests exist to catch a STALE cached tag: every case below asks for
+// sizeof() BEFORE mutating, so the tag is already populated, then mutates and
+// asks again. A cache that failed to invalidate would return the pre-mutation
+// answer.
+void do_tests() {
+  string s;
+  string wide;
+
+  // --- baseline: ASCII is one cluster per byte ---
+  s = "hello";
+  ASSERT_EQ(5, sizeof(s));
+  ASSERT_EQ(5, sizeof(s));  // again: served from the cache
+
+  ASSERT_EQ(0, sizeof(""));
+
+  // --- CR-LF is ONE grapheme cluster (UAX #29 GB3), so a CR-bearing string
+  // must not take the byte-length path ---
+  s = "a\r\nb";
+  ASSERT_EQ(3, sizeof(s));  // 'a', CRLF, 'b' -- not 4
+  ASSERT_EQ(3, sizeof(s));
+  s = "a\rb";  // lone CR is its own cluster
+  ASSERT_EQ(3, sizeof(s));
+
+  // --- non-ASCII counts clusters, not bytes ---
+  wide = "你好";  // 你好: 2 clusters, 6 bytes
+  ASSERT_EQ(2, sizeof(wide));
+  ASSERT_EQ(2, sizeof(wide));
+
+  // --- ASCII, then grow it with non-ASCII: the tag must be re-evaluated ---
+  s = "abc";
+  ASSERT_EQ(3, sizeof(s));  // populate the cache as ASCII
+  s += wide;
+  ASSERT_EQ(5, sizeof(s));  // 3 + 2 clusters, NOT 3 + 6 bytes
+
+  // --- the in-place realloc path: a MALLOC string with refcount 1 is grown
+  // by extend_string() rather than reallocated fresh, so the tag must be
+  // invalidated there specifically. Build one at runtime so it is neither a
+  // shared literal nor multiply referenced. ---
+  s = "";
+  for (int i = 0; i < 5; i++) {
+    s += "a";
+  }
+  ASSERT_EQ(5, sizeof(s));  // populate the cache as ASCII
+  s += wide;                // grows in place
+  ASSERT_EQ(7, sizeof(s));  // 5 + 2 clusters, NOT 5 + 6 bytes
+
+  // --- non-ASCII, then reduced back to ASCII ---
+  s = wide + "xy";
+  ASSERT_EQ(4, sizeof(s));
+  s = s[2..3];
+  ASSERT_EQ(2, sizeof(s));
+
+  // --- write a non-ASCII codepoint through a string-char lvalue after the
+  // string has been cached as ASCII ---
+  s = "abc";
+  ASSERT_EQ(3, sizeof(s));
+  s[1] = 20320;             // U+4F60 你 -- character constants are ASCII-only
+  ASSERT_EQ(3, sizeof(s));  // still 3 clusters, now 5 bytes
+  ASSERT_EQ(20320, s[1]);
+
+  // --- and the reverse: cached as non-ASCII, then overwritten with ASCII ---
+  s = "a你c";
+  ASSERT_EQ(3, sizeof(s));
+  s[1] = 'b';
+  ASSERT_EQ(3, sizeof(s));
+  ASSERT_EQ("abc", s);
+
+  // --- indexing and ranges agree with the cluster count on both paths ---
+  s = "0123456789";
+  ASSERT_EQ(10, sizeof(s));
+  ASSERT_EQ('5', s[5]);
+  ASSERT_EQ("345", s[3..5]);
+  ASSERT_EQ('9', s[<1]);
+
+  wide = "你好世";  // 你好世
+  ASSERT_EQ(3, sizeof(wide));
+  ASSERT_EQ("好", wide[1..1]);
+  ASSERT_EQ("世", wide[<1..]);
+
+  // --- a shared string (interned) reused via a second reference keeps a
+  // correct tag ---
+  s = "shared literal";
+  ASSERT_EQ(14, sizeof(s));
+  ASSERT_EQ(14, sizeof("shared literal"));
+}


### PR DESCRIPTION
`sizeof(str)`, `s[i]` and `s[a..b]` all walk Unicode grapheme cluster boundaries through ICU's `RuleBasedBreakIterator`. Profiling the LPC testsuite put `RuleBasedBreakIterator` at **20.6% of the entire run**, with `f_sizeof()` alone at 32% inclusive — roughly 53 instructions per byte of string.

Three commits, each independently useful.

## 1. Skip ICU entirely for pure-ASCII strings

For text with no high-bit byte every byte is its own grapheme cluster, so the EGC index *is* the byte offset and the cluster count *is* the byte length. `EGCIterator::reset()` now scans for that case (a flat, auto-vectorizing accumulate) and skips ICU setup completely; `EGCSmartIterator` answers count/index/walk queries arithmetically. ICU is still wired up lazily via `ensure_icu()` so callers that drive the underlying `icu::BreakIterator` directly keep working on any input.

**The ASCII test deliberately also rejects CR.** UAX #29 rule GB3 joins CR × LF into a single cluster, so `"\r\n"` is two bytes but one cluster and the `offset == index` identity breaks. That is not hypothetical — it was caught by the equivalence test below, which failed on a CRLF string before the exclusion was added. Rejecting every CR (rather than only CR-before-LF) keeps detection a single flat scan; a lone CR just falls back to ICU, which is still correct.

Correctness is pinned by tests that compare the fast path against **ICU driven over the same bytes on a separate iterator**, rather than against a reading of the spec. `count`, `index_to_offset` and `post_index_to_offset` are swept across every index from past-the-start to past-the-end so the DONE edges are covered, and `CrLfIsTheOnlyAsciiJoin` checks all 128×128 ASCII pairs against ICU to prove CR-LF is the only joining pair — an extra one would silently corrupt `sizeof()` on any string containing it.

## 2. Memoize the tag in the block header

The fast path still had to *prove* a string was ASCII before using it, so every `sizeof()`/index rescanned the bytes — making the very common `for (i = 0; i < sizeof(s); i++)` O(n²).

Both counted-string headers gain a tri-state `ascii` byte (unknown / yes / no), which lands in the two bytes of padding that already sat between `ref` and the string data — so `sizeof(block_t)` is unchanged in every build, debug included, now pinned by a `static_assert` on the field offsets as well as the size.

`UNKNOWN` is the default at every creation site and is load-bearing: a string-creation path that forgets to set the tag degrades to scanning (slow but correct) rather than asserting a wrong answer. Only three sites produce counted strings — `alloc_new_shared_string()`, `int_new_string()` and `extend_string()` — and `extend_string()` additionally has to *reset* the tag, since it grows a refcount-1 MALLOC string in place and the caller then writes new bytes into it. Nothing else mutates a counted string's bytes: `s[i] = c` builds a fresh string via `new_string()` (verified), and there are no direct writes through `svalue_t::u.string`.

The regression test drives the stale-cache cases specifically — every case queries `sizeof()` *before* mutating so the tag is already populated, then mutates and queries again. It was verified to **FAIL** with `extend_string()`'s invalidation removed, which required building the string at runtime: a shared literal is reallocated fresh on append and never reaches the in-place realloc path at all. (My first version of this test passed either way, which is how I found that out.)

## 3. Propagate the tag across concatenation

All three concat macros now carry the tag through: `ascii(a + b) == ascii(a) && ascii(b)`, computed from the operands before the result is built. That identity is exact **only because the predicate excludes CR** — with no CR on either side no CR-LF can form across the seam. It is exact in the NO direction too, so neither case ever rescans the joined string.

The third macro is `SVALUE_STRING_ADD_LEFT`, backing `f_add`'s `int`/`float`/`object` + `string` paths. Its left operand is a raw stack buffer rather than an svalue, so it's queried with `counted=false`: there's no block header to read a cached tag out of, and treating it as though there were would be a wild read.

Pinned by tests that tag `"a\r"` and `"\nb"` separately and then join them — a propagated "both ASCII" would report 4 clusters where the CRLF makes 3. Covered on both the `string + string` path and the `<non-string> + string` one, the latter with the left operand held in a variable so the expression can't be constant-folded before `f_add` ever runs. Verified to **fail** (2 checks) with the propagation forced to "ASCII".

## Results

RelWithDebInfo `-O3`, same machine, A/B against the same tree with only the relevant changes reverted:

| | before | after | |
|---|---|---|---|
| `sizeof(16-byte string)` | 741 ns | 38 ns | 19× |
| `sizeof(72KB string)` | 2,434,974 ns | 41 ns | now O(1) |
| string index `s[5]` | 435 ns | 75 ns | 5.8× |
| string range `s[3..8]` | 648 ns | 107 ns | 6.1× |
| append+sizeof loop, 4000 iters | 875,913 ns | 548,144 ns | 1.6× |

The append-loop remainder is the string building itself, which is inherently quadratic in copying.

**Non-ASCII text pays one extra linear scan before ICU runs and is not measurably slower** — 1,853 → 1,659 ns for a small non-ASCII string, 313,950 → 303,209 ns for a 6,400-cluster one. The scan costs ~0.02 ns/byte against ICU's ~47 ns/byte, so the added pass is ~0.04% of the work it guards. After commit 2 the scan happens once per string rather than per query.

Also adds sizeof/index/range benchmarks (ASCII and non-ASCII) to `/command/bench` so the two paths can be tracked separately.

## Note on the header byte

Packing the tri-state into existing header padding is frugal but is admittedly a tight fit against a struct whose layout is already load-bearing (`malloc_block_t` and `block_t` must stay identical). The `static_assert`s pin it. The cleaner long-term home for this is a real string object — filed as #1341.

## Validation

LPC testsuite ×3 (randomized order), 334/334 GTest, Debug+ASan/UBSan with the DEBUGMALLOC ref-count checker ×2, and RelWithDebInfo+ASan/UBSan — all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MN9sz4nvGgBZw9oZiei3XR

---
_Generated by [Claude Code](https://claude.ai/code/session_01MN9sz4nvGgBZw9oZiei3XR)_