### PR TITLE
Promise combinators, promise_cancel(), and await inside foreach (#1319 phase 1.5)

### DIFF
--- a/docs/concepts/general/async.md
+++ b/docs/concepts/general/async.md
@@ -14,7 +14,9 @@ form of `catch`. This page is the execution-model specification.
 
 A promise is a first-class LPC value holding the eventual result of an
 asynchronous operation. It is created pending and settles exactly once —
-**fulfilled** with a value or **rejected** with a reason. See
+**fulfilled** with a value, **rejected** with a reason, or **cancelled**.
+Cancelled is reported by `promise_status()` as 3: a negative settlement
+that is not a fault. See
 `promise_create()`, `promise_resolve()`, `promise_reject()`,
 `promise_then()`, `promise_catch()`, `promise_status()`,
 `promise_result()`, and `async_info()`.

--- a/docs/concepts/general/async.md
+++ b/docs/concepts/general/async.md
@@ -316,14 +316,21 @@ compile-time or runtime error, never silent misbehavior:
 2. `await` is not allowed inside `catch(...)` or `time_expression(...)`
    (their implementation recurses the C++ stack). Use `acatch`.
 3. An `await` cannot suspend while a transient reference sits on the value
-   stack. In practice this means **any `foreach` loop** (over arrays,
-   mappings, strings or buffers — the loop keeps an lvalue slot live for its
-   variable for the whole body) and a `ref` argument. It is a runtime error
+   stack that suspension cannot relocate. A `foreach` over a **local** loop
+   variable is fine — arrays, mappings, strings, buffers, nested loops
+   included — because that variable's lvalue addresses a slot inside the
+   frame, and the frame is exactly what parking copies and rebuilds, so it
+   is carried across as an offset. What is still refused is a `foreach` over
+   a **global** loop variable (its lvalue points into the object's variable
+   block, a second relocation base), a **`ref`** loop variable or `ref`
+   argument, and a string-char or buffer-byte lvalue (`s[i]`, `b[i]` —
+   those are backed by shared VM scratch state, one instance at a time by
+   construction, so they can never be per-frame). It is a runtime error
    rather than a compile error because it depends on what the awaited
-   promise turns out to be; use an indexed `for` loop when the body needs to
-   suspend. Compound assignment is *not* affected — `arr[i] += await p`,
-   `s += await p` and friends evaluate the right-hand side before pinning
-   the target, so they park and resume normally.
+   promise turns out to be; use a local loop variable, or an indexed `for`.
+   Compound assignment is *not* affected — `arr[i] += await p`, `s += await
+   p` and friends evaluate the right-hand side before pinning the target, so
+   they park and resume normally.
 4. If the object is destructed, recompiled by `recompile_object()`, or has
    its program swapped by `replace_program()` while a function is
    suspended, the resume is abandoned and the function's promise rejects

--- a/docs/concepts/general/async.md
+++ b/docs/concepts/general/async.md
@@ -131,12 +131,19 @@ object alive and keeps its suspension slot. Note that JS cannot reach this
 state at all, since an async function's resolver is never handed out; here
 promises are first-class, so the refusal has to be explicit.
 
-There is no cancellation primitive in phase 1, and the refusal removes the
-one thing that looked like one. Two replacements, depending on which side
-you are on.
+To ask a body to stop, use `promise_cancel()`, which is the real primitive
+the refusal above pointed at: it makes the body's **next `await` raise** a
+catchable `"*async function cancelled"`, unwinding through `acatch` and
+running `defer` handlers on the way out. It is cooperative — a body part-way
+through straight-line code finishes that stretch, and one that never awaits
+again runs to completion — and the request is **consumed** by the raise, so
+a body that catches its cancellation can still `await` cleanup and return
+normally. It does not propagate into promises the body is awaiting.
 
-A body that should be able to give up early `await`s a gate the caller
-holds:
+Two patterns remain useful alongside it, depending on which side you are on.
+
+A body that wants a cheaper, purely voluntary check `await`s a gate the
+caller holds:
 
 ```c
 async int worker(promise cancel) {
@@ -167,10 +174,22 @@ The `promise_status()` guards are not optional, and this is where LPC
 differs from JS: there, settling an already-settled promise is a silent
 no-op, which is what lets `Promise.race` be written in userland. Here it is
 an **error**, so the unguarded version throws on whichever of the two paths
-finishes second — the common case, not a rare one. Note also that the
-underlying work is not stopped by either shape; only your wait ends
-(exception: `promise_reject` of an `external_start` / `external_run`
-promise kills the child; `external_kill(handle)` is the handle form).
+finishes second — the common case, not a rare one.
+
+In practice `promise_race()` does this for you, and is what you should reach
+for first:
+
+```c
+promise with_timeout(promise p, int secs) {
+    return promise_race(({ p, timer_that_rejects(secs) }));
+}
+```
+
+Neither shape stops the underlying work; only your wait ends. To stop the
+work as well, the operation has to be an `async` function you can
+`promise_cancel()`. The exception is `promise_reject` of an
+`external_start` / `external_run` promise, which kills the child;
+`external_kill(handle)` is the handle form.
 
 `return value` fulfills the promise (a returned promise is adopted). An
 uncaught error inside the body rejects it — an async body behaves as if

--- a/docs/efun/promises/promise_all.md
+++ b/docs/efun/promises/promise_all.md
@@ -1,0 +1,43 @@
+---
+title: promises / promise_all
+---
+# promise_all
+
+### NAME
+
+    promise_all - wait for every promise, failing on the first rejection
+
+### SYNOPSIS
+
+    promise promise_all(mixed *promises);
+
+### DESCRIPTION
+
+    Returns a promise that fulfills with an array of every input's value,
+    **positionally**: entry `i` of the result is the value of `promises[i]`,
+    whatever order they settled in.
+
+    If any input rejects, the returned promise rejects immediately with that
+    reason and the remaining inputs are ignored (they keep running -- there
+    is no cancellation implied). Only the FIRST rejection is reported; use
+    promise_all_settled(3) to see every outcome.
+
+    An element that is not a promise counts as already fulfilled with
+    itself, so the output of an ordinary `map()` can be passed straight in
+    without wrapping.
+
+    An empty array fulfills immediately with an empty array.
+
+### EXAMPLE
+```c
+async void load(string *names) {
+    mixed *rows = await promise_all(map(names, (: fetch($1) :)));
+
+    // rows[i] corresponds to names[i]
+    write("loaded " + sizeof(rows) + "\n");
+}
+```
+
+### SEE ALSO
+
+    promise_any(3), promise_race(3), promise_all_settled(3), promise_then(3)

--- a/docs/efun/promises/promise_all_settled.md
+++ b/docs/efun/promises/promise_all_settled.md
@@ -1,0 +1,58 @@
+---
+title: promises / promise_all_settled
+---
+# promise_all_settled
+
+### NAME
+
+    promise_all_settled - wait for every promise and report each outcome
+
+### SYNOPSIS
+
+    promise promise_all_settled(mixed *promises);
+
+### DESCRIPTION
+
+    Returns a promise that fulfills once every input has settled -- it never
+    rejects. The value is an array of one mapping per input, positionally,
+    describing how that input ended:
+
+        ([ "status": 1, "value":  v ])   fulfilled
+        ([ "status": 2, "reason": r ])   rejected
+
+    The status codes are promise_status(3)'s, so one vocabulary covers both.
+    A fulfilled entry has no `"reason"` key and a rejected entry has no
+    `"value"` key, so `undefinedp()` distinguishes them as reliably as
+    `"status"` does.
+
+    Use this instead of promise_all(3) when a partial failure is a result
+    rather than an error -- fanning work out over many objects and reporting
+    which succeeded, for instance.
+
+    An element that is not a promise counts as already fulfilled with
+    itself, so the output of an ordinary `map()` can be passed straight in.
+    An empty array fulfills immediately with an empty array.
+
+    The name follows JavaScript's `Promise.allSettled`. It is deliberately
+    not `promise_settle`: that already names the driver's internal "settle
+    this one promise" operation, and reusing it for "wait for all of these"
+    would read as almost the opposite.
+
+### EXAMPLE
+```c
+async void reindex(object *rooms) {
+    mixed *results = await promise_all_settled(map(rooms, (: $1->rebuild() :)));
+    int i;
+
+    foreach (mixed r in results) {
+        if (r["status"] == 2) {
+            write("room " + i + " failed: " + r["reason"] + "\n");
+        }
+        i++;
+    }
+}
+```
+
+### SEE ALSO
+
+    promise_all(3), promise_any(3), promise_race(3), promise_status(3)

--- a/docs/efun/promises/promise_all_settled.md
+++ b/docs/efun/promises/promise_all_settled.md
@@ -19,11 +19,12 @@ title: promises / promise_all_settled
 
         ([ "status": 1, "value":  v ])   fulfilled
         ([ "status": 2, "reason": r ])   rejected
+        ([ "status": 3, "reason": r ])   cancelled
 
     The status codes are promise_status(3)'s, so one vocabulary covers both.
-    A fulfilled entry has no `"reason"` key and a rejected entry has no
-    `"value"` key, so `undefinedp()` distinguishes them as reliably as
-    `"status"` does.
+    A fulfilled entry has no `"reason"` key and a rejected or cancelled
+    entry has no `"value"` key, so `undefinedp()` distinguishes them as
+    reliably as `"status"` does.
 
     Use this instead of promise_all(3) when a partial failure is a result
     rather than an error -- fanning work out over many objects and reporting
@@ -45,7 +46,7 @@ async void reindex(object *rooms) {
     int i;
 
     foreach (mixed r in results) {
-        if (r["status"] == 2) {
+        if (r["status"] != 1) {
             write("room " + i + " failed: " + r["reason"] + "\n");
         }
         i++;

--- a/docs/efun/promises/promise_any.md
+++ b/docs/efun/promises/promise_any.md
@@ -1,0 +1,40 @@
+---
+title: promises / promise_any
+---
+# promise_any
+
+### NAME
+
+    promise_any - take the first promise that succeeds
+
+### SYNOPSIS
+
+    promise promise_any(mixed *promises);
+
+### DESCRIPTION
+
+    Returns a promise that fulfills with the value of the first input to
+    **fulfill**. Rejections are tolerated: they are collected rather than
+    propagated, so one failing source does not spoil the result.
+
+    Only if EVERY input rejects does the returned promise reject, with an
+    array of the reasons, positionally (entry `i` is `promises[i]`'s reason).
+
+    Contrast promise_race(3), which is settled by the first input to settle
+    either way -- a rejection there wins the race.
+
+    An element that is not a promise counts as already fulfilled with
+    itself. An empty array rejects: there is nothing that could ever
+    satisfy it.
+
+### EXAMPLE
+```c
+async string first_reachable(string *mirrors) {
+    // whichever mirror answers first; failures are ignored unless all fail
+    return await promise_any(map(mirrors, (: fetch($1) :)));
+}
+```
+
+### SEE ALSO
+
+    promise_all(3), promise_race(3), promise_all_settled(3)

--- a/docs/efun/promises/promise_cancel.md
+++ b/docs/efun/promises/promise_cancel.md
@@ -1,0 +1,90 @@
+---
+title: promises / promise_cancel
+---
+# promise_cancel
+
+### NAME
+
+    promise_cancel - ask an async function to give up
+
+### SYNOPSIS
+
+    int promise_cancel(promise p);
+
+### DESCRIPTION
+
+    Requests cancellation of the `async` function body that owns `p`. The
+    body's **next `await` raises** a catchable error whose value is the
+    string `"*async function cancelled"`.
+
+    Cancellation is **cooperative, not preemptive**. A body part-way through
+    a stretch of straight-line code finishes that stretch first; a body that
+    never awaits again runs to completion and its cancellation is never
+    delivered at all. Nothing is torn down mid-expression.
+
+    The raise behaves like any other rejection arriving at that `await`: it
+    unwinds through enclosing `acatch` regions, runs `defer()` handlers in
+    order, and — if nothing catches it — rejects `p` with the same reason.
+
+    A body parked on a promise that will never settle is still cancelled
+    promptly: it is detached from that promise and its rejection is
+    scheduled directly, so cancellation is never hostage to the thing being
+    awaited.
+
+### RETURN VALUE
+
+    1 if a cancellation was armed, 0 if there was nothing left to cancel —
+    the body already finished, or it returned a still-pending promise and is
+    gone. A body racing its canceller to completion is a normal outcome, not
+    an error.
+
+### THE REQUEST IS CONSUMED
+
+    The raise **clears** the request. A body that catches its own
+    cancellation may go on to `await` cleanup work and even return a value,
+    in which case `p` *fulfills* normally:
+
+```c
+async int worker() {
+    mixed err = acatch(await slow_thing());
+
+    if (err) {
+        await write_log("gave up");   // does NOT re-raise
+        return 0;
+    }
+    return 1;
+}
+```
+
+    So cancellation is a request a body may decline, not a verdict. Cancel
+    again if you mean it again. The alternative — a sticky flag — would make
+    every cleanup `await` throw, leaving a body no way to release what it
+    holds.
+
+### ERRORS
+
+    It is an error to cancel a promise that is not an `async` function's.
+    Only a body has a "next await" for the cancellation to arrive at:
+
+    * a `promise_create()` promise is already settleable by whoever owns it;
+    * an async_read(3)/async_write(3)/async_getdir(3) promise cannot stop the
+      worker thread that is already doing the I/O;
+    * a `call_out(delay)` promise is not cancellable — use the classic
+      `call_out()` form and remove_call_out(3);
+    * rejecting a promise_then(3) chain link cannot stop its upstream.
+
+    To stop *waiting* for any of those without stopping the work, race them
+    against a timer — see promise_race(3).
+
+### NOTES
+
+    Cancellation does **not** propagate. If a cancelled body was awaiting
+    another async function's promise, that inner body keeps running: its
+    promise is first-class and may have other awaiters, `then` handlers, or
+    simply be stored somewhere, and rejecting it would settle it for all of
+    them. A body that wants the inner work stopped too can catch its own
+    cancellation and cancel the inner promise it holds.
+
+### SEE ALSO
+
+    promise_race(3), promise_status(3), promise_reject(3), async_info(3)

--- a/docs/efun/promises/promise_cancel.md
+++ b/docs/efun/promises/promise_cancel.md
@@ -24,7 +24,11 @@ title: promises / promise_cancel
 
     The raise behaves like any other rejection arriving at that `await`: it
     unwinds through enclosing `acatch` regions, runs `defer()` handlers in
-    order, and — if nothing catches it — rejects `p` with the same reason.
+    order, and — if nothing catches it — **cancels** `p` (promise_status(3)
+    returns 3) with the same reason. That is not a rejection: `acatch` still
+    yields the string, but `promise_status(p) == 3` is the test that cannot
+    be forged. Downstream `await` / `then` / `promise_all` / `promise_race`
+    links inherit the cancellation the same way.
 
     A body parked on a promise that will never settle is still cancelled
     promptly: it is detached from that promise and its rejection is

--- a/docs/efun/promises/promise_race.md
+++ b/docs/efun/promises/promise_race.md
@@ -1,0 +1,44 @@
+---
+title: promises / promise_race
+---
+# promise_race
+
+### NAME
+
+    promise_race - settle as the first input settles, either way
+
+### SYNOPSIS
+
+    promise promise_race(mixed *promises);
+
+### DESCRIPTION
+
+    Returns a promise that settles exactly as the **first input to settle**
+    does -- fulfilled with its value, or rejected with its reason. A
+    rejection wins a race; that is the difference from promise_any(3),
+    which ignores rejections until every input has failed.
+
+    The losing inputs are not cancelled. They keep running and their results
+    are discarded, so a race is a way to stop *waiting*, not a way to stop
+    work.
+
+    An element that is not a promise counts as already fulfilled with
+    itself, which therefore wins the race outright.
+
+    An **empty array is an error**, not a promise that never settles. This
+    deliberately departs from the JavaScript behaviour: here a permanently
+    pending promise that something awaits is a parked frame holding its
+    object, its program and one `max suspended async functions` slot for the
+    life of the driver, so the mistake is refused where it is made.
+
+### EXAMPLE
+```c
+// bound a wait without touching the operation's own promise
+async mixed with_timeout(promise p, int secs) {
+    return await promise_race(({ p, timeout_promise(secs) }));
+}
+```
+
+### SEE ALSO
+
+    promise_any(3), promise_all(3), promise_all_settled(3), call_out(3)

--- a/docs/efun/promises/promise_result.md
+++ b/docs/efun/promises/promise_result.md
@@ -10,12 +10,13 @@ title: promises / promise_result
     mixed promise_result(promise p);
 
 ### DESCRIPTION
-    Returns the fulfillment value or rejection reason of the settled
-    promise `p`. It is an error to call this on a pending promise (check
-    promise_status(3) first, or use promise_then(3) / `await` instead).
+    Returns the fulfillment value, rejection reason, or cancellation
+    reason of the settled promise `p`. It is an error to call this on a
+    pending promise (check promise_status(3) first, or use promise_then(3)
+    / `await` instead).
 
-    Reading a rejected promise's result counts as observing the rejection:
-    the unhandled-rejection report is suppressed for it.
+    Reading a rejected or cancelled promise's result counts as observing
+    it: the unhandled-rejection report is suppressed for it.
 
 ### SEE ALSO
     promise_status(3), promise_then(3)

--- a/docs/efun/promises/promise_status.md
+++ b/docs/efun/promises/promise_status.md
@@ -15,6 +15,14 @@ title: promises / promise_status
         0   pending
         1   fulfilled
         2   rejected
+        3   cancelled
+
+    Cancelled is a negative settlement -- `await`, `promise_then` /
+    `promise_catch`, and the fail-fast combinators treat it like a
+    rejection -- but it is not a fault. `acatch` still yields the reason
+    string (`"*async function cancelled"`); use this code, not that
+    string, to tell a cancellation from a rejection. A mudlib can forge
+    the string with `throw()`.
 
 ### SEE ALSO
-    promise_result(3), promise_create(3)
+    promise_result(3), promise_cancel(3), promise_create(3)

--- a/docs/lpc/types/promise.md
+++ b/docs/lpc/types/promise.md
@@ -4,8 +4,11 @@ title: types / promise
 # promise
 
 A `promise` is a first-class value standing for a result that is not
-available yet. It is in one of three states — **pending**, **fulfilled**
-with a value, or **rejected** with a reason — and it settles at most once.
+available yet. It is in one of four states — **pending**, **fulfilled**
+with a value, **rejected** with a reason, or **cancelled** — and it
+settles at most once. Cancelled is a negative settlement (await and
+`then` treat it like a rejection) that `promise_status()` reports as 3
+so a cancellation can be told from a fault.
 
 ```c
 promise p = promise_create();   // pending

--- a/docs/lpc/types/promise.md
+++ b/docs/lpc/types/promise.md
@@ -83,3 +83,5 @@ tagged `int`; nothing re-checks it at settle time.
 * `promise_create`, `promise_resolve`, `promise_reject`, `promise_then`,
   `promise_catch`, `promise_status`, `promise_result`, `promisep`,
   `async_yield`, `async_info`
+* combinators: `promise_all`, `promise_any`, `promise_race`,
+  `promise_all_settled`

--- a/docs/lpc/types/promise.md
+++ b/docs/lpc/types/promise.md
@@ -85,3 +85,4 @@ tagged `int`; nothing re-checks it at settle time.
   `async_yield`, `async_info`
 * combinators: `promise_all`, `promise_any`, `promise_race`,
   `promise_all_settled`
+* `promise_cancel` — ask an `async` body to give up at its next `await`

--- a/docs/sidebars.generated.json
+++ b/docs/sidebars.generated.json
@@ -2500,6 +2500,24 @@
           },
           {
             "type": "doc",
+            "id": "efun/promises/promise_all",
+            "key": "efun/promises/promise_all",
+            "label": "promise_all"
+          },
+          {
+            "type": "doc",
+            "id": "efun/promises/promise_all_settled",
+            "key": "efun/promises/promise_all_settled",
+            "label": "promise_all_settled"
+          },
+          {
+            "type": "doc",
+            "id": "efun/promises/promise_any",
+            "key": "efun/promises/promise_any",
+            "label": "promise_any"
+          },
+          {
+            "type": "doc",
             "id": "efun/promises/promise_catch",
             "key": "efun/promises/promise_catch",
             "label": "promise_catch"
@@ -2509,6 +2527,12 @@
             "id": "efun/promises/promise_create",
             "key": "efun/promises/promise_create",
             "label": "promise_create"
+          },
+          {
+            "type": "doc",
+            "id": "efun/promises/promise_race",
+            "key": "efun/promises/promise_race",
+            "label": "promise_race"
           },
           {
             "type": "doc",

--- a/docs/sidebars.generated.json
+++ b/docs/sidebars.generated.json
@@ -2518,6 +2518,12 @@
           },
           {
             "type": "doc",
+            "id": "efun/promises/promise_cancel",
+            "key": "efun/promises/promise_cancel",
+            "label": "promise_cancel"
+          },
+          {
+            "type": "doc",
             "id": "efun/promises/promise_catch",
             "key": "efun/promises/promise_catch",
             "label": "promise_catch"

--- a/src/include/promise.h
+++ b/src/include/promise.h
@@ -1,0 +1,67 @@
+/*
+ * promise.h -- the LPC-visible promise surface: promise_status() codes
+ * and the rejection reasons the driver itself produces.
+ *
+ * Shared between driver and mudlib: the driver rejects with these, LPC
+ * compares against them. Defined once here so the two can never drift.
+ *
+ * Every one is a constant string with a leading "*", the driver's marker for
+ * a value it authored. None of them is an error(): they are delivered
+ * outcomes that arrive at an await() or acatch() like any other rejection,
+ * and none reaches the master's error_handler(). No trailing newline -- these
+ * are values handed to a rejection handler, not messages printed by error().
+ *
+ * They are matched by CONTENT, which means a mudlib can forge one with
+ * throw(). That is accepted: discriminating them authoritatively would need a
+ * driver-reserved value kind, and promise_status() already answers the
+ * question from outside.
+ */
+
+#ifndef _PROMISE_H_
+#define _PROMISE_H_
+
+/* promise_status() return codes. The driver's own state field is typed from
+ * these, so the two cannot disagree. */
+#define PROMISE_PENDING   0
+#define PROMISE_FULFILLED 1
+#define PROMISE_REJECTED  2
+
+/* What a cancelled body's next await raises, and what its promise rejects
+ * with if nothing catches it. Identical on every delivery path -- body
+ * running, queued, or parked -- so one comparison catches all three. */
+#define PROMISE_REASON_CANCELLED "*async function cancelled"
+
+/* The suspended body's owner went away underneath it, so the body can never
+ * continue. PROMISE_REASON_DESTRUCTED is shared by both abandon routes
+ * (destruct_object()'s eager sweep and resume_coroutine()'s check) because
+ * which route a frame takes is an internal scheduling detail. */
+#define PROMISE_REASON_DESTRUCTED "*async function owner was destructed while suspended"
+#define PROMISE_REASON_RECOMPILED "*async function owner was recompiled while suspended"
+#define PROMISE_REASON_REPLACED_PROGRAM "*async function owner's program was replaced while suspended"
+
+/* No stack left to rebuild the frame on when the body was resumed. */
+#define PROMISE_REASON_STACK_OVERFLOW "*stack overflow while resuming async function"
+
+/* A promise lost its last reference before it settled, so whoever was
+ * waiting can never be told. Which one you see says who was waiting: the
+ * adoption source of a resolve-with-promise, a parked body, or a combinator
+ * input. */
+#define PROMISE_REASON_ADOPTION_COLLECTED "*promise adoption source was collected before settling"
+#define PROMISE_REASON_AWAITED_COLLECTED "*awaited promise was collected before settling"
+#define PROMISE_REASON_COLLECTED "*promise was collected before settling"
+
+/* promise_resolve(p, p) -- a promise cannot adopt itself. */
+#define PROMISE_REASON_SELF_RESOLVED "*promise resolved with itself"
+
+/* promise_any() over an empty array: nothing can ever fulfil it. */
+#define PROMISE_REASON_ANY_EMPTY "*promise_any: no promises to wait for"
+
+/* An async_yield() still queued when the driver shut down. */
+#define PROMISE_REASON_YIELD_SHUTDOWN "*async_yield never ran: the driver shut down"
+
+/* promise_reject(p) with no reason. Substituted so a bare reject is never
+ * falsy -- acatch signals failure by yielding the reason, so a falsy reason
+ * would read as success. */
+#define PROMISE_REASON_NO_REASON "*promise rejected"
+
+#endif /* _PROMISE_H_ */

--- a/src/include/promise.h
+++ b/src/include/promise.h
@@ -12,9 +12,8 @@
  * are values handed to a rejection handler, not messages printed by error().
  *
  * They are matched by CONTENT, which means a mudlib can forge one with
- * throw(). That is accepted: discriminating them authoritatively would need a
- * driver-reserved value kind, and promise_status() already answers the
- * question from outside.
+ * throw(). That is accepted: the authoritative test is promise_status() --
+ * PROMISE_CANCELLED is a real settlement, not a reserved string.
  */
 
 #ifndef _PROMISE_H_
@@ -25,10 +24,12 @@
 #define PROMISE_PENDING   0
 #define PROMISE_FULFILLED 1
 #define PROMISE_REJECTED  2
+#define PROMISE_CANCELLED 3
 
-/* What a cancelled body's next await raises, and what its promise rejects
- * with if nothing catches it. Identical on every delivery path -- body
- * running, queued, or parked -- so one comparison catches all three. */
+/* What a cancelled body's next await raises, and what its promise settles
+ * with as PROMISE_CANCELLED if nothing catches it. Identical on every
+ * delivery path -- body running, queued, or parked -- so one comparison
+ * catches all three. */
 #define PROMISE_REASON_CANCELLED "*async function cancelled"
 
 /* The suspended body's owner went away underneath it, so the body can never

--- a/src/packages/core/core.spec
+++ b/src/packages/core/core.spec
@@ -390,6 +390,12 @@ mixed promise_result(promise);
 /* the *p() type test for T_PROMISE; `mixed`, not `promise`, because the
    whole point is to ask about a value whose type is not known statically */
 int promisep(mixed);
+/* combinators over an array of promises; a non-promise element counts as
+   already fulfilled with itself, so map() output can be passed straight in */
+promise promise_all(mixed *);
+promise promise_any(mixed *);
+promise promise_race(mixed *);
+promise promise_all_settled(mixed *);
 /* pending suspended async function frames, most recently parked last */
 mixed async_info(int default: 0);
 /* a promise fulfilled on the next pass of the event loop, after the driver

--- a/src/packages/core/core.spec
+++ b/src/packages/core/core.spec
@@ -396,6 +396,9 @@ promise promise_all(mixed *);
 promise promise_any(mixed *);
 promise promise_race(mixed *);
 promise promise_all_settled(mixed *);
+/* ask an async function body to give up: its next await raises. Returns 1 if
+   a cancellation was armed, 0 if there was nothing left to cancel. */
+int promise_cancel(promise);
 /* pending suspended async function frames, most recently parked last */
 mixed async_info(int default: 0);
 /* a promise fulfilled on the next pass of the event loop, after the driver

--- a/src/packages/core/promises.cc
+++ b/src/packages/core/promises.cc
@@ -171,6 +171,42 @@ void f_promise_result() {
 }
 #endif
 
+/* shared body of the four combinators; the array arg is spec-typed, so only
+ * its ELEMENTS need checking (AGENTS.md section 2) -- and they need none: a
+ * non-promise element is defined to count as already fulfilled with itself,
+ * so map() output drops straight in. */
+static void promise_combinator_efun(uint8_t kind) {
+  array_t* inputs = sp->u.arr;
+
+  if (kind == PROMISE_COMB_RACE && inputs->size == 0) {
+    /* JS lets this hang forever. Here a hung await is a parked frame holding
+     * its object, its program and one `max suspended async functions` slot
+     * for the life of the driver, so refuse it where the mistake is. */
+    error("promise_race: needs at least one promise; an empty array would never settle.\n");
+  }
+  promise_t* result = promise_combinator_start(kind, inputs);
+  free_svalue(sp, "promise_combinator_efun");
+  sp->type = T_PROMISE;
+  sp->subtype = 0;
+  sp->u.prom = result;
+}
+
+#ifdef F_PROMISE_ALL
+void f_promise_all() { promise_combinator_efun(PROMISE_COMB_ALL); }
+#endif
+
+#ifdef F_PROMISE_ANY
+void f_promise_any() { promise_combinator_efun(PROMISE_COMB_ANY); }
+#endif
+
+#ifdef F_PROMISE_RACE
+void f_promise_race() { promise_combinator_efun(PROMISE_COMB_RACE); }
+#endif
+
+#ifdef F_PROMISE_ALL_SETTLED
+void f_promise_all_settled() { promise_combinator_efun(PROMISE_COMB_ALL_SETTLED); }
+#endif
+
 #ifdef F_PROMISEP
 void f_promisep() {
   /* the argument is `mixed`, so unlike the rest of this file the tag has

--- a/src/packages/core/promises.cc
+++ b/src/packages/core/promises.cc
@@ -207,6 +207,16 @@ void f_promise_race() { promise_combinator_efun(PROMISE_COMB_RACE); }
 void f_promise_all_settled() { promise_combinator_efun(PROMISE_COMB_ALL_SETTLED); }
 #endif
 
+#ifdef F_PROMISE_CANCEL
+void f_promise_cancel() {
+  /* validated (and possibly error()ed) before the stack is touched */
+  int const armed = promise_request_cancel(sp->u.prom);
+
+  free_svalue(sp, "f_promise_cancel");
+  put_number(armed);
+}
+#endif
+
 #ifdef F_PROMISEP
 void f_promisep() {
   /* the argument is `mixed`, so unlike the rest of this file the tag has

--- a/src/packages/core/promises.cc
+++ b/src/packages/core/promises.cc
@@ -1,6 +1,7 @@
 #include "base/package_api.h"
 
 #include "packages/core/call_out.h"
+#include "include/promise.h"  // LPC-visible rejection reasons
 
 /*
  * Promise efuns (issue #1319 phase 1). The T_PROMISE machinery itself lives
@@ -78,7 +79,7 @@ void f_promise_reject() {
   svalue_t default_reason;
   default_reason.type = T_STRING;
   default_reason.subtype = STRING_CONSTANT;
-  default_reason.u.string = "*promise rejected";
+  default_reason.u.string = PROMISE_REASON_NO_REASON;
   promise_settle(p, (num_arg > 1) ? sp : &default_reason, 1);
   pop_n_elems(num_arg);
 }

--- a/src/packages/core/promises.cc
+++ b/src/packages/core/promises.cc
@@ -161,8 +161,8 @@ void f_promise_result() {
   if (p->state == PROMISE_PENDING) {
     error("promise_result: promise is still pending.\n");
   }
-  if (p->state == PROMISE_REJECTED) {
-    /* reading a rejection counts as observing it */
+  if (p->state == PROMISE_REJECTED || p->state == PROMISE_CANCELLED) {
+    /* reading a rejection or cancellation counts as observing it */
     p->handled = true;
   }
   svalue_t result;

--- a/src/packages/core/sprintf.cc
+++ b/src/packages/core/sprintf.cc
@@ -480,6 +480,11 @@ void svalue_to_string(svalue_t* obj, outbuffer_t* outbuf, int indent, int traili
           svalue_to_string(&obj->u.prom->result, outbuf, indent + 2, 0, 1);
           outbuf_add(outbuf, " )");
           break;
+        case PROMISE_CANCELLED:
+          outbuf_add(outbuf, "( cancelled: ");
+          svalue_to_string(&obj->u.prom->result, outbuf, indent + 2, 0, 1);
+          outbuf_add(outbuf, " )");
+          break;
         default:
           outbuf_add(outbuf, "( pending )");
           break;

--- a/src/vm/internal/base/promise.cc
+++ b/src/vm/internal/base/promise.cc
@@ -1209,8 +1209,20 @@ void resume_coroutine(lpc_coroutine_t* coro, promise_t* source) {
   coro->frame = nullptr;
   coro->frame_size = 0;
 
+#ifdef DEBUG
+  /* The base these markers' offsets were taken against. When there was no
+   * frame to restore there were no temporaries either, so the counter is
+   * already the base. */
+  int const marker_base = (resumed_temp_base >= 0) ? resumed_temp_base : stack_in_use_as_temporary;
+#endif
   for (auto& m : coro->markers) {
     push_control_stack(FRAME_CATCH | FRAME_ASYNC);
+#ifdef DEBUG
+    /* push_control_stack() recorded the count as it is NOW -- with this
+     * body's temporaries already back on it -- which is not what the region
+     * was entered with. */
+    csp->save_temporaries = marker_base + m.temporaries_offset;
+#endif
     csp->pc = coro->prog->program + m.pc_offset;
     csp->save_sp = fp + m.sp_offset;
     csp->save_cgsp = cgsp;
@@ -2070,8 +2082,13 @@ void coroutine_await_pending(promise_t* awaited) {
   coro->defers = async_frame->defers;
   async_frame->defers = nullptr;
   for (control_stack_t* f = async_frame + 1; f <= csp; f++) {
-    coro->markers.push_back({static_cast<int>(f->pc - current_prog->program),
-                             static_cast<int>(f->save_sp - fp), f->defers});
+    lpc_coroutine_acatch_t m{static_cast<int>(f->pc - current_prog->program),
+                             static_cast<int>(f->save_sp - fp), f->defers};
+#ifdef DEBUG
+    /* see the field's comment: carried relative to the body's base */
+    m.temporaries_offset = f->save_temporaries - g_coroutine_temp_base;
+#endif
+    coro->markers.push_back(m);
     f->defers = nullptr;
   }
 

--- a/src/vm/internal/base/promise.cc
+++ b/src/vm/internal/base/promise.cc
@@ -46,7 +46,8 @@ extern int stack_in_use_as_temporary;
  * namespace but CALLED from inside it, and declaring them in there would
  * name a different, never-defined symbol. */
 void free_combinator(promise_combinator_t* c);
-void deliver_combinator(promise_combinator_t* c, int index, svalue_t* value, bool rejected);
+void deliver_combinator(promise_combinator_t* c, int index, svalue_t* value, bool rejected,
+                       bool from_cancel = false);
 
 namespace {
 
@@ -553,7 +554,7 @@ void deliver_reaction(QueuedReaction* qr) {
   if (qr->comb) {
     /* Pure aggregation: runs no LPC, so it needs neither an eval budget nor
      * the command_giver dance below, and cannot re-enter the drain. */
-    deliver_combinator(qr->comb, qr->comb_index, &src->result, rejected);
+    deliver_combinator(qr->comb, qr->comb_index, &src->result, rejected, src->from_cancel);
     free_queued_reaction(qr);
     return;
   }
@@ -590,6 +591,9 @@ void deliver_reaction(QueuedReaction* qr) {
     /* pass-through: propagate the source's state to the chained promise */
     if (qr->next) {
       if (rejected) {
+        if (src->from_cancel) {
+          qr->next->from_cancel = true;
+        }
         promise_settle(qr->next, &src->result, 1);
       } else {
         promise_resolve_with(qr->next, &src->result);
@@ -1130,6 +1134,9 @@ void resume_coroutine(lpc_coroutine_t* coro, promise_t* source) {
     /* no acatch() region spans the await: the rejection propagates
      * straight to the coroutine's own promise, no need to rebuild the
      * frame at all (no catch may span an await by construction). */
+    if (source->from_cancel || reason == &cancel_reason) {
+      coro->result_promise->from_cancel = true;
+    }
     free_coroutine(coro, reason, true);
     return;
   }
@@ -1367,6 +1374,7 @@ promise_t* promise_alloc() {
   p->resolving = false;
   p->body_owned = false;
   p->cancelled = false;
+  p->from_cancel = false;
   p->value_type = 0;
   p->result = const0;
   p->reactions = nullptr;
@@ -1432,7 +1440,7 @@ void dealloc_promise(promise_t* p) {
   if (p->state == PROMISE_PENDING) {
     fire_cancel_handler(p);
   }
-  if (p->state == PROMISE_REJECTED && !p->handled) {
+  if (p->state == PROMISE_REJECTED && !p->handled && !p->from_cancel) {
     /* Where it was rejected. Without this the report is a bare reason with no
      * object, function or line -- and it is printed at DEALLOCATION, which
      * can be arbitrarily far from the rejection, so there is nothing else in
@@ -1536,7 +1544,7 @@ void dealloc_promise(promise_t* p) {
         err.type = T_STRING;
         err.subtype = STRING_CONSTANT;
         err.u.string = PROMISE_REASON_COLLECTED;
-        deliver_combinator(r.comb, r.comb_index, &err, true);
+        deliver_combinator(r.comb, r.comb_index, &err, true, p->from_cancel);
         free_combinator(r.comb);
       }
     }
@@ -1671,15 +1679,22 @@ svalue_t* promise_map_slot(mapping_t* m, const char* key) {
 
 /* One input settled (or was a plain value). Records it and settles the result
  * if this input decided the outcome. Runs no LPC. */
-void deliver_combinator(promise_combinator_t* c, int index, svalue_t* value, bool rejected) {
+void deliver_combinator(promise_combinator_t* c, int index, svalue_t* value, bool rejected,
+                       bool from_cancel) {
   switch (c->kind) {
     case PROMISE_COMB_RACE:
       /* first to settle decides, either way */
+      if (rejected && from_cancel) {
+        c->result->from_cancel = true;
+      }
       (void)promise_settle(c->result, value, rejected ? 1 : 0);
       break;
 
     case PROMISE_COMB_ALL:
       if (rejected) {
+        if (from_cancel) {
+          c->result->from_cancel = true;
+        }
         (void)promise_settle(c->result, value, 1); /* fail fast */
       } else {
         assign_svalue(&c->slots->item[index], value);
@@ -1839,8 +1854,10 @@ int promise_request_cancel(promise_t* p) {
   p->cancelled = true;
   /* The canceller has forced the outcome, so the rejection below is not
    * "unhandled" even if nobody attached a handler; without this a
-   * fire-and-forget cancel logs a rejection report when the promise dies. */
+   * fire-and-forget cancel logs a rejection report when the promise dies.
+   * from_cancel travels with the reason to every downstream link. */
   p->handled = true;
+  p->from_cancel = true;
 
   /* Find the parked frame, if there is one. A linear scan over at most
    * `max suspended async functions` entries, on a rare user-initiated efun.

--- a/src/vm/internal/base/promise.cc
+++ b/src/vm/internal/base/promise.cc
@@ -9,6 +9,7 @@
 #include "backend.h"
 #include "thirdparty/scope_guard/scope_guard.hpp"  // DEFER
 #include "vm/internal/eval_limit.h"
+#include "vm/internal/simulate.h"  // throw_error (cancellation raise)
 
 /*
  * Native LPC promises (issue #1319 phase 1). See promise.h for the ownership
@@ -199,6 +200,13 @@ constexpr LPC_INT kDefaultDrainBudgetUs = 1000;
  * newline. No trailing newline: this is a value handed to a rejection
  * handler, not a message printed by error(). */
 constexpr const char* kDestructedRejection = "*async function owner was destructed while suspended";
+/* What a cancelled body's next await raises, and what its promise rejects
+ * with if nothing catches it. Matched by CONTENT, like every other reason in
+ * this family -- a plain string is forgeable by throw(), which is accepted:
+ * discriminating cancellation authoritatively would need a driver-reserved
+ * value kind, and promise_status() already answers the question from
+ * outside. */
+constexpr const char* kCancelledRejection = "*async function cancelled";
 
 /* Consecutive slices that ended with work still queued. Routine under load;
  * a long run of them means the queue is not keeping up. Reset by any slice
@@ -1033,7 +1041,11 @@ void free_coroutine(lpc_coroutine_t* coro, svalue_t* reject_with, bool run_lpc) 
 }
 
 void resume_coroutine(lpc_coroutine_t* coro, promise_t* source) {
-  bool const rejected = (source->state == PROMISE_REJECTED);
+  bool rejected = (source->state == PROMISE_REJECTED);
+  /* what the resumed await yields, or rejects with -- the source's result
+   * unless a cancellation overrides it below */
+  svalue_t cancel_reason;
+  svalue_t* reason = &source->result;
 
   /* Three ways the owner can invalidate the parked frame: destruction,
    * recompile_object() (bumps prog_generation), and replace_program()
@@ -1061,11 +1073,33 @@ void resume_coroutine(lpc_coroutine_t* coro, promise_t* source) {
     return;
   }
 
+  /* A cancellation requested while this frame was already QUEUED: it is
+   * sitting AT an await, so converting the delivery in flight into the
+   * cancellation raise is exactly what "raises at the next await" means for
+   * it. Letting the value through and raising one await later would silently
+   * run one more stretch of the body.
+   *
+   * Deliberately AFTER the destruct/staleness block above, which must win: a
+   * frame whose owner is gone cannot run acatch or defer LPC at all, so the
+   * reason that names the real reason it can never continue is the useful
+   * one. A cancellation that loses that race is simply consumed with the
+   * frame. If the queued delivery was itself a rejection, cancellation
+   * overrides its reason -- deterministic, and the canceller has declared
+   * disinterest in the outcome either way. */
+  if (coro->result_promise->cancelled) {
+    coro->result_promise->cancelled = false; /* consume-once */
+    cancel_reason.type = T_STRING;
+    cancel_reason.subtype = STRING_CONSTANT;
+    cancel_reason.u.string = kCancelledRejection;
+    reason = &cancel_reason;
+    rejected = true;
+  }
+
   if (rejected && coro->markers.empty()) {
     /* no acatch() region spans the await: the rejection propagates
      * straight to the coroutine's own promise, no need to rebuild the
      * frame at all (no catch may span an await by construction). */
-    free_coroutine(coro, &source->result, true);
+    free_coroutine(coro, reason, true);
     return;
   }
 
@@ -1177,11 +1211,11 @@ void resume_coroutine(lpc_coroutine_t* coro, promise_t* source) {
   if (!rejected) {
     /* the await expression's value */
     STACK_INC;
-    assign_svalue_no_free(sp, &source->result);
+    assign_svalue_no_free(sp, reason);
     entry = coro->prog->program + coro->pc_offset;
   } else {
     /* re-raise at the await point; the innermost acatch() catches it */
-    assign_svalue(&catch_value, &source->result);
+    assign_svalue(&catch_value, reason);
     entry = unwind_to_acatch_marker(csp);
   }
   /* The eval-cost flag is deliberately NOT consumed here, unlike the
@@ -1271,6 +1305,7 @@ promise_t* promise_alloc() {
   p->handled = false;
   p->resolving = false;
   p->body_owned = false;
+  p->cancelled = false;
   p->value_type = 0;
   p->result = const0;
   p->reactions = nullptr;
@@ -1718,6 +1753,94 @@ promise_t* promise_combinator_start(uint8_t kind, array_t* inputs) {
   return result;
 }
 
+int promise_request_cancel(promise_t* p) {
+  if (!p->body_owned) {
+    /* Only an async function body has a "next await" for a cancellation to
+     * arrive at. Everything else the driver hands out is refused rather than
+     * quietly ignored: a promise_create() promise is already settleable by
+     * whoever owns it (and cancelling someone else's channel is what the
+     * body_owned refusal exists to prevent); an async_read()/async_write()
+     * promise cannot stop the worker thread that is already reading the
+     * file; a call_out(delay) promise is documented as non-cancellable (use
+     * the classic form and remove_call_out()); and rejecting a then-chain
+     * link cannot stop its upstream. */
+    error("promise_cancel: promise does not belong to an async function.\n");
+  }
+  if (p->state != PROMISE_PENDING || p->resolving) {
+    /* Already finished, or the body returned a still-pending promise and is
+     * gone -- in both cases there is no frame left to interrupt. NOT an
+     * error: a body racing to completion against its canceller is the
+     * documented normal outcome, and erroring would make every cancel a
+     * race against its target. */
+    return 0;
+  }
+
+  p->cancelled = true;
+  /* The canceller has forced the outcome, so the rejection below is not
+   * "unhandled" even if nobody attached a handler; without this a
+   * fire-and-forget cancel logs a rejection report when the promise dies. */
+  p->handled = true;
+
+  /* Find the parked frame, if there is one. A linear scan over at most
+   * `max suspended async functions` entries, on a rare user-initiated efun.
+   * Deliberately NOT an index keyed by result promise: that would add two
+   * more sync points to the park/free pair, which is exactly the
+   * "one sibling path forgot" hazard of AGENTS.md section 13.15 -- and the
+   * owner index already needed a Debug sweep to police the two it has. */
+  lpc_coroutine_t* coro = nullptr;
+  for (auto& entry : g_live_coroutines) {
+    if (entry.second->result_promise == p && !entry.second->abandoned) {
+      coro = entry.second;
+      break;
+    }
+  }
+  /* No frame parked on a promise right now: the body is running (its first
+   * synchronous stretch, or after an acatch caught an earlier cancel), or it
+   * is already queued for resumption. Both consume the flag at their own
+   * boundary -- coroutine_await_pending() and resume_coroutine() -- so there
+   * is no window where the request is lost. */
+  if (coro == nullptr || coro->queued || coroutine_is_running(coro)) {
+    return 1;
+  }
+
+  /* Parked on a promise that may never settle, so waiting for it is not an
+   * option: detach the frame and schedule its own rejection delivery. From
+   * here to the enqueue nothing may run LPC or throw -- the coroutine is
+   * owned by a raw local in between. */
+  promise_t* awaited = coro->awaiting;
+  if (awaited != nullptr && awaited->reactions != nullptr) {
+    for (auto rit = awaited->reactions->begin(); rit != awaited->reactions->end(); ++rit) {
+      if (rit->coro == coro) {
+        awaited->reactions->erase(rit);
+        break;
+      }
+    }
+  }
+
+  /* A synthetic already-rejected source to deliver through. coro->awaiting is
+   * REPOINTED at it, which is load-bearing rather than tidiness:
+   * build_async_info() dereferences coro->awaiting unconditionally and it is
+   * deliberately not ref-held, so after the detach above the original could
+   * be freed by its other holders at any moment -- leaving a dangling read
+   * reachable from an ordinary async_info() call. The queued reaction holds a
+   * ref on this one for exactly as long as the coroutine is queued, so the
+   * lifetimes match. */
+  promise_t* s = promise_alloc();
+  svalue_t reason;
+  reason.type = T_STRING;
+  reason.subtype = STRING_CONSTANT;
+  reason.u.string = kCancelledRejection;
+  (void)promise_settle(s, &reason, 1);
+  /* nothing will attach a handler to a promise only the driver can see */
+  s->handled = true;
+  coro->awaiting = s;
+
+  promise_reaction_t r{nullptr, nullptr, nullptr, nullptr, coro, nullptr, 0};
+  enqueue_reaction(s, &r); /* takes its own ref on s, marks coro queued */
+  free_promise(s);         /* the queue is now the sole owner */
+  return 1;
+}
+
 /* Attach a parked coroutine to the promise it awaits. Ownership of `coro`
  * transfers to the promise machinery. */
 static void promise_add_coroutine(promise_t* p, lpc_coroutine_t* coro) {
@@ -1786,6 +1909,29 @@ void coroutine_await_pending(promise_t* awaited) {
   }
   if (!async_frame || !g_coroutine_promise) {
     error("await: not directly inside an async function body.\n");
+  }
+  /* A cancellation requested while this body was RUNNING (its own first
+   * synchronous stretch, or the code after an acatch caught an earlier one)
+   * is delivered here, at the next await -- which is what makes cancellation
+   * cooperative rather than preemptive.
+   *
+   * Raised through the throw path rather than error(), for two reasons: the
+   * caught value is then the IDENTICAL constant the parked route delivers
+   * (an error() would wrap it in its own "*...\n" formatting, so acatch
+   * would see two different spellings depending on where the cancel landed),
+   * and cancellation is a delivered outcome, not a fault, so it should not
+   * reach the error handler's log. f_throw()/throw_error() is the precedent.
+   *
+   * Placed before ANY STACK_INC or allocation below, so the unwind has no
+   * half-initialised slot to trip over (AGENTS.md section 4). */
+  if (g_coroutine_promise->cancelled) {
+    g_coroutine_promise->cancelled = false; /* consume-once */
+    /* the value travels in catch_value, exactly as f_throw() does it */
+    free_svalue(&catch_value, "coroutine_await_pending: cancelled");
+    catch_value.type = T_STRING;
+    catch_value.subtype = STRING_CONSTANT;
+    catch_value.u.string = kCancelledRejection;
+    throw_error();
   }
   /* Parking inside an object that is ALREADY destructed would create a frame
    * nothing can ever clean up: abandon_coroutines_of_object() runs once, from

--- a/src/vm/internal/base/promise.cc
+++ b/src/vm/internal/base/promise.cc
@@ -84,7 +84,8 @@ int g_coroutine_temp_base = 0;
 #endif
 
 void free_coroutine(lpc_coroutine_t* coro, svalue_t* reject_with, bool run_lpc);
-bool run_coroutine_body(char* entry_pc, promise_t* p, control_stack_t* async_frame);
+bool run_coroutine_body(char* entry_pc, promise_t* p, control_stack_t* async_frame,
+                        int resumed_temp_base = -1);
 
 /* A settled reaction awaiting delivery. Holds a ref on everything it points
  * at, including the source promise (for the result value). */
@@ -836,7 +837,8 @@ char* unwind_to_acatch_marker(control_stack_t* marker) {
  * set up and `entry_pc` points into its program. Settles `p` on completion
  * or failure. Returns true if an uncatchable eval-cost error must be
  * propagated by the caller (do_catch() parity). */
-bool run_coroutine_body(char* entry_pc, promise_t* p, control_stack_t* async_frame) {
+bool run_coroutine_body(char* entry_pc, promise_t* p, control_stack_t* async_frame,
+                        int resumed_temp_base) {
   error_context_t econ;
   save_context(&econ);
   /* The coroutine owns its whole frame (safe_apply's "callee owns the
@@ -858,7 +860,15 @@ bool run_coroutine_body(char* entry_pc, promise_t* p, control_stack_t* async_fra
   g_coroutine_promise = p;
 #ifdef DEBUG
   int const prev_temp_base = g_coroutine_temp_base;
-  g_coroutine_temp_base = stack_in_use_as_temporary;
+  /* On a RESUME the caller has already put the frame's own foreach
+   * temporaries back on the counter, so reading it here would fold them
+   * into this body's base -- the next park would then compute a delta of
+   * zero, hand the coroutine nothing, and leave the count elevated for
+   * whatever runs next (permanently, if the frame is later abandoned and
+   * its F_EXIT_FOREACH never runs). A nonzero count silently disables
+   * break_point()'s stack check, so the loss is quiet. resume_coroutine()
+   * passes what the counter held before it re-added them. */
+  g_coroutine_temp_base = resumed_temp_base >= 0 ? resumed_temp_base : stack_in_use_as_temporary;
 #endif
   /* RAII, not a tail assignment: `econ` lives on THIS C++ frame, so if an
    * exception ever escapes this function the globals must not be left
@@ -1061,6 +1071,8 @@ void free_coroutine(lpc_coroutine_t* coro, svalue_t* reject_with, bool run_lpc) 
 
 void resume_coroutine(lpc_coroutine_t* coro, promise_t* source) {
   bool rejected = (source->state == PROMISE_REJECTED);
+  /* -1 = "no resumed frame to account for"; see the frame restore below */
+  int resumed_temp_base = -1;
   /* what the resumed await yields, or rejects with -- the source's result
    * unless a cancellation overrides it below */
   svalue_t cancel_reason;
@@ -1184,7 +1196,10 @@ void resume_coroutine(lpc_coroutine_t* coro, promise_t* source) {
     coro->frame_lvalues.clear();
 #ifdef DEBUG
     /* the temporaries are back on the stack, so the count is owed again --
-     * F_EXIT_FOREACH will retire them one loop at a time as before */
+     * F_EXIT_FOREACH will retire them one loop at a time as before. The
+     * base handed to run_coroutine_body() below is what the counter held
+     * BEFORE this frame's share went back on it. */
+    resumed_temp_base = stack_in_use_as_temporary;
     stack_in_use_as_temporary += coro->temporaries;
     coro->temporaries = 0;
 #endif
@@ -1257,7 +1272,7 @@ void resume_coroutine(lpc_coroutine_t* coro, promise_t* source) {
    * caller's evaluation. A resumption has no caller -- but the drain turn
    * that delivered it does read the flag, as a resumed frame that burned its
    * whole budget ends the turn. drain_promise_microtasks() clears it. */
-  (void)run_coroutine_body(entry, coro->result_promise, async_frame);
+  (void)run_coroutine_body(entry, coro->result_promise, async_frame, resumed_temp_base);
   free_coroutine(coro, nullptr, false);
 }
 
@@ -2423,10 +2438,14 @@ void mark_promise_queue() {
       c->result->extra_ref++;
     }
     if (c->slots) {
+      /* Only the combinator's own reference: `slots` is an ordinary
+       * allocated array, so the sweep that reaches this one reaches its
+       * TAG_ARRAY block too and marks every item there (checkmemory.cc's
+       * TAG_ARRAY case). Marking them again here would report one ref
+       * nobody holds per refcounted delivered value -- unlike a
+       * coroutine's frame[], which is a bare new[] the sweep never sees
+       * and which mark_coroutine() therefore does have to walk. */
       c->slots->extra_ref++;
-      for (int i = 0; i < c->slots->size; i++) {
-        mark_svalue(&c->slots->item[i]);
-      }
     }
   }
   auto mark_one = [](QueuedReaction& qr) {

--- a/src/vm/internal/base/promise.cc
+++ b/src/vm/internal/base/promise.cc
@@ -214,13 +214,17 @@ constexpr LPC_INT kDefaultDrainBudgetUs = 1000;
  * newline. No trailing newline: this is a value handed to a rejection
  * handler, not a message printed by error(). */
 constexpr const char* kDestructedRejection = PROMISE_REASON_DESTRUCTED;
-/* What a cancelled body's next await raises, and what its promise rejects
- * with if nothing catches it. Matched by CONTENT, like every other reason in
- * this family -- a plain string is forgeable by throw(), which is accepted:
- * discriminating cancellation authoritatively would need a driver-reserved
- * value kind, and promise_status() already answers the question from
- * outside. */
+/* What a cancelled body's next await raises, and what its promise settles
+ * with as PROMISE_CANCELLED if nothing catches it. Matched by CONTENT for
+ * the raise itself -- a plain string is forgeable by throw() -- but
+ * promise_status() is the authoritative test from outside. */
 constexpr const char* kCancelledRejection = PROMISE_REASON_CANCELLED;
+
+/* Cancelled is a negative settlement: await / then / combinators treat it
+ * like a rejection, but promise_status() reports PROMISE_CANCELLED. */
+bool promise_failed(const promise_t* p) {
+  return p->state == PROMISE_REJECTED || p->state == PROMISE_CANCELLED;
+}
 
 /* Consecutive slices that ended with work still queued. Routine under load;
  * a long run of them means the queue is not keeping up. Reset by any slice
@@ -549,7 +553,7 @@ void deliver_reaction(QueuedReaction* qr) {
     return;
   }
 
-  bool const rejected = (src->state == PROMISE_REJECTED);
+  bool const rejected = promise_failed(src);
 
   if (qr->comb) {
     /* Pure aggregation: runs no LPC, so it needs neither an eval budget nor
@@ -924,6 +928,14 @@ bool run_coroutine_body(char* entry_pc, promise_t* p, control_stack_t* async_fra
         } catch (const char*) {
         }
         if (unwound) {
+          /* The body caught the raise. If this was a cancellation, it was
+           * declined -- later settlement is ordinary fulfill or reject, not
+           * PROMISE_CANCELLED. Matched by the driver's constant pointer, not
+           * by string content: a mudlib throw of the same letters is a
+           * rejection. */
+          if (catch_value.type == T_STRING && catch_value.u.string == kCancelledRejection) {
+            p->from_cancel = false;
+          }
           continue;
         }
       }
@@ -1074,7 +1086,7 @@ void free_coroutine(lpc_coroutine_t* coro, svalue_t* reject_with, bool run_lpc) 
 }
 
 void resume_coroutine(lpc_coroutine_t* coro, promise_t* source) {
-  bool rejected = (source->state == PROMISE_REJECTED);
+  bool rejected = promise_failed(source);
   /* -1 = "no resumed frame to account for"; see the frame restore below */
   int resumed_temp_base = -1;
   /* what the resumed await yields, or rejects with -- the source's result
@@ -1282,7 +1294,14 @@ void resume_coroutine(lpc_coroutine_t* coro, promise_t* source) {
     assign_svalue_no_free(sp, reason);
     entry = coro->prog->program + coro->pc_offset;
   } else {
-    /* re-raise at the await point; the innermost acatch() catches it */
+    /* re-raise at the await point; the innermost acatch() catches it.
+     * Catching THIS body's own cancel (reason == &cancel_reason) declines
+     * it -- later settlement is ordinary. An inherited cancelled await is
+     * just a catchable rejection here; from_cancel was never set on this
+     * result. */
+    if (reason == &cancel_reason) {
+      coro->result_promise->from_cancel = false;
+    }
     assign_svalue(&catch_value, reason);
     entry = unwind_to_acatch_marker(csp);
   }
@@ -1566,7 +1585,13 @@ int promise_settle(promise_t* p, svalue_t* value, int rejected) {
   } else {
     promise_clear_cancel_handler(p);
   }
-  p->state = rejected ? PROMISE_REJECTED : PROMISE_FULFILLED;
+  if (!rejected) {
+    p->state = PROMISE_FULFILLED;
+  } else if (p->from_cancel) {
+    p->state = PROMISE_CANCELLED;
+  } else {
+    p->state = PROMISE_REJECTED;
+  }
   assign_svalue(&p->result, value);
   if (p->reactions) {
     std::vector<promise_reaction_t>* reactions = p->reactions;
@@ -1710,13 +1735,14 @@ void deliver_combinator(promise_combinator_t* c, int index, svalue_t* value, boo
       break;
 
     case PROMISE_COMB_ALL_SETTLED: {
-      /* ([ "status": 1|2, "value"|"reason": v ]) -- the status codes are
+      /* ([ "status": 1|2|3, "value"|"reason": v ]) -- the status codes are
        * promise_status()'s, so one vocabulary covers both. */
       mapping_t* m = allocate_mapping(2);
       svalue_t* slot = promise_map_slot(m, "status");
       slot->type = T_NUMBER;
       slot->subtype = 0;
-      slot->u.number = rejected ? PROMISE_REJECTED : PROMISE_FULFILLED;
+      slot->u.number = rejected ? (from_cancel ? PROMISE_CANCELLED : PROMISE_REJECTED)
+                                : PROMISE_FULFILLED;
       slot = promise_map_slot(m, rejected ? "reason" : "value");
       assign_svalue_no_free(slot, value);
       free_svalue(&c->slots->item[index], "deliver_combinator");

--- a/src/vm/internal/base/promise.cc
+++ b/src/vm/internal/base/promise.cc
@@ -39,6 +39,13 @@ extern int _in_reference_allowed;
  * declaration. Read only under DEBUG; see control_stack_t::save_temporaries. */
 extern int stack_in_use_as_temporary;
 
+/* Combinator helpers, declared at file scope for the same reason as
+ * _in_reference_allowed above: they are DEFINED below the anonymous
+ * namespace but CALLED from inside it, and declaring them in there would
+ * name a different, never-defined symbol. */
+void free_combinator(promise_combinator_t* c);
+void deliver_combinator(promise_combinator_t* c, int index, svalue_t* value, bool rejected);
+
 namespace {
 
 /* set by coroutine_await_pending(); read by run_coroutine_body() to tell a
@@ -74,6 +81,8 @@ struct QueuedReaction {
   promise_t* next;
   object_t* command_giver;
   lpc_coroutine_t* coro;
+  promise_combinator_t* comb;
+  int comb_index;
   promise_t* source;
 };
 
@@ -414,6 +423,12 @@ void free_queued_reaction(QueuedReaction* qr) {
     free_coroutine(qr->coro, nullptr, false);
     qr->coro = nullptr;
   }
+  if (qr->comb) {
+    /* never delivered (shutdown): this input simply never reports, and the
+     * aggregate dies with the last of its reactions */
+    free_combinator(qr->comb);
+    qr->comb = nullptr;
+  }
   if (qr->source) {
     free_promise(qr->source);
     qr->source = nullptr;
@@ -422,7 +437,8 @@ void free_queued_reaction(QueuedReaction* qr) {
 
 void enqueue_reaction(promise_t* source, promise_reaction_t* r) {
   source->ref++;
-  QueuedReaction qr{r->on_fulfilled, r->on_rejected, r->next, r->command_giver, r->coro, source};
+  QueuedReaction qr{r->on_fulfilled, r->on_rejected, r->next,       r->command_giver,
+                    r->coro,         r->comb,        r->comb_index, source};
   if (qr.coro != nullptr) {
     qr.coro->queued = true;
   }
@@ -512,6 +528,15 @@ void deliver_reaction(QueuedReaction* qr) {
   }
 
   bool const rejected = (src->state == PROMISE_REJECTED);
+
+  if (qr->comb) {
+    /* Pure aggregation: runs no LPC, so it needs neither an eval budget nor
+     * the command_giver dance below, and cannot re-enter the drain. */
+    deliver_combinator(qr->comb, qr->comb_index, &src->result, rejected);
+    free_queued_reaction(qr);
+    return;
+  }
+
   funptr_t* handler = rejected ? qr->on_rejected : qr->on_fulfilled;
 
   object_t* giver = qr->command_giver;
@@ -1405,6 +1430,19 @@ void dealloc_promise(promise_t* p) {
         err.u.string = "*awaited promise was collected before settling";
         free_coroutine(r.coro, &err, false);
       }
+      if (r.comb) {
+        /* This input died unsettled, so it can never report. Deliver a
+         * rejection on its behalf rather than just dropping the reference:
+         * otherwise `remaining` never reaches zero and a promise_all() whose
+         * input was collected stays pending forever -- the same stranded
+         * shape the r.next arm above exists to prevent. */
+        svalue_t err;
+        err.type = T_STRING;
+        err.subtype = STRING_CONSTANT;
+        err.u.string = "*promise was collected before settling";
+        deliver_combinator(r.comb, r.comb_index, &err, true);
+        free_combinator(r.comb);
+      }
     }
     delete p->reactions;
     p->reactions = nullptr;
@@ -1465,7 +1503,7 @@ void promise_add_reaction(promise_t* p, funptr_t* on_fulfilled, funptr_t* on_rej
   if (on_rejected || next) {
     p->handled = true;
   }
-  promise_reaction_t r{on_fulfilled, on_rejected, next, giver, nullptr};
+  promise_reaction_t r{on_fulfilled, on_rejected, next, giver, nullptr, nullptr, 0};
   if (p->state == PROMISE_PENDING) {
     if (!p->reactions) {
       p->reactions = new std::vector<promise_reaction_t>();
@@ -1476,11 +1514,215 @@ void promise_add_reaction(promise_t* p, funptr_t* on_fulfilled, funptr_t* on_rej
   }
 }
 
+/*
+ * Combinators: promise_all / promise_any / promise_race / promise_all_settled.
+ *
+ * One promise_combinator_t is shared by every input's reaction; each holds a
+ * reference, so the aggregate dies with the last input however that input
+ * ends. Aggregation runs no LPC, so it happens inside the delivery like a
+ * pass-through link -- ordering stays the drain's, and a combinator can never
+ * settle its result synchronously from the efun unless every input was a
+ * plain value.
+ */
+
+#ifdef DEBUGMALLOC_EXTENSIONS
+/* Marked from here, once per combinator, NOT from each reaction that points
+ * at it: N reactions share one aggregate holding ONE reference to `result`
+ * and `slots`, so per-reaction marking would report N-1 phantom refs. Same
+ * reason g_active_body_promises exists. */
+std::vector<promise_combinator_t*> g_live_combinators;
+#endif
+
+void free_combinator(promise_combinator_t* c) {
+  if (--c->ref > 0) {
+    return;
+  }
+#ifdef DEBUGMALLOC_EXTENSIONS
+  for (auto it = g_live_combinators.begin(); it != g_live_combinators.end(); ++it) {
+    if (*it == c) {
+      g_live_combinators.erase(it);
+      break;
+    }
+  }
+#endif
+  if (c->result) {
+    free_promise(c->result);
+  }
+  if (c->slots) {
+    free_array(c->slots);
+  }
+  delete c;
+}
+
+/* Insert a constant-named key and return its value slot, ready to overwrite.
+ *
+ * A local mirror of mapping.cc's insert_in_mapping(), which is static there.
+ * Do not be tempted to hand find_for_insert() a reused key svalue: its hash
+ * (svalue_to_int) CONVERTS the key IN PLACE from a constant to a ref-bumped
+ * shared string, so a second insert through the same svalue carries subtype
+ * STRING_SHARED over a string literal and INC_COUNTED_REF writes into
+ * read-only memory. The ref that conversion took is ours to release, on the
+ * throwing path too -- hence the DEFER, exactly as the original explains. */
+svalue_t* promise_map_slot(mapping_t* m, const char* key) {
+  svalue_t lv;
+
+  lv.type = T_STRING;
+  lv.subtype = STRING_CONSTANT;
+  lv.u.string = key;
+  DEFER { free_string(lv.u.string); };
+  return find_for_insert(m, &lv, 1);
+}
+
+/* One input settled (or was a plain value). Records it and settles the result
+ * if this input decided the outcome. Runs no LPC. */
+void deliver_combinator(promise_combinator_t* c, int index, svalue_t* value, bool rejected) {
+  switch (c->kind) {
+    case PROMISE_COMB_RACE:
+      /* first to settle decides, either way */
+      (void)promise_settle(c->result, value, rejected ? 1 : 0);
+      break;
+
+    case PROMISE_COMB_ALL:
+      if (rejected) {
+        (void)promise_settle(c->result, value, 1); /* fail fast */
+      } else {
+        assign_svalue(&c->slots->item[index], value);
+      }
+      break;
+
+    case PROMISE_COMB_ANY:
+      if (rejected) {
+        assign_svalue(&c->slots->item[index], value);
+      } else {
+        (void)promise_settle(c->result, value, 0); /* first success wins */
+      }
+      break;
+
+    case PROMISE_COMB_ALL_SETTLED: {
+      /* ([ "status": 1|2, "value"|"reason": v ]) -- the status codes are
+       * promise_status()'s, so one vocabulary covers both. */
+      mapping_t* m = allocate_mapping(2);
+      svalue_t* slot = promise_map_slot(m, "status");
+      slot->type = T_NUMBER;
+      slot->subtype = 0;
+      slot->u.number = rejected ? PROMISE_REJECTED : PROMISE_FULFILLED;
+      slot = promise_map_slot(m, rejected ? "reason" : "value");
+      assign_svalue_no_free(slot, value);
+      free_svalue(&c->slots->item[index], "deliver_combinator");
+      c->slots->item[index].type = T_MAPPING;
+      c->slots->item[index].u.map = m;
+      break;
+    }
+
+    default:
+      break;
+  }
+
+  /* Decrement unconditionally, including on the paths that already settled
+   * above: a later settle is a silent no-op, so one counter serves every
+   * kind and no arm can forget to advance it. */
+  if (--c->remaining == 0) {
+    if (c->kind == PROMISE_COMB_ALL || c->kind == PROMISE_COMB_ALL_SETTLED) {
+      svalue_t all = const0;
+      all.type = T_ARRAY;
+      all.u.arr = c->slots;
+      (void)promise_settle(c->result, &all, 0);
+    } else if (c->kind == PROMISE_COMB_ANY) {
+      /* every input rejected: reject with the array of reasons */
+      svalue_t all = const0;
+      all.type = T_ARRAY;
+      all.u.arr = c->slots;
+      (void)promise_settle(c->result, &all, 1);
+    }
+  }
+}
+
+promise_t* promise_combinator_start(uint8_t kind, array_t* inputs) {
+  int const n = inputs->size;
+  promise_t* result = promise_alloc();
+
+  if (n == 0) {
+    /* Decided here rather than left to the loop, and deliberately not
+     * uniform: an empty promise_all()/promise_all_settled() has trivially
+     * met its condition, an empty promise_any() can never be satisfied, and
+     * an empty promise_race() would wait forever -- which in a driver is a
+     * parked frame holding an object, a program and a suspension slot for
+     * the life of the process, so it is refused by the efun before it gets
+     * here rather than reproduced from JS. */
+    if (kind == PROMISE_COMB_ANY) {
+      svalue_t err = const0;
+      err.type = T_STRING;
+      err.subtype = STRING_CONSTANT;
+      err.u.string = "*promise_any: no promises to wait for";
+      (void)promise_settle(result, &err, 1);
+    } else {
+      svalue_t empty = const0;
+      empty.type = T_ARRAY;
+      empty.u.arr = &the_null_array;
+      (void)promise_settle(result, &empty, 0);
+    }
+    return result;
+  }
+
+  /* Plain new, not DMALLOC: every TAG_PROMISE block is cast straight to
+   * promise_t* by checkmemory.cc's sweep, so borrowing that tag would be a
+   * type confusion, and a new tag would have to be taught to all of its
+   * walkers. lpc_coroutine_t -- a bigger off-graph struct holding far more
+   * references -- is allocated the same way for the same reason; what the
+   * checker needs is the MARKING below, not the block. */
+  auto* c = new promise_combinator_t{};
+  c->ref = 1; /* held by this function until every input is attached */
+  c->kind = kind;
+  c->result = result;
+  result->ref++;
+  c->slots = allocate_empty_array(n);
+  for (int i = 0; i < n; i++) {
+    c->slots->item[i] = const0;
+  }
+  c->remaining = n;
+#ifdef DEBUGMALLOC_EXTENSIONS
+  g_live_combinators.push_back(c);
+#endif
+
+  /* Two passes. Attaching first means a plain value can never drive
+   * `remaining` to zero while later inputs are still being hooked up, which
+   * would settle the result early and leave the rest writing into a decided
+   * aggregate. */
+  for (int i = 0; i < n; i++) {
+    if (inputs->item[i].type != T_PROMISE) {
+      continue;
+    }
+    promise_t* src = inputs->item[i].u.prom;
+    src->handled = true; /* the combinator observes the rejection */
+    c->ref++;
+    promise_reaction_t r{nullptr, nullptr, nullptr, nullptr, nullptr, c, i};
+    if (src->state == PROMISE_PENDING) {
+      if (!src->reactions) {
+        src->reactions = new std::vector<promise_reaction_t>();
+      }
+      src->reactions->push_back(r);
+    } else {
+      enqueue_reaction(src, &r);
+    }
+  }
+  for (int i = 0; i < n; i++) {
+    if (inputs->item[i].type == T_PROMISE) {
+      continue;
+    }
+    /* A non-promise counts as already fulfilled with itself, so the output of
+     * an ordinary map() can be passed straight in. */
+    deliver_combinator(c, i, &inputs->item[i], false);
+  }
+
+  free_combinator(c); /* release the arming reference */
+  return result;
+}
+
 /* Attach a parked coroutine to the promise it awaits. Ownership of `coro`
  * transfers to the promise machinery. */
 static void promise_add_coroutine(promise_t* p, lpc_coroutine_t* coro) {
   p->handled = true; /* the await observes a rejection */
-  promise_reaction_t r{nullptr, nullptr, nullptr, nullptr, coro};
+  promise_reaction_t r{nullptr, nullptr, nullptr, nullptr, coro, nullptr, 0};
   if (p->state == PROMISE_PENDING) {
     if (!p->reactions) {
       p->reactions = new std::vector<promise_reaction_t>();
@@ -1946,6 +2188,21 @@ void mark_promise_queue() {
    * registry, which is a C++ global the allocation sweep never walks. */
   for (auto* p : g_pending_yields) {
     p->extra_ref++;
+  }
+  /* Combinators, likewise off-graph -- and marked ONCE per aggregate rather
+   * than from each of the N reactions pointing at it, because those N share
+   * a single reference to `result` and `slots`. Marking per reaction would
+   * report N-1 references nobody holds. */
+  for (auto* c : g_live_combinators) {
+    if (c->result) {
+      c->result->extra_ref++;
+    }
+    if (c->slots) {
+      c->slots->extra_ref++;
+      for (int i = 0; i < c->slots->size; i++) {
+        mark_svalue(&c->slots->item[i]);
+      }
+    }
   }
   auto mark_one = [](QueuedReaction& qr) {
     if (qr.on_fulfilled) {

--- a/src/vm/internal/base/promise.cc
+++ b/src/vm/internal/base/promise.cc
@@ -70,6 +70,17 @@ std::unordered_map<object_t*, std::vector<uint64_t>> g_coroutines_by_owner;
 uint64_t g_next_coroutine_id = 0;
 /* the result promise of the innermost running coroutine body */
 promise_t* g_coroutine_promise = nullptr;
+#ifdef DEBUG
+/* stack_in_use_as_temporary as it stood when the innermost body was entered.
+ * foreach bumps that GLOBAL counter to tell break_point() its temporaries are
+ * legitimately sitting above fp; anything above this base belongs to the
+ * running body, and moves into the parked frame with it. Without the split, a
+ * body that parks inside a foreach leaves the count elevated for whatever
+ * runs next, and -- because reset_machine() zeroes it between top-level calls
+ * -- arrives at its resume with the temporaries restored but the count gone,
+ * which is a "Bad stack pointer" fatal on Debug builds. */
+int g_coroutine_temp_base = 0;
+#endif
 
 void free_coroutine(lpc_coroutine_t* coro, svalue_t* reject_with, bool run_lpc);
 bool run_coroutine_body(char* entry_pc, promise_t* p, control_stack_t* async_frame);
@@ -844,6 +855,10 @@ bool run_coroutine_body(char* entry_pc, promise_t* p, control_stack_t* async_fra
   promise_t* prev_promise = g_coroutine_promise;
   g_coroutine_econ = &econ;
   g_coroutine_promise = p;
+#ifdef DEBUG
+  int const prev_temp_base = g_coroutine_temp_base;
+  g_coroutine_temp_base = stack_in_use_as_temporary;
+#endif
   /* RAII, not a tail assignment: `econ` lives on THIS C++ frame, so if an
    * exception ever escapes this function the globals must not be left
    * pointing at it (error_handler() compares current_error_context against
@@ -851,6 +866,9 @@ bool run_coroutine_body(char* entry_pc, promise_t* p, control_stack_t* async_fra
   DEFER {
     g_coroutine_econ = prev_econ;
     g_coroutine_promise = prev_promise;
+#ifdef DEBUG
+    g_coroutine_temp_base = prev_temp_base;
+#endif
     pop_context(&econ);
   };
   bool propagate_eval_error = false;
@@ -1154,6 +1172,21 @@ void resume_coroutine(lpc_coroutine_t* coro, promise_t* source) {
   fp = sp + 1;
   if (coro->frame_size > 0) {
     memcpy(fp, coro->frame, coro->frame_size * sizeof(svalue_t));
+    /* re-derive the frame-relative lvalues against the NEW fp (see the
+     * matching conversion in coroutine_await_pending) */
+    for (int slot : coro->frame_lvalues) {
+      svalue_t* target = fp + fp[slot].u.number;
+      fp[slot].type = T_LVALUE;
+      fp[slot].subtype = 0;
+      fp[slot].u.lvalue = target;
+    }
+    coro->frame_lvalues.clear();
+#ifdef DEBUG
+    /* the temporaries are back on the stack, so the count is owed again --
+     * F_EXIT_FOREACH will retire them one loop at a time as before */
+    stack_in_use_as_temporary += coro->temporaries;
+    coro->temporaries = 0;
+#endif
   }
   sp = fp + coro->frame_size - 1;
   delete[] coro->frame;
@@ -1959,14 +1992,34 @@ void coroutine_await_pending(promise_t* awaited) {
       error("await: too many suspended async functions (limit %d).\n", static_cast<int>(limit));
     }
   }
-  /* transient references into the stacks cannot be parked */
+  /* Transient references into the stacks. A plain T_LVALUE that addresses a
+   * slot INSIDE this frame is fine and is relocated across the suspension
+   * (see the frame copy below) -- that is what every ordinary `foreach`
+   * leaves on the stack for its loop variable, so refusing it blanket-wise
+   * made `await` illegal in any foreach at all.
+   *
+   * Everything else here genuinely cannot be parked, and for different
+   * reasons worth keeping straight:
+   *   - T_LVALUE addressing something outside the frame (a GLOBAL loop
+   *     variable goes through find_value() into the object's variable
+   *     block) has a second relocation base and its own lifetime questions;
+   *     refused for now rather than guessed at.
+   *   - T_LVALUE_BYTE / _CODEPOINT / _RANGE are backed by SHARED VM globals
+   *     (AGENTS.md section 13.9), one instance at a time by construction, so
+   *     they can never be per-frame state -- these stay refused permanently.
+   *   - T_REF and T_ERROR_HANDLER own heap state whose unwind is tied to
+   *     this C++ frame. */
   for (svalue_t* v = fp; v < sp; v++) {
+    if (v->type == T_LVALUE && v->u.lvalue >= fp && v->u.lvalue < sp) {
+      continue; /* relocatable */
+    }
     if (v->type &
         (T_LVALUE | T_LVALUE_BYTE | T_LVALUE_RANGE | T_LVALUE_CODEPOINT | T_REF | T_ERROR_HANDLER)) {
       error(
           "await: cannot suspend while a reference or lvalue is pending on the stack. "
-          "Inside a `foreach` loop, use an indexed `for` loop instead; for a `ref` "
-          "argument, await into a plain variable first and pass that.\n");
+          "A `foreach` over a GLOBAL loop variable or a `ref` one cannot hold an await -- "
+          "use a local loop variable, or an indexed `for`; for a `ref` argument, await "
+          "into a plain variable first and pass that.\n");
     }
   }
 
@@ -2013,7 +2066,32 @@ void coroutine_await_pending(promise_t* awaited) {
   if (n > 0) {
     coro->frame = new svalue_t[n];
     memcpy(coro->frame, fp, n * sizeof(svalue_t));
+    /* Relocate frame-relative lvalues. The resume rebuilds this slice at a
+     * DIFFERENT fp, so a T_LVALUE pointing into it (a foreach loop variable
+     * is the common one) would be stale on arrival. Held as an OFFSET while
+     * parked, and as a T_NUMBER rather than a T_LVALUE carrying an offset in
+     * its pointer, so nothing in between -- free_svalue on the frame, the
+     * debug ref checker's mark_svalue -- can be handed a pointer that no
+     * longer addresses anything. The scan above has already refused every
+     * lvalue kind that is NOT relocatable this way. */
+    for (int i = 0; i < n; i++) {
+      if (coro->frame[i].type != T_LVALUE) {
+        continue;
+      }
+      coro->frame_lvalues.push_back(i);
+      coro->frame[i].type = T_NUMBER;
+      coro->frame[i].subtype = 0;
+      coro->frame[i].u.number = coro->frame[i].u.lvalue - fp;
+    }
   }
+
+#ifdef DEBUG
+  /* The foreach temporaries above fp leave the stack with the frame, so the
+   * global count hands its body-owned part over to the coroutine and drops
+   * back to what the enclosing frames legitimately have. */
+  coro->temporaries = stack_in_use_as_temporary - g_coroutine_temp_base;
+  stack_in_use_as_temporary = g_coroutine_temp_base;
+#endif
 
   /* registered from the moment it exists: every free_coroutine() erases */
   g_live_coroutines[coro->id] = coro;

--- a/src/vm/internal/base/promise.cc
+++ b/src/vm/internal/base/promise.cc
@@ -10,6 +10,7 @@
 #include "thirdparty/scope_guard/scope_guard.hpp"  // DEFER
 #include "vm/internal/eval_limit.h"
 #include "vm/internal/simulate.h"  // throw_error (cancellation raise)
+#include "include/promise.h"  // LPC-visible rejection reasons
 
 /*
  * Native LPC promises (issue #1319 phase 1). See promise.h for the ownership
@@ -210,14 +211,14 @@ constexpr LPC_INT kDefaultDrainBudgetUs = 1000;
  * They previously differed in wording and in whether they carried a trailing
  * newline. No trailing newline: this is a value handed to a rejection
  * handler, not a message printed by error(). */
-constexpr const char* kDestructedRejection = "*async function owner was destructed while suspended";
+constexpr const char* kDestructedRejection = PROMISE_REASON_DESTRUCTED;
 /* What a cancelled body's next await raises, and what its promise rejects
  * with if nothing catches it. Matched by CONTENT, like every other reason in
  * this family -- a plain string is forgeable by throw(), which is accepted:
  * discriminating cancellation authoritatively would need a driver-reserved
  * value kind, and promise_status() already answers the question from
  * outside. */
-constexpr const char* kCancelledRejection = "*async function cancelled";
+constexpr const char* kCancelledRejection = PROMISE_REASON_CANCELLED;
 
 /* Consecutive slices that ended with work still queued. Routine under load;
  * a long run of them means the queue is not keeping up. Reset by any slice
@@ -1083,9 +1084,9 @@ void resume_coroutine(lpc_coroutine_t* coro, promise_t* source) {
     if (coro->ob->flags & O_DESTRUCTED) {
       err.u.string = const_cast<char*>(kDestructedRejection);
     } else if (coro->prog_generation != coro->ob->prog_generation) {
-      err.u.string = "*async function owner was recompiled while suspended";
+      err.u.string = PROMISE_REASON_RECOMPILED;
     } else {
-      err.u.string = "*async function owner's program was replaced while suspended";
+      err.u.string = PROMISE_REASON_REPLACED_PROGRAM;
     }
     free_coroutine(coro, &err, true);
     return;
@@ -1125,7 +1126,7 @@ void resume_coroutine(lpc_coroutine_t* coro, promise_t* source) {
     svalue_t err;
     err.type = T_STRING;
     err.subtype = STRING_CONSTANT;
-    err.u.string = "*stack overflow while resuming async function";
+    err.u.string = PROMISE_REASON_STACK_OVERFLOW;
     free_coroutine(coro, &err, true);
     return;
   }
@@ -1481,7 +1482,7 @@ void dealloc_promise(promise_t* p) {
           svalue_t err;
           err.type = T_STRING;
           err.subtype = STRING_CONSTANT;
-          err.u.string = "*promise adoption source was collected before settling";
+          err.u.string = PROMISE_REASON_ADOPTION_COLLECTED;
           (void)promise_settle(r.next, &err, 1);
         }
         free_promise(r.next);
@@ -1495,7 +1496,7 @@ void dealloc_promise(promise_t* p) {
         svalue_t err;
         err.type = T_STRING;
         err.subtype = STRING_CONSTANT;
-        err.u.string = "*awaited promise was collected before settling";
+        err.u.string = PROMISE_REASON_AWAITED_COLLECTED;
         free_coroutine(r.coro, &err, false);
       }
       if (r.comb) {
@@ -1507,7 +1508,7 @@ void dealloc_promise(promise_t* p) {
         svalue_t err;
         err.type = T_STRING;
         err.subtype = STRING_CONSTANT;
-        err.u.string = "*promise was collected before settling";
+        err.u.string = PROMISE_REASON_COLLECTED;
         deliver_combinator(r.comb, r.comb_index, &err, true);
         free_combinator(r.comb);
       }
@@ -1550,7 +1551,7 @@ void promise_resolve_with(promise_t* p, svalue_t* value) {
       svalue_t err;
       err.type = T_STRING;
       err.subtype = STRING_CONSTANT;
-      err.u.string = "*promise resolved with itself";
+      err.u.string = PROMISE_REASON_SELF_RESOLVED;
       promise_settle(p, &err, 1);
       return;
     }
@@ -1721,7 +1722,7 @@ promise_t* promise_combinator_start(uint8_t kind, array_t* inputs) {
       svalue_t err = const0;
       err.type = T_STRING;
       err.subtype = STRING_CONSTANT;
-      err.u.string = "*promise_any: no promises to wait for";
+      err.u.string = PROMISE_REASON_ANY_EMPTY;
       (void)promise_settle(result, &err, 1);
     } else {
       svalue_t empty = const0;
@@ -2528,7 +2529,7 @@ void promise_cleanup() {
     svalue_t err;
     err.type = T_STRING;
     err.subtype = STRING_CONSTANT;
-    err.u.string = "*async_yield never ran: the driver shut down";
+    err.u.string = PROMISE_REASON_YIELD_SHUTDOWN;
     (void)promise_settle(p, &err, 1);
     free_promise(p);
   }

--- a/src/vm/internal/base/promise.cc
+++ b/src/vm/internal/base/promise.cc
@@ -84,7 +84,8 @@ promise_t* g_coroutine_promise = nullptr;
 int g_coroutine_temp_base = 0;
 #endif
 
-void free_coroutine(lpc_coroutine_t* coro, svalue_t* reject_with, bool run_lpc);
+void free_coroutine(lpc_coroutine_t* coro, svalue_t* reject_with, bool run_lpc,
+                    bool from_cancel = false);
 bool run_coroutine_body(char* entry_pc, promise_t* p, control_stack_t* async_frame,
                         int resumed_temp_base = -1);
 
@@ -595,10 +596,7 @@ void deliver_reaction(QueuedReaction* qr) {
     /* pass-through: propagate the source's state to the chained promise */
     if (qr->next) {
       if (rejected) {
-        if (src->from_cancel) {
-          qr->next->from_cancel = true;
-        }
-        promise_settle(qr->next, &src->result, 1);
+        promise_settle(qr->next, &src->result, 1, src->from_cancel);
       } else {
         promise_resolve_with(qr->next, &src->result);
       }
@@ -928,14 +926,10 @@ bool run_coroutine_body(char* entry_pc, promise_t* p, control_stack_t* async_fra
         } catch (const char*) {
         }
         if (unwound) {
-          /* The body caught the raise. If this was a cancellation, it was
-           * declined -- later settlement is ordinary fulfill or reject, not
-           * PROMISE_CANCELLED. Matched by the driver's constant pointer, not
-           * by string content: a mudlib throw of the same letters is a
-           * rejection. */
-          if (catch_value.type == T_STRING && catch_value.u.string == kCancelledRejection) {
-            p->from_cancel = false;
-          }
+          /* Declined: later settlement is ordinary fulfill or reject. Do
+           * not stamp from_cancel here -- catch_value has already been
+           * replaced by unwind_to_acatch_marker(), and from_cancel is a
+           * settle-time fact anyway. */
           continue;
         }
       }
@@ -943,7 +937,16 @@ bool run_coroutine_body(char* entry_pc, promise_t* p, control_stack_t* async_fra
       svalue_t err = catch_value;
       catch_value = const1;
       restore_context(&econ);
-      (void)promise_settle(p, &err, 1);
+#ifdef DEBUG
+      /* do_catch() parity: restore_context() does not carry the foreach
+       * temporary counter. An uncaught error inside foreach would otherwise
+       * leave it elevated and silently disable break_point()'s stack check. */
+      stack_in_use_as_temporary = g_coroutine_temp_base;
+#endif
+      /* Settle-time cancel: only the driver's constant pointer, never a
+       * pre-stamped flag that would outlive a declined cancel. */
+      (void)promise_settle(p, &err, 1,
+                           err.type == T_STRING && err.u.string == kCancelledRejection);
       free_svalue(&err, "run_coroutine_body");
       too_deep_error = 0;
       if (max_eval_error) {
@@ -973,7 +976,8 @@ void discard_defer_list(struct defer_list* d) {
  * are discarded. `reject_with`, if non-null, rejects the result promise
  * (promise_settle only queues -- no LPC runs synchronously, so this is
  * safe from deallocation paths too). */
-void free_coroutine(lpc_coroutine_t* coro, svalue_t* reject_with, bool run_lpc) {
+void free_coroutine(lpc_coroutine_t* coro, svalue_t* reject_with, bool run_lpc,
+                    bool from_cancel) {
   /* Latched before free_object() below nulls coro->ob: the owner index is
    * keyed on that pointer, and losing it would strand the entry -- so the
    * object's next destruct would find no frames and skip abandoning them.
@@ -1053,7 +1057,7 @@ void free_coroutine(lpc_coroutine_t* coro, svalue_t* reject_with, bool run_lpc) 
     coro->frame = nullptr;
   }
   if (reject_with) {
-    (void)promise_settle(coro->result_promise, reject_with, 1);
+    (void)promise_settle(coro->result_promise, reject_with, 1, from_cancel);
   }
   free_promise(coro->result_promise);
   free_object(&coro->ob, "free_coroutine");
@@ -1146,10 +1150,7 @@ void resume_coroutine(lpc_coroutine_t* coro, promise_t* source) {
     /* no acatch() region spans the await: the rejection propagates
      * straight to the coroutine's own promise, no need to rebuild the
      * frame at all (no catch may span an await by construction). */
-    if (source->from_cancel || reason == &cancel_reason) {
-      coro->result_promise->from_cancel = true;
-    }
-    free_coroutine(coro, reason, true);
+    free_coroutine(coro, reason, true, source->from_cancel || reason == &cancel_reason);
     return;
   }
 
@@ -1295,13 +1296,8 @@ void resume_coroutine(lpc_coroutine_t* coro, promise_t* source) {
     entry = coro->prog->program + coro->pc_offset;
   } else {
     /* re-raise at the await point; the innermost acatch() catches it.
-     * Catching THIS body's own cancel (reason == &cancel_reason) declines
-     * it -- later settlement is ordinary. An inherited cancelled await is
-     * just a catchable rejection here; from_cancel was never set on this
-     * result. */
-    if (reason == &cancel_reason) {
-      coro->result_promise->from_cancel = false;
-    }
+     * Catching THIS body's own cancel declines it -- later settlement is
+     * ordinary because from_cancel is recorded only when settle wins. */
     assign_svalue(&catch_value, reason);
     entry = unwind_to_acatch_marker(csp);
   }
@@ -1573,9 +1569,9 @@ void dealloc_promise(promise_t* p) {
   FREE(p);
 }
 
-int promise_settle(promise_t* p, svalue_t* value, int rejected) {
+int promise_settle(promise_t* p, svalue_t* value, int rejected, bool from_cancel) {
   if (p->state != PROMISE_PENDING) {
-    return 0; /* first settle wins */
+    return 0; /* first settle wins -- do not rewrite from_cancel */
   }
   if (rejected && p->reject_origin == nullptr) {
     p->reject_origin = capture_reject_origin();
@@ -1585,9 +1581,12 @@ int promise_settle(promise_t* p, svalue_t* value, int rejected) {
   } else {
     promise_clear_cancel_handler(p);
   }
+  /* Record the bit only when this settle wins. A late combinator input or
+   * a declined cancel must not flip an already-decided promise. */
+  p->from_cancel = rejected && from_cancel;
   if (!rejected) {
     p->state = PROMISE_FULFILLED;
-  } else if (p->from_cancel) {
+  } else if (from_cancel) {
     p->state = PROMISE_CANCELLED;
   } else {
     p->state = PROMISE_REJECTED;
@@ -1709,18 +1708,12 @@ void deliver_combinator(promise_combinator_t* c, int index, svalue_t* value, boo
   switch (c->kind) {
     case PROMISE_COMB_RACE:
       /* first to settle decides, either way */
-      if (rejected && from_cancel) {
-        c->result->from_cancel = true;
-      }
-      (void)promise_settle(c->result, value, rejected ? 1 : 0);
+      (void)promise_settle(c->result, value, rejected ? 1 : 0, rejected && from_cancel);
       break;
 
     case PROMISE_COMB_ALL:
       if (rejected) {
-        if (from_cancel) {
-          c->result->from_cancel = true;
-        }
-        (void)promise_settle(c->result, value, 1); /* fail fast */
+        (void)promise_settle(c->result, value, 1, from_cancel); /* fail fast */
       } else {
         assign_svalue(&c->slots->item[index], value);
       }
@@ -1878,12 +1871,12 @@ int promise_request_cancel(promise_t* p) {
   }
 
   p->cancelled = true;
-  /* The canceller has forced the outcome, so the rejection below is not
-   * "unhandled" even if nobody attached a handler; without this a
-   * fire-and-forget cancel logs a rejection report when the promise dies.
-   * from_cancel travels with the reason to every downstream link. */
-  p->handled = true;
-  p->from_cancel = true;
+  /* Do not stamp from_cancel or handled here. from_cancel is a settle-time
+   * fact: a body that declines the raise and then faults (or returns) must
+   * not be recorded as PROMISE_CANCELLED, and a declined cancel must not
+   * suppress a later unhandled-rejection report. Fire-and-forget cancel
+   * still skips that report because dealloc_promise() keys on from_cancel
+   * of the winning settle. */
 
   /* Find the parked frame, if there is one. A linear scan over at most
    * `max suspended async functions` entries, on a rare user-initiated efun.
@@ -1934,7 +1927,7 @@ int promise_request_cancel(promise_t* p) {
   reason.type = T_STRING;
   reason.subtype = STRING_CONSTANT;
   reason.u.string = kCancelledRejection;
-  (void)promise_settle(s, &reason, 1);
+  (void)promise_settle(s, &reason, 1, true);
   /* nothing will attach a handler to a promise only the driver can see */
   s->handled = true;
   coro->awaiting = s;

--- a/src/vm/internal/base/promise.h
+++ b/src/vm/internal/base/promise.h
@@ -107,6 +107,14 @@ struct promise_t {
    * and a body running its first synchronous stretch has no coroutine at
    * all. */
   bool cancelled;
+  /* This rejection exists because a cancellation propagated here -- either
+   * this promise is the cancelled body, or it inherited that body's reason
+   * through await / then / adoption / a combinator. dealloc_promise() skips
+   * the unhandled-rejection report: cancel is a delivered outcome, not a
+   * fault, and stamping handled on the target alone left every downstream
+   * link to spam the driver log (PR #1353). Copied with the reason, not
+   * inferred from the string, which a mudlib can forge. */
+  bool from_cancel;
   /* the declared payload tag of an `async T f()`'s promise, as the runtime
    * T_* mask (0 = unannotated, e.g. promise_create()). The authoritative
    * copy lives in the svalue's subtype -- this is the record that survives

--- a/src/vm/internal/base/promise.h
+++ b/src/vm/internal/base/promise.h
@@ -30,11 +30,10 @@
  * any value.
  */
 
-enum : uint8_t {
-  PROMISE_PENDING = 0,
-  PROMISE_FULFILLED = 1,
-  PROMISE_REJECTED = 2,
-};
+/* The state codes are LPC-visible (promise_status() returns them), so they
+ * are defined in include/promise.h and shared with the mudlib rather than
+ * duplicated here. */
+#include "include/promise.h"
 
 /* promise_all() / promise_any() / promise_race() / promise_all_settled() */
 enum : uint8_t {

--- a/src/vm/internal/base/promise.h
+++ b/src/vm/internal/base/promise.h
@@ -107,13 +107,15 @@ struct promise_t {
    * and a body running its first synchronous stretch has no coroutine at
    * all. */
   bool cancelled;
-  /* This rejection exists because a cancellation propagated here -- either
-   * this promise is the cancelled body, or it inherited that body's reason
-   * through await / then / adoption / a combinator. dealloc_promise() skips
-   * the unhandled-rejection report: cancel is a delivered outcome, not a
-   * fault, and stamping handled on the target alone left every downstream
-   * link to spam the driver log (PR #1353). Copied with the reason, not
-   * inferred from the string, which a mudlib can forge. */
+  /* This settlement is a cancellation -- either this promise is the
+   * cancelled body, or it inherited that body's reason through await / then
+   * / adoption / a combinator. promise_settle() records PROMISE_CANCELLED
+   * rather than PROMISE_REJECTED when the bit is set, which is what
+   * promise_status() returns. dealloc_promise() also skips the unhandled-
+   * rejection report: cancel is a delivered outcome, not a fault, and
+   * stamping handled on the target alone left every downstream link to spam
+   * the driver log (PR #1353). Copied with the reason, not inferred from
+   * the string, which a mudlib can forge. */
   bool from_cancel;
   /* the declared payload tag of an `async T f()`'s promise, as the runtime
    * T_* mask (0 = unannotated, e.g. promise_create()). The authoritative

--- a/src/vm/internal/base/promise.h
+++ b/src/vm/internal/base/promise.h
@@ -109,13 +109,12 @@ struct promise_t {
   bool cancelled;
   /* This settlement is a cancellation -- either this promise is the
    * cancelled body, or it inherited that body's reason through await / then
-   * / adoption / a combinator. promise_settle() records PROMISE_CANCELLED
-   * rather than PROMISE_REJECTED when the bit is set, which is what
-   * promise_status() returns. dealloc_promise() also skips the unhandled-
-   * rejection report: cancel is a delivered outcome, not a fault, and
-   * stamping handled on the target alone left every downstream link to spam
-   * the driver log (PR #1353). Copied with the reason, not inferred from
-   * the string, which a mudlib can forge. */
+   * / adoption / a combinator. Set only when promise_settle() WINS, never
+   * at cancel-request time: a declined cancel (acatch then a later fault
+   * or return) must settle as ordinary fulfill/reject, and a late input
+   * on an already-settled combinator must not flip this bit. Copied with
+   * the reason, not inferred from the string, which a mudlib can forge.
+   * dealloc_promise() skips the unhandled-rejection report when set. */
   bool from_cancel;
   /* the declared payload tag of an `async T f()`'s promise, as the runtime
    * T_* mask (0 = unannotated, e.g. promise_create()). The authoritative
@@ -151,8 +150,10 @@ void free_promise(promise_t* p);
 void dealloc_promise(promise_t* p);
 
 /* First settle wins: returns 1 if this call settled the promise, 0 if it was
- * already settled (the value is not consumed in that case). */
-int promise_settle(promise_t* p, svalue_t* value, int rejected);
+ * already settled (the value is not consumed in that case, and from_cancel
+ * is not written). A winning rejection with from_cancel records
+ * PROMISE_CANCELLED rather than PROMISE_REJECTED. */
+int promise_settle(promise_t* p, svalue_t* value, int rejected, bool from_cancel = false);
 /* Fulfill with a plain value, or adopt the eventual state of a promise value
  * (flattening). Self-resolution rejects the promise. */
 void promise_resolve_with(promise_t* p, svalue_t* value);

--- a/src/vm/internal/base/promise.h
+++ b/src/vm/internal/base/promise.h
@@ -202,6 +202,20 @@ struct lpc_coroutine_acatch_t {
   int pc_offset; /* continuation (code after the region), relative to prog->program */
   int sp_offset; /* value-stack top at region entry, relative to fp */
   struct defer_list* defers;
+#ifdef DEBUG
+  /* The frame's recorded foreach-temporaries count (control_stack_t::
+   * save_temporaries), relative to the BODY's base -- relative for exactly
+   * the reason sp_offset is relative to fp: the absolute value is meaningless
+   * once the frame is rebuilt on a resume, where the base is different.
+   *
+   * Without carrying it, resume_coroutine() re-pushes these markers AFTER it
+   * has added the body's temporaries back, so each frame records the inflated
+   * count instead of the one at region entry -- and an error unwinding to the
+   * region then restores the counter to that, leaving it high by however many
+   * loops were open inside the region. `acatch { foreach (...) { await p;
+   * error(); } }` is the shape. */
+  int temporaries_offset = 0;
+#endif
 };
 
 struct lpc_coroutine_t {

--- a/src/vm/internal/base/promise.h
+++ b/src/vm/internal/base/promise.h
@@ -36,12 +36,39 @@ enum : uint8_t {
   PROMISE_REJECTED = 2,
 };
 
+/* promise_all() / promise_any() / promise_race() / promise_all_settled() */
+enum : uint8_t {
+  PROMISE_COMB_ALL = 0,
+  PROMISE_COMB_ANY = 1,
+  PROMISE_COMB_RACE = 2,
+  PROMISE_COMB_ALL_SETTLED = 3,
+};
+
+/* Aggregation state shared by every input reaction of ONE combinator call.
+ * Ref-counted with one reference per outstanding input reaction, so it dies
+ * with the last of them however they end (delivered, or dropped at shutdown).
+ *
+ * It is an OFF-GRAPH holder of `result` and `slots` (AGENTS.md section 3):
+ * reachable only from reaction records, and reachable from SEVERAL of them at
+ * once. That is why the debug ref checker marks it from its own registry
+ * rather than from each reaction -- marking per reaction would bump
+ * extra_ref once per input against a single real reference. */
+struct promise_combinator_t {
+  uint32_t ref;
+  uint8_t kind;             /* PROMISE_COMB_* */
+  struct promise_t* result; /* ref held; settled when the rule below is met */
+  struct array_t* slots;    /* ref held; one entry per input, filled in place */
+  int remaining;            /* inputs not yet settled */
+};
+
 struct promise_reaction_t {
   struct funptr_t* on_fulfilled;    /* ref held; may be null (pass-through) */
   struct funptr_t* on_rejected;     /* ref held; may be null (pass-through) */
   struct promise_t* next;           /* ref held; chained promise to settle; may be null */
   struct object_t* command_giver;   /* ref held; may be null */
   struct lpc_coroutine_t* coro;     /* owned; a parked await to resume; may be null */
+  struct promise_combinator_t* comb; /* ref held; may be null */
+  int comb_index;                   /* which input of `comb` this reaction is */
 };
 
 struct promise_t {
@@ -118,6 +145,13 @@ void promise_add_reaction(promise_t* p, funptr_t* on_fulfilled, funptr_t* on_rej
                           promise_t* next, object_t* giver);
 
 void push_refed_promise(promise_t* p);
+
+/* Build a combinator over `inputs` and return its result promise with one
+ * reference for the caller. An element that is not a promise counts as
+ * already fulfilled with itself (so the output of an ordinary map() works).
+ * Never settles the result before the caller receives it unless every input
+ * was a plain value. */
+promise_t* promise_combinator_start(uint8_t kind, struct array_t* inputs);
 
 /* A promise fulfilled with 0 on the next pass of the event loop -- after the
  * driver has polled sockets, queued commands and fired due timers. This is

--- a/src/vm/internal/base/promise.h
+++ b/src/vm/internal/base/promise.h
@@ -235,6 +235,16 @@ struct lpc_coroutine_t {
   struct defer_list* defers; /* the async frame's defers */
   svalue_t* frame;           /* owned bitwise copy of [fp .. sp] */
   int frame_size;
+  /* Slots of `frame` that held a T_LVALUE pointing INTO the frame -- a
+   * foreach loop variable, typically. The resume rebuilds the slice at a
+   * different fp, so those are stored as offsets (and as T_NUMBER, so no
+   * stale pointer exists at any point) and re-derived on arrival. */
+  std::vector<int> frame_lvalues;
+#ifdef DEBUG
+  /* open foreach loops whose temporaries travel inside `frame`. Handed back
+   * to the global counter on resume; see g_coroutine_temp_base. */
+  int temporaries;
+#endif
   /* True from the moment a settle hands this coroutine to the microtask queue
    * until the delivery consumes it. Ownership has moved to the queue by then,
    * so destruct-time abandonment must leave it alone -- freeing it would

--- a/src/vm/internal/base/promise.h
+++ b/src/vm/internal/base/promise.h
@@ -98,6 +98,16 @@ struct promise_t {
    * state unreachable by never handing out an async function's resolver;
    * here promises are first-class, so the refusal has to be explicit. */
   bool body_owned;
+  /* A cancellation has been requested on this async body and not yet
+   * delivered. CONSUME-ONCE: the raise clears it, so a body that catches its
+   * cancellation in acatch() can still await cleanup and even return a value
+   * -- cancel is a request the body may decline, not a verdict. Lives on the
+   * promise rather than on lpc_coroutine_t because the promise is the only
+   * LPC-reachable handle AND the durable identity of the body across all its
+   * parks: each park allocates a fresh coroutine and each resume frees it,
+   * and a body running its first synchronous stretch has no coroutine at
+   * all. */
+  bool cancelled;
   /* the declared payload tag of an `async T f()`'s promise, as the runtime
    * T_* mask (0 = unannotated, e.g. promise_create()). The authoritative
    * copy lives in the svalue's subtype -- this is the record that survives
@@ -152,6 +162,12 @@ void push_refed_promise(promise_t* p);
  * Never settles the result before the caller receives it unless every input
  * was a plain value. */
 promise_t* promise_combinator_start(uint8_t kind, struct array_t* inputs);
+
+/* Request cancellation of the async function body that owns `p`. Returns 1
+ * if a cancellation was armed, 0 if there was nothing left to cancel (the
+ * body already finished, or its fate is already committed to an adoption).
+ * error()s if `p` is not an async function's promise. Runs no LPC. */
+int promise_request_cancel(promise_t* p);
 
 /* A promise fulfilled with 0 on the next pass of the event loop -- after the
  * driver has polled sockets, queued commands and fired due timers. This is

--- a/src/vm/internal/base/svalue.cc
+++ b/src/vm/internal/base/svalue.cc
@@ -274,6 +274,8 @@ json svalue_to_json_summary(const svalue_t* obj, int depth) {
           return "promise (fulfilled)";
         case PROMISE_REJECTED:
           return "promise (rejected)";
+        case PROMISE_CANCELLED:
+          return "promise (cancelled)";
         default:
           return "promise (pending)";
       }

--- a/testsuite/single/tests/efuns/async_foreach.lpc
+++ b/testsuite/single/tests/efuns/async_foreach.lpc
@@ -84,6 +84,34 @@ private async int ref_loopvar() {
   return 0;
 }
 
+// Every gate above is resolved before its await, so all of those resumes
+// land in the one drain turn. Here each iteration parks and comes back in a
+// LATER backend turn, which is what exercises the per-frame handover of the
+// count owed for an open foreach: it goes to the coroutine at each park and
+// comes back at each resume, and a base taken on the wrong side of that
+// leaves the count elevated for whatever runs next.
+private promise next_turn(int v) {
+  promise p = promise_create();
+
+  // The locals travel as call_out arguments: an anonymous function body is
+  // not a closure over the enclosing frame.
+  call_out(function(promise target, int with) {
+    promise_resolve(target, with);
+  }, 1, p, v);
+
+  return p;
+}
+
+private async int sum_across_turns() {
+  int total;
+
+  foreach (int i in ({ 1, 2, 3 })) {
+    total += i * await next_turn(2);
+  }
+
+  return total;
+}
+
 void do_tests() {
   gate = promise_create();
   promise_resolve(gate, 2);
@@ -110,6 +138,16 @@ void do_tests() {
   promise_then(nested(), function(mixed v) {
     ASSERT_EQ(180, v);  // (10+20+20+40) * 2
     RELEASE_LATCH("nested");
+  });
+
+  // Deferred by construction: master::flag() sits on the stack for the whole
+  // run, so the first call_out cannot fire until the suite is over -- which
+  // is exactly the point. The latch is the counted signal (a check inside a
+  // post-run callback is printed but not tallied).
+  EXPECT_LATCH("cross-turn");
+  promise_then(sum_across_turns(), function(mixed v) {
+    ASSERT_EQ(12, v);  // (1+2+3) * 2, one park per iteration
+    RELEASE_LATCH("cross-turn");
   });
 
   // Still refused, with a diagnostic that now says which shapes are the

--- a/testsuite/single/tests/efuns/async_foreach.lpc
+++ b/testsuite/single/tests/efuns/async_foreach.lpc
@@ -1,0 +1,130 @@
+// `await` inside a foreach loop.
+//
+// Every foreach pushes a T_LVALUE for its loop variable (interpret.cc's
+// F_FOREACH, the branch after the iterable setup), and the suspension used
+// to refuse ANY lvalue on the stack -- so an await was illegal in every
+// foreach shape, including the plain local-variable one.
+//
+// A loop variable's lvalue addresses a slot INSIDE the frame, and the frame
+// is exactly what parking copies and rebuilds. So it is relocatable: held as
+// an offset across the suspension and re-derived against the new fp. What
+// stays refused is the rest, for reasons that differ:
+//
+//   * a GLOBAL loop variable's lvalue points into the object's variable
+//     block -- a second relocation base, not attempted here;
+//   * a `ref` loop variable owns heap state tied to the C++ frame;
+//   * string-char and buffer-byte lvalues are backed by SHARED VM globals
+//     (AGENTS.md 13.9), one instance at a time by construction, so they can
+//     never be per-frame state and are refused permanently.
+
+#include "/include/tests.h"
+
+nosave promise gate;
+nosave int g_loopvar;
+
+private async int sum_array() {
+  int total;
+
+  foreach (int i in ({ 1, 2, 3 })) {
+    total += i * await gate;
+  }
+
+  return total;
+}
+
+private async string cat_string() {
+  string out = "";
+
+  foreach (int c in "abc") {
+    await gate;
+    out += sprintf("%c", c);
+  }
+
+  return out;
+}
+
+private async int sum_mapping() {
+  int total;
+
+  foreach (string k, int v in ([ "a": 1, "b": 2 ])) {
+    total += v * await gate;
+    total += strlen(k);
+  }
+
+  return total;
+}
+
+private async int nested() {
+  int total;
+
+  foreach (int i in ({ 1, 2 })) {
+    foreach (int j in ({ 10, 20 })) {
+      total += (i * j) * await gate;
+    }
+  }
+
+  return total;
+}
+
+private async int global_loopvar() {
+  foreach (g_loopvar in ({ 1, 2 })) {
+    await gate;
+  }
+
+  return 0;
+}
+
+private async int ref_loopvar() {
+  int *a = ({ 1, 2 });
+
+  foreach (int ref x in a) {
+    x = await gate;
+  }
+
+  return 0;
+}
+
+void do_tests() {
+  gate = promise_create();
+  promise_resolve(gate, 2);
+
+  EXPECT_LATCH("array");
+  promise_then(sum_array(), function(mixed v) {
+    ASSERT_EQ(12, v);  // (1+2+3) * 2
+    RELEASE_LATCH("array");
+  });
+
+  EXPECT_LATCH("string");
+  promise_then(cat_string(), function(mixed v) {
+    ASSERT_EQ("abc", v);
+    RELEASE_LATCH("string");
+  });
+
+  EXPECT_LATCH("mapping");
+  promise_then(sum_mapping(), function(mixed v) {
+    ASSERT_EQ(8, v);  // (1+2)*2 + 1 + 1
+    RELEASE_LATCH("mapping");
+  });
+
+  EXPECT_LATCH("nested");
+  promise_then(nested(), function(mixed v) {
+    ASSERT_EQ(180, v);  // (10+20+20+40) * 2
+    RELEASE_LATCH("nested");
+  });
+
+  // Still refused, with a diagnostic that now says which shapes are the
+  // problem rather than blaming foreach as a whole.
+  EXPECT_LATCH("global-refused");
+  promise_catch(global_loopvar(), function(mixed reason) {
+    ASSERT2(stringp(reason) && strsrch(reason, "GLOBAL loop variable") != -1,
+      "a global loop variable is refused, and named: " + reason);
+    RELEASE_LATCH("global-refused");
+  });
+
+  EXPECT_LATCH("ref-refused");
+  promise_catch(ref_loopvar(), function(mixed reason) {
+    ASSERT2(stringp(reason) && strsrch(reason, "cannot suspend") != -1,
+      "a ref loop variable is refused: " + reason);
+    RELEASE_LATCH("ref-refused");
+  });
+}

--- a/testsuite/single/tests/efuns/async_foreach.lpc
+++ b/testsuite/single/tests/efuns/async_foreach.lpc
@@ -168,6 +168,38 @@ private async int loop_error() {
   return total;
 }
 
+/* An acatch region wrapping a foreach that awaits, erroring after the
+ * resume. The region's marker frame is rebuilt at the resume, and the count
+ * of temporaries it was entered with has to be rebuilt with it -- the frame
+ * comes back on a different base, so the recorded value travels relative to
+ * that base (lpc_coroutine_acatch_t::temporaries_offset). The miscount is not
+ * observable from LPC (an over-count only stops break_point() checking), so
+ * this pins the path itself: the error is caught by the acatch, the body
+ * carries on, and the loop after it still runs. */
+private async int acatch_over_loop() {
+  mixed err;
+  int total;
+
+  err = acatch {
+    foreach (int i in ({ 1, 2, 3 })) {
+      total += await gate;
+      if (i == 2) {
+        error("caught inside the loop");
+      }
+    }
+  };
+
+  if (!err) {
+    return -1;
+  }
+
+  foreach (int j in ({ 10, 20 })) {
+    total += j * await gate;
+  }
+
+  return total;
+}
+
 void do_tests() {
   gate = promise_create();
   promise_resolve(gate, 2);
@@ -229,6 +261,13 @@ void do_tests() {
     ASSERT2(stringp(reason) && strsrch(reason, "boom in loop") != -1,
       "an error after a resume unwinds out of the open foreach: " + reason);
     RELEASE_LATCH("loop-error");
+  });
+
+  EXPECT_LATCH("acatch-loop");
+  promise_then(acatch_over_loop(), function(mixed v) {
+    // 2+2 from the two iterations before the error, then (10+20)*2
+    ASSERT_EQ(64, v);
+    RELEASE_LATCH("acatch-loop");
   });
 
   // Still refused, with a diagnostic that now says which shapes are the

--- a/testsuite/single/tests/efuns/async_foreach.lpc
+++ b/testsuite/single/tests/efuns/async_foreach.lpc
@@ -112,6 +112,62 @@ private async int sum_across_turns() {
   return total;
 }
 
+/* Leaving a foreach EARLY across a suspension. Each of these emits one
+ * F_EXIT_FOREACH per open loop (icode.cc), which is what retires the loop's
+ * temporaries; a resumed frame has to reach them the same way an ordinary
+ * one does. `return` from inside the loop skips the loop's own exit path,
+ * so it is the one worth pinning separately. */
+private async int loop_break() {
+  int total;
+
+  foreach (int i in ({ 1, 2, 3, 4 })) {
+    total += i * await gate;
+    if (i == 2) {
+      break;
+    }
+  }
+
+  return total;
+}
+
+private async int loop_continue() {
+  int total;
+
+  foreach (int i in ({ 1, 2, 3, 4 })) {
+    if (i == 2) {
+      continue;
+    }
+    total += i * await gate;
+  }
+
+  return total;
+}
+
+private async int loop_return() {
+  foreach (int i in ({ 1, 2, 3 })) {
+    if (await gate) {
+      return i * 10;
+    }
+  }
+
+  return -1;
+}
+
+/* An error raised after a resume, inside the loop: it unwinds through the
+ * open foreach and out of the body, rejecting the result promise. */
+private async int loop_error() {
+  int total;
+
+  foreach (int i in ({ 1, 2, 3 })) {
+    total += await gate;
+    if (i == 2) {
+      error("boom in loop");
+    }
+  }
+
+  return total;
+}
+
 void do_tests() {
   gate = promise_create();
   promise_resolve(gate, 2);
@@ -148,6 +204,31 @@ void do_tests() {
   promise_then(sum_across_turns(), function(mixed v) {
     ASSERT_EQ(12, v);  // (1+2+3) * 2, one park per iteration
     RELEASE_LATCH("cross-turn");
+  });
+
+  EXPECT_LATCH("break");
+  promise_then(loop_break(), function(mixed v) {
+    ASSERT_EQ(6, v);  // (1+2) * 2
+    RELEASE_LATCH("break");
+  });
+
+  EXPECT_LATCH("continue");
+  promise_then(loop_continue(), function(mixed v) {
+    ASSERT_EQ(16, v);  // (1+3+4) * 2
+    RELEASE_LATCH("continue");
+  });
+
+  EXPECT_LATCH("return");
+  promise_then(loop_return(), function(mixed v) {
+    ASSERT_EQ(10, v);
+    RELEASE_LATCH("return");
+  });
+
+  EXPECT_LATCH("loop-error");
+  promise_catch(loop_error(), function(mixed reason) {
+    ASSERT2(stringp(reason) && strsrch(reason, "boom in loop") != -1,
+      "an error after a resume unwinds out of the open foreach: " + reason);
+    RELEASE_LATCH("loop-error");
   });
 
   // Still refused, with a diagnostic that now says which shapes are the

--- a/testsuite/single/tests/efuns/promise_cancel.lpc
+++ b/testsuite/single/tests/efuns/promise_cancel.lpc
@@ -112,6 +112,22 @@ private void check_refusals() {
   ASSERT_EQ(0, promise_cancel(done));
 }
 
+/* Cancelling a frame parked inside a NESTED foreach: two loops' worth of
+ * temporaries are handed back at the resume and then thrown through by the
+ * cancellation, which is the shape where the count and the stack have the
+ * most to disagree about. */
+private async int cancel_in_nested_loop() {
+  int total;
+
+  foreach (int i in ({ 1, 2 })) {
+    foreach (int j in ({ 10, 20 })) {
+      total += await never;
+    }
+  }
+
+  return total;
+}
+
 void do_tests() {
   never = promise_create();
   gate = promise_create();
@@ -124,4 +140,16 @@ void do_tests() {
   // Lets recovers()' cleanup await through; `never` is deliberately never
   // settled, which is the whole point of the first three.
   promise_resolve(gate, 9);
+
+  // Parked inside a nested foreach when the cancellation arrives.
+  {
+    promise nested = cancel_in_nested_loop();
+
+    EXPECT_LATCH("cancel-nested");
+    promise_catch(nested, function(mixed reason) {
+      ASSERT_EQ("*async function cancelled", reason);
+      RELEASE_LATCH("cancel-nested");
+    });
+    ASSERT_EQ(1, promise_cancel(nested));
+  }
 }

--- a/testsuite/single/tests/efuns/promise_cancel.lpc
+++ b/testsuite/single/tests/efuns/promise_cancel.lpc
@@ -128,6 +128,118 @@ private async int cancel_in_nested_loop() {
   return total;
 }
 
+// Cancelling a body that another dropped awaiter is waiting on must not
+// print "Unhandled promise rejection" for the downstream link. The
+// canceller stamped handled on the TARGET only; the reason has to carry
+// from_cancel with it (PR #1353). Read the debug log, same channel as
+// unhandled_rejection_locus.lpc.
+
+#define DEBUG_LOG_FILE 10
+#define CANCEL_LOG_TRIES 12
+#define CANCEL_CHUNK_LINES 500
+#define CANCEL_MAX_CHUNKS 400
+
+nosave string cancel_log_marker;
+nosave string cancel_logfile;
+nosave int cancel_log_tries;
+nosave int cancel_log_finished;
+nosave promise inner_p;
+
+private async int cancel_leaf() {
+  await never;
+  return 1;
+}
+
+private async int cancel_waiter() {
+  return await inner_p;
+}
+
+private void cancel_log_done(mixed complaint) {
+  if (cancel_log_finished++) {
+    return;
+  }
+  if (complaint) {
+    ASSERT2(0, complaint);
+  }
+  RELEASE_LATCH("cancel-propagate");
+}
+
+private mixed cancel_scan_after_marker() {
+  int line = 1;
+  int i;
+  int seen_marker = 0;
+  int total = file_size(cancel_logfile);
+
+  if (total < 0) {
+    return 0;
+  }
+
+  for (i = 0; i < CANCEL_MAX_CHUNKS; i++) {
+    string chunk = read_file(cancel_logfile, line, CANCEL_CHUNK_LINES);
+    int at;
+
+    if (!chunk || chunk == "") {
+      break;
+    }
+    if (!seen_marker) {
+      at = strsrch(chunk, cancel_log_marker);
+      if (at == -1) {
+        line += CANCEL_CHUNK_LINES;
+        continue;
+      }
+      seen_marker = 1;
+      chunk = chunk[at..];
+    }
+    if (strsrch(chunk, "Unhandled promise rejection") != -1 &&
+      strsrch(chunk, "*async function cancelled") != -1) {
+      return chunk;
+    }
+    line += CANCEL_CHUNK_LINES;
+  }
+
+  return seen_marker ? "" : 0;
+}
+
+private void cancel_check_log() {
+  mixed hit = cancel_scan_after_marker();
+
+  if (hit == 0) {
+    if (++cancel_log_tries < CANCEL_LOG_TRIES) {
+      call_out((: cancel_check_log :), 1);
+      return;
+    }
+    // Marker never appeared: no debug log we can read. Not a failure.
+    cancel_log_done(0);
+    return;
+  }
+  if (stringp(hit) && hit != "") {
+    cancel_log_done("a cancelled downstream was reported unhandled: " + hit);
+    return;
+  }
+  cancel_log_done(0);
+}
+
+private void check_cancel_propagate() {
+  string configured = get_config(DEBUG_LOG_FILE);
+  promise all;
+
+  if (!stringp(configured) || configured == "") {
+    return;
+  }
+  cancel_logfile = LOG_DIR + "/" + configured;
+  cancel_log_marker = "cancel-propagate-probe-" + time() + "-" + random(1000000);
+  debug_message(cancel_log_marker + "\n");
+
+  EXPECT_LATCH("cancel-propagate");
+  inner_p = cancel_leaf();
+  // Drop the waiter and the combinator: both inherit the cancellation.
+  cancel_waiter();
+  all = promise_all(({ inner_p }));
+  all = 0;
+  ASSERT_EQ(1, promise_cancel(inner_p));
+  call_out((: cancel_check_log :), 1);
+}
+
 void do_tests() {
   never = promise_create();
   gate = promise_create();
@@ -152,4 +264,6 @@ void do_tests() {
     });
     ASSERT_EQ(1, promise_cancel(nested));
   }
+
+  check_cancel_propagate();
 }

--- a/testsuite/single/tests/efuns/promise_cancel.lpc
+++ b/testsuite/single/tests/efuns/promise_cancel.lpc
@@ -1,0 +1,127 @@
+// promise_cancel(): ask an async function body to give up.
+//
+// Cooperative, not preemptive. The body's NEXT await raises a catchable
+// cancellation; a stretch of straight-line code already running finishes
+// first, and a body that never awaits again runs to completion. It unwinds
+// through acatch() and runs defer() handlers like any other rejection.
+//
+// CONSUME-ONCE: the raise clears the request, so a body that catches its
+// cancellation can still await cleanup and even return normally. Cancel is a
+// request the body may decline, not a verdict.
+//
+// The awkward case the machinery exists for is a frame parked on a promise
+// that never settles: waiting for it would mean the cancellation never
+// arrives, so the frame is detached from that promise and its rejection is
+// scheduled directly.
+
+#include "/include/tests.h"
+
+nosave promise never, gate;
+nosave promise held, caught_body, defer_body;
+nosave int body_ran_past_await, defer_ran, cleanup_awaited;
+nosave mixed caught;
+
+// Parked on a promise nothing will ever settle.
+private async int stuck() {
+  await never;
+  body_ran_past_await = 1;
+
+  return 1;
+}
+
+// Catches its own cancellation, then does async cleanup and returns anyway.
+private async int recovers() {
+  mixed err = acatch(await never);
+
+  caught = err;
+  // Consume-once: this second await must NOT re-raise.
+  cleanup_awaited = await gate;
+
+  return 42;
+}
+
+private async int with_defer() {
+  defer(function() { defer_ran = 1; });
+  await never;
+
+  return 0;
+}
+
+private async int quick() { return 3; }
+
+private void check_stuck() {
+  EXPECT_LATCH("stuck");
+  held = stuck();
+  ASSERT_EQ(0, promise_status(held));
+  ASSERT_EQ(1, promise_cancel(held));
+
+  promise_catch(held, function(mixed reason) {
+    ASSERT_EQ("*async function cancelled", reason);
+    ASSERT_EQ(0, body_ran_past_await);
+    ASSERT_EQ(2, promise_status(held));
+    RELEASE_LATCH("stuck");
+  });
+}
+
+private void check_recovers() {
+  EXPECT_LATCH("recovers");
+  caught_body = recovers();
+  ASSERT_EQ(1, promise_cancel(caught_body));
+
+  promise_then(caught_body, function(mixed v) {
+    // The body declined the cancellation: its promise FULFILS.
+    ASSERT_EQ(42, v);
+    ASSERT_EQ("*async function cancelled", caught);
+    ASSERT_EQ(9, cleanup_awaited);
+    RELEASE_LATCH("recovers");
+  });
+}
+
+private void check_defer() {
+  EXPECT_LATCH("defer");
+  defer_body = with_defer();
+  ASSERT_EQ(1, promise_cancel(defer_body));
+
+  promise_catch(defer_body, function(mixed reason) {
+    ASSERT_EQ("*async function cancelled", reason);
+    ASSERT_EQ(1, defer_ran);
+    RELEASE_LATCH("defer");
+  });
+}
+
+private void check_refusals() {
+  mixed err;
+  promise done;
+
+  // Not an async function's promise: refused, loudly.
+  err = catch(promise_cancel(promise_create()));
+  ASSERT2(err, "promise_create() promise cannot be cancelled");
+  ASSERT2(stringp(err) && strsrch(err, "does not belong to an async function") != -1,
+    "the refusal says why: " + err);
+
+  err = catch(promise_cancel(promise_then(promise_create(), function(mixed v) { return v; })));
+  ASSERT2(err, "a then-chain link cannot be cancelled");
+
+  err = catch(promise_cancel(call_out(60)));
+  ASSERT2(err, "a call_out(delay) promise cannot be cancelled");
+
+  // An async body that already finished: 0, not an error. A body racing its
+  // canceller to completion is the normal outcome, not a mistake.
+  done = quick();
+  ASSERT_EQ(1, promise_status(done));
+  ASSERT_EQ(0, promise_cancel(done));
+}
+
+void do_tests() {
+  never = promise_create();
+  gate = promise_create();
+
+  check_stuck();
+  check_recovers();
+  check_defer();
+  check_refusals();
+
+  // Lets recovers()' cleanup await through; `never` is deliberately never
+  // settled, which is the whole point of the first three.
+  promise_resolve(gate, 9);
+}

--- a/testsuite/single/tests/efuns/promise_cancel.lpc
+++ b/testsuite/single/tests/efuns/promise_cancel.lpc
@@ -18,8 +18,10 @@
 
 nosave promise never, gate;
 nosave promise held, caught_body, defer_body;
+nosave promise status_leaf, status_all, status_race, status_settled;
+nosave promise catch_then_fail_p;
 nosave int body_ran_past_await, defer_ran, cleanup_awaited;
-nosave mixed caught;
+nosave mixed caught, declined_caught;
 
 // Parked on a promise nothing will ever settle.
 private async int stuck() {
@@ -49,6 +51,13 @@ private async int with_defer() {
 
 private async int quick() { return 3; }
 
+// Catches its own cancellation, then faults for a different reason.
+// from_cancel must not stick: the settlement is a rejection, not a cancel.
+private async int catch_then_fail() {
+  declined_caught = acatch(await never);
+  error("real fault");
+}
+
 private void check_stuck() {
   EXPECT_LATCH("stuck");
   held = stuck();
@@ -58,7 +67,10 @@ private void check_stuck() {
   promise_catch(held, function(mixed reason) {
     ASSERT_EQ("*async function cancelled", reason);
     ASSERT_EQ(0, body_ran_past_await);
-    ASSERT_EQ(2, promise_status(held));
+    // 3 == PROMISE_CANCELLED (src/include/promise.h). Not 2: cancel is
+    // a negative settlement, not a fault.
+    ASSERT_EQ(3, promise_status(held));
+    ASSERT_EQ("*async function cancelled", promise_result(held));
     RELEASE_LATCH("stuck");
   });
 }
@@ -240,6 +252,45 @@ private void check_cancel_propagate() {
   call_out((: cancel_check_log :), 1);
 }
 
+// PROMISE_CANCELLED == 3. Combinators inherit it: all / race fail-fast as
+// cancelled; all_settled reports status 3 with a reason and no value.
+private void check_cancel_status() {
+  EXPECT_LATCH("cancel-status");
+  status_leaf = cancel_leaf();
+  status_all = promise_all(({ status_leaf }));
+  status_race = promise_race(({ status_leaf }));
+  status_settled = promise_all_settled(({ status_leaf }));
+  ASSERT_EQ(1, promise_cancel(status_leaf));
+
+  promise_then(status_settled, function(mixed v) {
+    ASSERT_EQ(3, promise_status(status_leaf));
+    ASSERT_EQ("*async function cancelled", promise_result(status_leaf));
+    ASSERT_EQ(3, promise_status(status_all));
+    ASSERT_EQ("*async function cancelled", promise_result(status_all));
+    ASSERT_EQ(3, promise_status(status_race));
+    ASSERT_EQ(1, promise_status(status_settled));
+    ASSERT_EQ(3, v[0]["status"]);
+    ASSERT_EQ("*async function cancelled", v[0]["reason"]);
+    ASSERT2(undefinedp(v[0]["value"]), "a cancelled entry carries no value");
+    RELEASE_LATCH("cancel-status");
+  });
+}
+
+private void check_catch_then_fail() {
+  EXPECT_LATCH("catch-then-fail");
+  catch_then_fail_p = catch_then_fail();
+  ASSERT_EQ(1, promise_cancel(catch_then_fail_p));
+
+  promise_catch(catch_then_fail_p, function(mixed reason) {
+    // Declined the cancel, then faulted: rejected, not cancelled.
+    ASSERT_EQ(2, promise_status(catch_then_fail_p));
+    ASSERT2(stringp(reason) && strsrch(reason, "real fault") != -1,
+      "declined cancel then faulted: " + reason);
+    ASSERT_EQ("*async function cancelled", declined_caught);
+    RELEASE_LATCH("catch-then-fail");
+  });
+}
+
 void do_tests() {
   never = promise_create();
   gate = promise_create();
@@ -266,4 +317,6 @@ void do_tests() {
   }
 
   check_cancel_propagate();
+  check_cancel_status();
+  check_catch_then_fail();
 }

--- a/testsuite/single/tests/efuns/promise_cancel.lpc
+++ b/testsuite/single/tests/efuns/promise_cancel.lpc
@@ -19,9 +19,10 @@
 nosave promise never, gate;
 nosave promise held, caught_body, defer_body;
 nosave promise status_leaf, status_all, status_race, status_settled;
-nosave promise catch_then_fail_p;
+nosave promise catch_then_fail_p, running_fail_p, armed_fault_p;
+nosave promise stale_x, stale_leaf, stale_all, stale_waiter;
 nosave int body_ran_past_await, defer_ran, cleanup_awaited;
-nosave mixed caught, declined_caught;
+nosave mixed caught, declined_caught, declined_running;
 
 // Parked on a promise nothing will ever settle.
 private async int stuck() {
@@ -291,6 +292,81 @@ private void check_catch_then_fail() {
   });
 }
 
+// Same contract on the RUNNING route: cancel after a resume, catch at the
+// next await, then fault. from_cancel must not have been stamped at request
+// time (unwind_to_acatch_marker() already replaced catch_value, so the old
+// decline check could never fire).
+private async int catch_then_fail_running() {
+  await gate;
+  ASSERT_EQ(1, promise_cancel(running_fail_p));
+  declined_running = acatch(await never);
+  error("running-route fault");
+}
+
+private void check_catch_then_fail_running() {
+  EXPECT_LATCH("catch-then-fail-running");
+  running_fail_p = catch_then_fail_running();
+  promise_catch(running_fail_p, function(mixed reason) {
+    ASSERT_EQ(2, promise_status(running_fail_p));
+    ASSERT2(stringp(reason) && strsrch(reason, "running-route fault") != -1,
+      "running-route declined cancel then faulted: " + reason);
+    ASSERT_EQ("*async function cancelled", declined_running);
+    RELEASE_LATCH("catch-then-fail-running");
+  });
+}
+
+// Cancel armed, no further await: the body faults for real. Docs: a body
+// that never awaits again runs to completion; the settlement is the fault,
+// not PROMISE_CANCELLED.
+private async int armed_then_fault() {
+  await gate;
+  ASSERT_EQ(1, promise_cancel(armed_fault_p));
+  error("armed no-await fault");
+}
+
+private void check_armed_then_fault() {
+  EXPECT_LATCH("armed-then-fault");
+  armed_fault_p = armed_then_fault();
+  promise_catch(armed_fault_p, function(mixed reason) {
+    ASSERT_EQ(2, promise_status(armed_fault_p));
+    ASSERT2(stringp(reason) && strsrch(reason, "armed no-await fault") != -1,
+      "armed cancel never delivered, real fault: " + reason);
+    RELEASE_LATCH("armed-then-fault");
+  });
+}
+
+private async int stale_leaf_body() {
+  await never;
+  return 1;
+}
+
+private async int stale_await_all() {
+  return await stale_all;
+}
+
+// A late cancelled input must not flip from_cancel on an already-settled
+// combinator. Otherwise `return await all` inherits PROMISE_CANCELLED with
+// the original plain-rejection reason.
+private void check_stale_combinator_flag() {
+  EXPECT_LATCH("stale-combinator");
+  stale_x = promise_create();
+  stale_leaf = stale_leaf_body();
+  stale_all = promise_all(({ stale_x, stale_leaf }));
+  promise_reject(stale_x, "*plain");
+  promise_catch(stale_all, function(mixed reason) {
+    ASSERT_EQ(2, promise_status(stale_all));
+    ASSERT_EQ("*plain", reason);
+    ASSERT_EQ(1, promise_cancel(stale_leaf));
+    stale_waiter = stale_await_all();
+    promise_catch(stale_waiter, function(mixed wreason) {
+      ASSERT_EQ(2, promise_status(stale_waiter));
+      ASSERT_EQ("*plain", wreason);
+      ASSERT_EQ(2, promise_status(stale_all));
+      RELEASE_LATCH("stale-combinator");
+    });
+  });
+}
+
 void do_tests() {
   never = promise_create();
   gate = promise_create();
@@ -319,4 +395,7 @@ void do_tests() {
   check_cancel_propagate();
   check_cancel_status();
   check_catch_then_fail();
+  check_catch_then_fail_running();
+  check_armed_then_fault();
+  check_stale_combinator_flag();
 }

--- a/testsuite/single/tests/efuns/promise_cancel.lpc
+++ b/testsuite/single/tests/efuns/promise_cancel.lpc
@@ -143,8 +143,8 @@ private async int cancel_in_nested_loop() {
 
 // Cancelling a body that another dropped awaiter is waiting on must not
 // print "Unhandled promise rejection" for the downstream link. The
-// canceller stamped handled on the TARGET only; the reason has to carry
-// from_cancel with it (PR #1353). Read the debug log, same channel as
+// winning settle carries from_cancel so dealloc_promise() skips the
+// report (PR #1353). Read the debug log, same channel as
 // unhandled_rejection_locus.lpc.
 
 #define DEBUG_LOG_FILE 10
@@ -357,12 +357,18 @@ private void check_stale_combinator_flag() {
     ASSERT_EQ(2, promise_status(stale_all));
     ASSERT_EQ("*plain", reason);
     ASSERT_EQ(1, promise_cancel(stale_leaf));
-    stale_waiter = stale_await_all();
-    promise_catch(stale_waiter, function(mixed wreason) {
-      ASSERT_EQ(2, promise_status(stale_waiter));
-      ASSERT_EQ("*plain", wreason);
-      ASSERT_EQ(2, promise_status(stale_all));
-      RELEASE_LATCH("stale-combinator");
+    // The leaf's combinator reaction was attached first, so it is
+    // delivered before this handler. Create the awaiter only once the
+    // stale input has been applied -- otherwise the waiter can resume
+    // before the flip and the test passes on the unfixed binary.
+    promise_catch(stale_leaf, function(mixed lreason) {
+      stale_waiter = stale_await_all();
+      promise_catch(stale_waiter, function(mixed wreason) {
+        ASSERT_EQ(2, promise_status(stale_waiter));
+        ASSERT_EQ("*plain", wreason);
+        ASSERT_EQ(2, promise_status(stale_all));
+        RELEASE_LATCH("stale-combinator");
+      });
     });
   });
 }

--- a/testsuite/single/tests/efuns/promise_combinators.lpc
+++ b/testsuite/single/tests/efuns/promise_combinators.lpc
@@ -12,6 +12,16 @@
 
 nosave promise a, b, c;
 
+// A combinator still PENDING when the file ends leaves its already delivered
+// slots there for the post-file check_memory() to walk. `slots` is an
+// ordinary allocated array, so the checker's sweep reaches its own block and
+// marks every item; marking them a second time from the combinator registry
+// reported one reference nobody holds per refcounted delivered value
+// ("Bad ref count for array, is 1 - should be 2") and failed the file with
+// LEAK. Numbers alone never showed it -- the delivered values have to be
+// refcounted, and the aggregate has to still be alive at the check.
+nosave promise live_input, live_result;
+
 private async int slow(int n, int fail) {
   await a;
   if (fail) {
@@ -141,6 +151,15 @@ private void check_edges() {
   ASSERT2(err, "an empty promise_race is refused");
   ASSERT2(stringp(err) && strsrch(err, "never settle") != -1,
     "the refusal says why: " + err);
+
+  // Left pending on purpose: see the declaration above. Settled from a
+  // call_out so the aggregate survives every check_memory() during the run
+  // and nothing is still pending at exit.
+  live_input = promise_create();
+  live_result = promise_all(({ ({ 1, 2 }), ([ "k": 1 ]), "a string", live_input }));
+  call_out(function() {
+    promise_resolve(live_input, 0);
+  }, 1);
 
   // All-plain input settles without any promise being involved.
   EXPECT_LATCH("plain");

--- a/testsuite/single/tests/efuns/promise_combinators.lpc
+++ b/testsuite/single/tests/efuns/promise_combinators.lpc
@@ -1,0 +1,172 @@
+// promise_all / promise_any / promise_race / promise_all_settled.
+//
+// One aggregate is shared by every input's reaction and dies with the last
+// of them. Aggregation runs no LPC, so it happens inside the delivery like a
+// pass-through chain link: ordering is the drain's, and nothing settles
+// synchronously from the efun unless every input was a plain value.
+//
+// A non-promise element counts as already fulfilled with itself, so the
+// output of an ordinary map() drops straight in without wrapping.
+
+#include "/include/tests.h"
+
+nosave promise a, b, c;
+
+private async int slow(int n, int fail) {
+  await a;
+  if (fail) {
+    error("boom " + n);
+  }
+
+  return n;
+}
+
+private void check_all() {
+  EXPECT_LATCH("all");
+  promise_then(promise_all(({ b, c, 99 })), function(mixed v) {
+    ASSERT2(pointerp(v), "promise_all fulfils with an array");
+    ASSERT_EQ(3, sizeof(v));
+    // Positional: slot i is input i, whatever order they settled in.
+    ASSERT_EQ(1, v[0]);
+    ASSERT_EQ(2, v[1]);
+    ASSERT_EQ(99, v[2]);
+    RELEASE_LATCH("all");
+  });
+}
+
+private void check_all_fail() {
+  promise x = promise_create();
+  promise y = promise_create();
+
+  EXPECT_LATCH("all-fail");
+  promise_catch(promise_all(({ x, y })), function(mixed reason) {
+    ASSERT_EQ("*first to fail", reason);
+    RELEASE_LATCH("all-fail");
+  });
+  promise_reject(x, "*first to fail");
+  promise_reject(y, "*second, ignored");
+}
+
+private void check_any() {
+  promise x = promise_create();
+  promise y = promise_create();
+
+  EXPECT_LATCH("any");
+  promise_then(promise_any(({ x, y })), function(mixed v) {
+    ASSERT_EQ(7, v);
+    RELEASE_LATCH("any");
+  });
+  promise_reject(x, "*this one failed");
+  promise_resolve(y, 7);
+}
+
+private void check_any_all_reject() {
+  promise x = promise_create();
+  promise y = promise_create();
+
+  EXPECT_LATCH("any-none");
+  promise_catch(promise_any(({ x, y })), function(mixed reason) {
+    ASSERT2(pointerp(reason), "promise_any rejects with the array of reasons");
+    ASSERT_EQ(2, sizeof(reason));
+    ASSERT_EQ("*no", reason[0]);
+    ASSERT_EQ("*nope", reason[1]);
+    RELEASE_LATCH("any-none");
+  });
+  promise_reject(x, "*no");
+  promise_reject(y, "*nope");
+}
+
+private void check_race() {
+  promise x = promise_create();
+  promise y = promise_create();
+
+  // A REJECTION wins a race too -- race is first-settled, not first-fulfilled.
+  EXPECT_LATCH("race");
+  promise_catch(promise_race(({ x, y })), function(mixed reason) {
+    ASSERT_EQ("*lost the race", reason);
+    RELEASE_LATCH("race");
+  });
+  promise_reject(x, "*lost the race");
+  promise_resolve(y, 1);
+}
+
+private void check_all_settled() {
+  promise x = promise_create();
+  promise y = promise_create();
+
+  EXPECT_LATCH("settled");
+  promise_then(promise_all_settled(({ x, y })), function(mixed v) {
+    ASSERT_EQ(2, sizeof(v));
+    // status uses promise_status()'s codes, so one vocabulary covers both.
+    ASSERT_EQ(1, v[0]["status"]);
+    ASSERT_EQ("ok", v[0]["value"]);
+    ASSERT_EQ(2, v[1]["status"]);
+    ASSERT_EQ("*bad", v[1]["reason"]);
+    ASSERT2(undefinedp(v[0]["reason"]), "a fulfilled entry carries no reason");
+    ASSERT2(undefinedp(v[1]["value"]), "a rejected entry carries no value");
+    RELEASE_LATCH("settled");
+  });
+  promise_resolve(x, "ok");
+  promise_reject(y, "*bad");
+}
+
+private void check_edges() {
+  mixed err;
+
+  // Empty promise_all/all_settled have trivially met their condition.
+  EXPECT_LATCH("empty-all");
+  promise_then(promise_all(({})), function(mixed v) {
+    ASSERT_EQ(0, sizeof(v));
+    RELEASE_LATCH("empty-all");
+  });
+
+  EXPECT_LATCH("empty-settled");
+  promise_then(promise_all_settled(({})), function(mixed v) {
+    ASSERT_EQ(0, sizeof(v));
+    RELEASE_LATCH("empty-settled");
+  });
+
+  // Empty promise_any can never be satisfied, so it rejects rather than
+  // hanging -- and the reason is truthy, as acatch() requires.
+  EXPECT_LATCH("empty-any");
+  promise_catch(promise_any(({})), function(mixed reason) {
+    ASSERT2(reason, "an empty promise_any rejects with a truthy reason");
+    RELEASE_LATCH("empty-any");
+  });
+
+  // Empty promise_race would wait forever, which here means a parked frame
+  // holding an object, a program and a suspension slot for the life of the
+  // driver. Refused where the mistake is instead of reproduced from JS.
+  err = catch(promise_race(({})));
+  ASSERT2(err, "an empty promise_race is refused");
+  ASSERT2(stringp(err) && strsrch(err, "never settle") != -1,
+    "the refusal says why: " + err);
+
+  // All-plain input settles without any promise being involved.
+  EXPECT_LATCH("plain");
+  promise_then(promise_all(({ 1, "two", 3 })), function(mixed v) {
+    ASSERT_EQ(3, sizeof(v));
+    ASSERT_EQ("two", v[1]);
+    RELEASE_LATCH("plain");
+  });
+}
+
+void do_tests() {
+  a = promise_create();
+  b = slow(1, 0);
+  c = slow(2, 0);
+
+  ASSERT_EQ("promise", typeof(promise_all(({}))));
+  ASSERT2(promisep(promise_race(({ promise_create() }))), "promise_race returns a promise");
+
+  check_all();
+  check_all_fail();
+  check_any();
+  check_any_all_reject();
+  check_race();
+  check_all_settled();
+  check_edges();
+
+  // Releases both async bodies; promise_all above then completes.
+  promise_resolve(a, 0);
+}

--- a/testsuite/single/tests/efuns/promise_combinators.lpc
+++ b/testsuite/single/tests/efuns/promise_combinators.lpc
@@ -161,6 +161,33 @@ private void check_edges() {
     promise_resolve(live_input, 0);
   }, 1);
 
+  // The SAME promise twice in one input: two independent reactions, two
+  // deliveries, two slots -- not one delivery that leaves a slot unwritten
+  // and `remaining` stuck above zero.
+  promise dup = promise_create();
+  EXPECT_LATCH("dup");
+  promise_then(promise_all(({ dup, dup, dup })), function(mixed v) {
+    ASSERT_EQ(3, sizeof(v));
+    ASSERT_EQ(7, v[0]);
+    ASSERT_EQ(7, v[1]);
+    ASSERT_EQ(7, v[2]);
+    RELEASE_LATCH("dup");
+  });
+  promise_resolve(dup, 7);
+
+  // An input whose last reference goes away before it settles: it can never
+  // settle now, so the aggregate is told rather than left pending forever.
+  promise orphaned;
+  {
+    promise doomed = promise_create();
+    orphaned = promise_all(({ doomed, 1 }));
+  }
+  EXPECT_LATCH("collected");
+  promise_catch(orphaned, function(mixed reason) {
+    ASSERT2(stringp(reason), "a collected input rejects the aggregate: " + reason);
+    RELEASE_LATCH("collected");
+  });
+
   // All-plain input settles without any promise being involved.
   EXPECT_LATCH("plain");
   promise_then(promise_all(({ 1, "two", 3 })), function(mixed v) {

--- a/testsuite/single/tests/efuns/promise_combinators.lpc
+++ b/testsuite/single/tests/efuns/promise_combinators.lpc
@@ -11,6 +11,7 @@
 #include "/include/tests.h"
 
 nosave promise a, b, c;
+nosave promise race_probe_in, race_probe;
 
 // A combinator still PENDING when the file ends leaves its already delivered
 // slots there for the post-file check_memory() to walk. `slots` is an
@@ -203,7 +204,11 @@ void do_tests() {
   c = slow(2, 0);
 
   ASSERT_EQ("promise", typeof(promise_all(({}))));
-  ASSERT2(promisep(promise_race(({ promise_create() }))), "promise_race returns a promise");
+  // Hold both ends so a temporary promise_race(({ promise_create() }))
+  // does not collect the input and log "Unhandled promise rejection".
+  race_probe_in = promise_create();
+  race_probe = promise_race(({ race_probe_in }));
+  ASSERT2(promisep(race_probe), "promise_race returns a promise");
 
   check_all();
   check_all_fail();

--- a/testsuite/single/tests/operators/await.lpc
+++ b/testsuite/single/tests/operators/await.lpc
@@ -85,24 +85,48 @@ async void local_compound_ok() {
   RELEASE_LATCH("local compound assign across a park");
 }
 
-// What the guard DOES cover: a foreach loop keeps an lvalue slot live for
-// its loop variable for the whole body, so a pending await inside one
-// refuses to suspend and acatch observes the error.
-async void foreach_guarded() {
+// A foreach keeps an lvalue slot live for its loop variable across the whole
+// body. For a LOCAL loop variable that lvalue addresses a slot inside the
+// frame, which is exactly what parking copies and rebuilds, so it is
+// relocated across the suspension and the loop resumes normally. (This used
+// to be refused along with everything else; see async_foreach.lpc.)
+async void foreach_local_suspends() {
   int *a = ({ 1, 2 });
   int completed = 0;
+  int total = 0;
   mixed err;
 
   err = acatch {
     foreach (int v in a) {
+      total += v * await pend;
+    }
+    completed = 1;
+  };
+  ASSERT_EQ(0, err);
+  ASSERT_EQ(1, completed);
+  ASSERT_EQ(30, total);  // (1 + 2) * 10
+  RELEASE_LATCH("foreach lvalue relocates across a park");
+}
+
+// What the guard still DOES cover: a GLOBAL loop variable's lvalue points
+// into the object's variable block, a second relocation base this does not
+// attempt, so it refuses and acatch observes the error.
+nosave int foreach_global;
+
+async void foreach_global_guarded() {
+  int completed = 0;
+  mixed err;
+
+  err = acatch {
+    foreach (foreach_global in ({ 1, 2 })) {
       await pend;
     }
     completed = 1;  // must stay 0: the loop must NOT resume normally
   };
-  ASSERT_EQ(0, completed);  // the loop must NOT have resumed normally
+  ASSERT_EQ(0, completed);
   ASSERT(stringp(err));
   ASSERT(strsrch(err, "cannot suspend") != -1);
-  RELEASE_LATCH("foreach lvalue refuses to suspend");
+  RELEASE_LATCH("foreach global lvalue refuses to suspend");
 }
 
 // suspension-limit fixtures: park on a promise that never settles during
@@ -157,8 +181,11 @@ void do_tests() {
   compound_ok();
   EXPECT_LATCH("local compound assign across a park");
   local_compound_ok();
-  EXPECT_LATCH("foreach lvalue refuses to suspend");
-  foreach_guarded();
+  EXPECT_LATCH("foreach lvalue relocates across a park");
+  foreach_local_suspends();
+
+  EXPECT_LATCH("foreach global lvalue refuses to suspend");
+  foreach_global_guarded();
 
   // the runaway-exhaustion guard: parking past the configured limit is a
   // clean error at the await point. 256 + 66 is __RC_MAX_SUSPENDED_ASYNC__


### PR DESCRIPTION
Phase 1.5 of #1319, now rebased onto master (#1347 has merged, as have #1355, #1354 and #1360). Four additions, driven by testing feedback on #1347: promise combinators, a real cancellation primitive, `await` inside `foreach`, and — from @gesslar, incorporated from #1357 — the LPC-visible promise constants in a shared header.

```c
mixed *rows = await promise_all(map(names, (: fetch($1) :)));   // fan out
mixed first = await promise_any(map(mirrors, (: fetch($1) :))); // first success
promise_cancel(worker);                                         // give up at the next await

async int total(int *xs) {
    int n;
    foreach (int x in xs) n += x * await weight(x);   // used to be refused
    return n;
}
```

## Combinators

`promise_all` (every value, positionally; rejects on the **first** rejection), `promise_any` (first success; rejects only if **every** input rejects, with the array of reasons), `promise_race` (settles as the first input to settle — **a rejection wins a race**), `promise_all_settled` (never rejects; one `([ "status": 1|2|3, "value"/"reason": .. ])` per input, reusing `promise_status()`'s codes, including cancelled = 3).

A non-promise element counts as already fulfilled with itself, so `map()` output drops straight in. Named `promise_all_settled`, not `promise_settle`: the latter already names the driver's internal "settle this one promise" operation, so reusing it would read as nearly the opposite.

**An empty `promise_race()` is an error, not an eternal wait.** JS hangs; here a permanently pending awaited promise is a parked frame holding its object, its program and one `max suspended async functions` slot for the life of the driver, so the mistake is refused where it is made. Empty `promise_all`/`promise_all_settled` fulfil with `({ })`; empty `promise_any` rejects.

## `promise_cancel()`

Cooperative, not preemptive: the target body's **next `await` raises** a catchable `"*async function cancelled"`, unwinding through `acatch` and running `defer` handlers exactly as any other rejection at that await would. A body mid-way through straight-line code finishes that stretch; one that never awaits again runs to completion. If nothing catches it, `p` **cancels** — `promise_status(p)` is `PROMISE_CANCELLED` (3), not rejected. That is the test `acatch` cannot forge; the reason string is still what the await yields.

**Consume-once**: the raise clears the request, so a body that catches its cancellation can still `await` cleanup and return a value — its promise then *fulfils*. Cancel is a request a body may decline. The sticky alternative makes every cleanup `await` throw, leaving a cancelled body no way to release what it holds.

A frame parked on a promise that will never settle is still cancelled promptly — detached from that promise with its rejection scheduled directly, so cancellation is never hostage to what is being awaited. As part of that detach, `coro->awaiting` is **repointed** at the synthetic rejected promise: `build_async_info()` dereferences it unconditionally and it is deliberately not ref-held, so without the repoint the original could be freed by its other holders — a use-after-free reachable from an ordinary `async_info()` call.

**No propagation**, for a reason specific to this driver rather than borrowed from JS: promises here are first-class and **multicast**. An inner body's promise may have other awaiters, `then` handlers, or simply be stored, so cancelling it would settle it for all of them, and "is my caller the only one who cares" is unknowable refcount guesswork. A body that wants the inner work stopped catches its own cancellation and cancels the inner promise it holds. Opt-in propagation stays a compatible extension.

### gesslar review: cancel is not a fault

`promise_cancel()` already avoids `error()` / `master::error_handler`. Two follow-ups from that review are in this PR:

1. **`from_cancel`** travels with a propagated cancellation (await with no `acatch`, `then` pass-through, adoption, `promise_all` / `promise_race` fail-fast). `dealloc_promise()` skips `Unhandled promise rejection` when the bit is set. The reason string is not matched — it is forgeable.
2. **`PROMISE_CANCELLED` (3).** `promise_settle()` records that state when `from_cancel` is set. Combinators: `promise_all` / `promise_race` inherit status 3; `promise_any` still rejects with the array of reasons if nothing fulfils; `promise_all_settled` reports `([ "status": 3, "reason": r ])`. A body that catches its cancellation and later faults settles as **rejected** (2).

Refused (not silently ignored) on any promise that is not an `async` function's; returns `0` rather than erroring for a body that already finished, since a body racing its canceller is a normal outcome.

## `await` inside `foreach`

Every `foreach` pushes a `T_LVALUE` for its loop variable, and the suspension refused **any** lvalue on the stack — so `await` was illegal in every `foreach` shape, including the plain local-variable one. But a local loop variable's lvalue addresses a slot **inside the frame**, and the frame is exactly what parking copies and rebuilds, so it is relocatable: carried across as an offset and re-derived against the new `fp`. Held as a `T_NUMBER` while parked, so nothing in between is ever handed a pointer that no longer addresses anything.

Now suspends: arrays, strings, buffers, mappings, nested loops. Still refused, with a diagnostic that names the shape: a **global** loop variable (its lvalue points into the object's variable block — a second relocation base, not attempted here), a **`ref`** loop variable or argument, and `s[i]`/`b[i]` lvalues — those are backed by shared VM scratch, one instance at a time by construction, so they can never be per-frame state and are refused **permanently**.

The subtle part was not the relocation. `foreach` bumps `stack_in_use_as_temporary`, a **global** Debug counter telling `break_point()` its temporaries legitimately sit above `fp`. A parked frame carries those off the stack and across a top-level boundary where `reset_machine()` zeroes the counter, so the frame arrived at its resume with the temporaries restored but the count gone — `FATAL ERROR: Bad stack pointer`. The counter is now split per body (`g_coroutine_temp_base`), saved and restored exactly as `g_coroutine_promise` is.

`operators/await.lpc`'s `foreach_guarded()` asserted the removed limitation, so it now asserts the loop completes with the right value, plus a new global-loop-variable case pinning what is still refused — both sides of the new boundary held.

## Shared promise constants (@gesslar, from #1357)

The rejection reasons the driver produces were inline string literals at their raise sites, and the state codes an anonymous enum in `vm/internal/base/promise.h` — neither visible to a mudlib. That matters most for cancellation, which is ordinary control flow a body is expected to catch, yet the only way to recognise it was `if (err == "*async function cancelled")` against a string living in the driver's `.cc`.

Both sets now live in `src/include/promise.h`, alongside `type.h` and `socket_err.h`, and **the driver consumes the macros** rather than keeping a parallel copy — so the header and the raise sites cannot drift. Status codes are `PROMISE_PENDING` / `FULFILLED` / `REJECTED` / `CANCELLED` (0–3). Verified end-to-end on this branch: `promise_status(promise_any(({}))) == PROMISE_REJECTED` and `promise_result(...) == PROMISE_REASON_ANY_EMPTY`.

Known gap, pre-existing and not introduced here: `testsuite/include/` keeps its own copies of the shared headers rather than using `src/include/`, and those have already drifted (`src/include/ffi.h` and `testsuite/include/ffi.h` differ today). No `testsuite/include/promise.h` was added, since a second copy is what this change exists to prevent — but it does mean a testsuite file cannot `#include <promise.h>` until the testsuite is pointed at the real directory.

## Testing

Three new/updated test files (`promise_combinators.lpc`, `promise_cancel.lpc`, `async_foreach.lpc`, plus the `operators/await.lpc` rewrite). `promise_cancel.lpc` also pins the unhandled-rejection log probe, status 3 on the target and on `all` / `race` / `all_settled`, and catch-then-fault staying 2.

Re-validated after the rebase and the merge of #1357, on the combined branch:

* **gcc Debug** (`check_memory()` after every file) ×2 — zero failures, zero `Bad ref count`
* **gcc RelWithDebInfo** — clean
* **clang ASan/UBSan Debug** and **clang ASan/UBSan RelWithDebInfo** — clean, no sanitizer reports
* **inside the wasm driver under node** — clean
* **GTest 340/340**
* corpus format check, `lpc-syntax` tests, and the `config.md` / `sidebars.generated.json` staleness gates all clean

## Two calls worth a reviewer's attention

- **Cancellation does not propagate** (reasoning above). Defensible, but it is a semantics decision.
- **Global `foreach` loop variables stay refused.** Extending relocation to the object's variable block is possible but is a second base with real questions against `recompile_object()`; it belongs in its own change rather than smuggled in here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)