### PR TITLE
Fix the intermittent DB testsuite failure, and a Coverity copy-instead-of-move

### DIFF
--- a/src/compiler/internal/compiler.cc
+++ b/src/compiler/internal/compiler.cc
@@ -265,7 +265,7 @@ std::string render_diagnostic(const Diagnostic& d, bool color) {
       }
       col_shift = static_cast<int>(prefix) - static_cast<int>(start);
       snippet_prefix = static_cast<int>(prefix);
-      shown = windowed;
+      shown = std::move(windowed);
     }
     char num[16];
     snprintf(num, sizeof(num), "%5d", line_no);

--- a/testsuite/.gitignore
+++ b/testsuite/.gitignore
@@ -18,6 +18,7 @@ testfile.zerolength
 /rename_test1
 /trace_json.json
 /test.sqlite
+/test_async_bound.sqlite
 /sqlite.db
 /tmp.o
 /testrun.log

--- a/testsuite/single/tests/efuns/async_db_exec.lpc
+++ b/testsuite/single/tests/efuns/async_db_exec.lpc
@@ -1,9 +1,15 @@
+// async_db_exec() validates the handle synchronously, so a handle that was
+// never issued must be a clean, catchable error -- never a crash, and never
+// a query queued onto a worker thread against somebody else's connection.
+// See db_close.lpc for why a small handle is unsafe here (global handle
+// namespace + randomized test order).
+#define NEVER_ISSUED_DB_HANDLE 1000000
+
 void got(mixed h) {}
+
 void do_tests() {
 #if defined(__PACKAGE_ASYNC__) && defined(__PACKAGE_DB__)
-  // No live db handle 1; the failure must be clean (sync error or
-  // errored callback), never a crash.
-  catch(async_db_exec(1, "SELECT 1", (: got :)));
+  ASSERT(catch(async_db_exec(NEVER_ISSUED_DB_HANDLE, "SELECT 1", (: got :))));
 #endif
   ASSERT(1);
 }

--- a/testsuite/single/tests/efuns/db_close.lpc
+++ b/testsuite/single/tests/efuns/db_close.lpc
@@ -1,7 +1,17 @@
+// db_close() on a handle that was never issued must be a clean, catchable
+// error, never a crash.
+//
+// The handle must be one create_db_conn() can never have returned: DB
+// handles are a PROCESS-GLOBAL namespace (lowest free slot + 1, and
+// free_db_conn() re-issues a closed slot immediately), so poking a small
+// handle here would close a connection another test file is still using --
+// test order is randomized, which made that an intermittent, cross-file
+// failure.
+#define NEVER_ISSUED_DB_HANDLE 1000000
+
 void do_tests() {
 #ifdef __PACKAGE_DB__
-  // No connection with handle 1 exists.
-  ASSERT(catch(db_close(1)) || 1);
+  ASSERT(catch(db_close(NEVER_ISSUED_DB_HANDLE)));
 #endif
   ASSERT(1);
 }

--- a/testsuite/single/tests/efuns/db_commit.lpc
+++ b/testsuite/single/tests/efuns/db_commit.lpc
@@ -1,7 +1,11 @@
+// db_commit() on a handle that was never issued must be a clean, catchable
+// error, never a crash. See db_close.lpc for why a small handle is unsafe
+// here (global handle namespace + randomized test order).
+#define NEVER_ISSUED_DB_HANDLE 1000000
+
 void do_tests() {
 #ifdef __PACKAGE_DB__
-  // No connection with handle 1 exists.
-  ASSERT(catch(db_commit(1)) || 1);
+  ASSERT(catch(db_commit(NEVER_ISSUED_DB_HANDLE)));
 #endif
   ASSERT(1);
 }

--- a/testsuite/single/tests/efuns/db_connect.lpc
+++ b/testsuite/single/tests/efuns/db_connect.lpc
@@ -1,6 +1,6 @@
 void do_tests() {
 #ifdef __PACKAGE_DB__
-  int h = 0;
+  mixed h;
   mixed err;
 
   // Guaranteed-unreachable target: failure must be a clean error or a
@@ -11,9 +11,15 @@ void do_tests() {
   // drop the file) instead of leaking both for the rest of the run: DB
   // handles are a process-global namespace re-issued lowest-slot-first, so
   // a leaked connection silently shifts every later test's handle numbers.
+  //
+  // `h` is mixed, not int: db_connect() returns the BACKEND'S ERROR STRING
+  // on failure (f_db_connect pushes push_malloced_string(errormsg)), not a
+  // number, so an int would take a type error on every build whose default
+  // backend cannot reach the host -- which is CI's, where the default is
+  // MySQL and only SQLite is compiled in.
   err = catch(h = db_connect("256.256.256.256", "no_such_db"));
   ASSERT(err || 1);
-  if (!err && h > 0) {
+  if (!err && intp(h) && h > 0) {
     db_close(h);
     catch(rm("/no_such_db"));
   }

--- a/testsuite/single/tests/efuns/db_connect.lpc
+++ b/testsuite/single/tests/efuns/db_connect.lpc
@@ -1,9 +1,22 @@
 void do_tests() {
 #ifdef __PACKAGE_DB__
+  int h = 0;
+  mixed err;
+
   // Guaranteed-unreachable target: failure must be a clean error or a
   // non-positive handle, never a crash.
-  mixed err = catch(db_connect("256.256.256.256", "no_such_db"));
+  //
+  // With SQLite3 as the default backend this actually SUCCEEDS -- the host
+  // is ignored and sqlite3_open() creates the file. Close the handle (and
+  // drop the file) instead of leaking both for the rest of the run: DB
+  // handles are a process-global namespace re-issued lowest-slot-first, so
+  // a leaked connection silently shifts every later test's handle numbers.
+  err = catch(h = db_connect("256.256.256.256", "no_such_db"));
   ASSERT(err || 1);
+  if (!err && h > 0) {
+    db_close(h);
+    catch(rm("/no_such_db"));
+  }
 #endif
   ASSERT(1);
 }

--- a/testsuite/single/tests/efuns/db_exec.lpc
+++ b/testsuite/single/tests/efuns/db_exec.lpc
@@ -1,7 +1,11 @@
+// db_exec() on a handle that was never issued must be a clean, catchable
+// error, never a crash. See db_close.lpc for why a small handle is unsafe
+// here (global handle namespace + randomized test order).
+#define NEVER_ISSUED_DB_HANDLE 1000000
+
 void do_tests() {
 #ifdef __PACKAGE_DB__
-  // No connection with handle 1 exists.
-  ASSERT(catch(db_exec(1, "SELECT 1")) || 1);
+  ASSERT(catch(db_exec(NEVER_ISSUED_DB_HANDLE, "SELECT 1")));
 #endif
   ASSERT(1);
 }

--- a/testsuite/single/tests/efuns/db_rollback.lpc
+++ b/testsuite/single/tests/efuns/db_rollback.lpc
@@ -1,7 +1,11 @@
+// db_rollback() on a handle that was never issued must be a clean, catchable
+// error, never a crash. See db_close.lpc for why a small handle is unsafe
+// here (global handle namespace + randomized test order).
+#define NEVER_ISSUED_DB_HANDLE 1000000
+
 void do_tests() {
 #ifdef __PACKAGE_DB__
-  // No connection with handle 1 exists.
-  ASSERT(catch(db_rollback(1)) || 1);
+  ASSERT(catch(db_rollback(NEVER_ISSUED_DB_HANDLE)));
 #endif
   ASSERT(1);
 }


### PR DESCRIPTION
Two independent fixes against `master`, kept out of #1347 because neither has anything to do with async/await.

## The intermittent DB failure

The full suite failed roughly **one run in five** — on `master`, not just on the feature branch — with one of:

```
/single/tests/efuns/db.lpc:100, Check Failed          (the select returned 0 rows)
uncaught error in deferred work: *Attempt to close an invalid database handle
```

Both are post-run deferred failures, so they report as `0 file(s), 1 failed check(s)` and are only caught by the exit status (AGENTS.md §7).

**Root cause.** DB handles are a process-global namespace: `create_db_conn()` returns the lowest free slot + 1, and `free_db_conn()` merely marks the slot empty, so the next `db_connect()` is handed the same number straight back. Five tests poked **handle 1** on the premise *"no connection with handle 1 exists"*:

| file | call |
|---|---|
| `db_close.lpc:4` | `db_close(1)` — destructive |
| `db_exec.lpc:4` | `db_exec(1, ...)` |
| `db_commit.lpc:4` | `db_commit(1)` |
| `db_rollback.lpc:4` | `db_rollback(1)` |
| `async_db_exec.lpc:6` | `async_db_exec(1, ...)` |

Meanwhile two *other* tests hold a live connection past the end of their `do_tests()`, because their final assertions run in post-run deferred work: `db.lpc` (used by its `async_db_exec` callback) and `async_db_exec_bound_args.lpc` (closed in its `call_out`).

Test file order is randomized. Whenever `db_close.lpc` ran after one of those two had been given slot 1, `db_close(1)` did exactly what it was asked and **freed another test's live connection**. The slot was then re-issued to the next `db_connect()` — usually `db_connect.lpc`, which opens `no_such_db` (`sqlite3_open` *creates* it) and never closed it, leaking the handle for the rest of the run. The victim then either queried a different database file (0 rows) or found its handle gone.

Three failing runs, ordered by their `[ RUN ]` lines, match the model exactly including which victim is hit:

- `db.lpc`, `db_close`, `bound_args`, …, `db_connect` → both signatures
- `db.lpc`, `bound_args`, `async_db_exec`, `db_close`, …, `db_connect` → the `db.lpc` one only
- `async_db_exec`, `bound_args`, `db_close`, `db.lpc`, `db_connect` → the invalid-handle one only

**The fix strengthens the tests.** The old assertions were `ASSERT(catch(db_close(1)) || 1)` — tautologies that could not fail, so they only ever checked "does not crash" while non-deterministically stomping another test's connection. They now use a handle `create_db_conn()` can never return, which makes the error path deterministic and the assertion real:

```c
ASSERT(catch(db_close(NEVER_ISSUED_DB_HANDLE)));
```

`db_connect.lpc` also closes the connection it opens and removes the file, so a run no longer litters the mudlib or shifts every later test's handle numbers.

**No driver change, deliberately.** `db_close(1)` was a legal, permitted operation on a valid handle; the driver cannot know that another object still held that integer. The global-handle model gated by the `valid_database()` master apply is the documented FluffOS design — the testsuite master simply approves everything unconditionally. Every path already errors cleanly on a genuinely invalid handle.

**Evidence:** 34 full-suite runs across two builds with zero failures, against ~1-in-5 before; 10 further runs on this branch specifically. No measurable change in suite time.

### A related driver hazard, reported but not fixed here

`add_db_exec()` (`src/packages/async/async.cc`) caches the handle as a bare int, and `dbexecthread()` resolves it later with `find_db_conn()`. A mudlib that closes the connection and opens another between queueing and the worker running gets its query executed against the **new** connection, silently — the same "cached raw handle outlives its resource" shape as AGENTS.md §13 item 14. The closed-but-not-reused case is already clean. A minimal guard would be a monotonic generation id on `db_t`, recorded in the request and re-checked in the worker, with no change to synchronous behaviour. None of the observed failures went through this path and it has no reliable single-file regression route, so it is left for a separate change rather than folded in here.

## Coverity CID 1685402 (COPY_INSTEAD_OF_MOVE)

`render_diagnostic()`'s snippet windowing assigned a local that dies at the end of the block, copying a string the compiler is free to steal. Now `std::move`.

Small in absolute terms — the window is bounded at 200 characters plus two elision markers — but it sits in the diagnostic path that the windowing exists to make cheap. No behaviour change: `shown` is a `std::string` local constructed from the `string_view` parameter, not a view, so there is no lifetime question here, purely the copy Coverity describes.

## Validation

RelWithDebInfo with the DB package and SQLite enabled, built from this branch: full LPC suite ×10 clean, 340/340 GTest, `testsuite/format.sh --check` clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Pg3YXAaLsiWJrv8AYqdYh3)_