### PR TITLE
Fix two Coverity findings in the async/await code

### DIFF
--- a/src/packages/contrib/cycles.cc
+++ b/src/packages/contrib/cycles.cc
@@ -345,7 +345,6 @@ void cycle_walk(svalue_t* root, WalkMode mode, WalkResult* res) {
           while (f.ridx < nreact && !have_edge && !descended) {
             auto& r = (*prom->reactions)[f.ridx];
             if (f.rphase < 3) {
-              int const ri = f.ridx;
               int const rs = f.rphase;
               void* target;
               uint32_t ttype = T_FUNCTION;
@@ -357,14 +356,21 @@ void cycle_walk(svalue_t* root, WalkMode mode, WalkResult* res) {
                 target = reinterpret_cast<void*>(r.next);
                 ttype = T_PROMISE;
               }
+              /* Record the cursor BEFORE the mutation below advances it --
+                 that ordering is the whole reason this is not written at the
+                 handle_edge() call. Unconditional rather than guarded by
+                 `target`: the hint is scratch that only the
+                 SLOT_PROMISE_REACTION handle_edge() reads, and every such
+                 call sets it first, so a write no edge consumes is
+                 overwritten before it can be read. */
+              reaction_hint.reaction_idx = f.ridx;
+              reaction_hint.reaction_slot = rs;
               f.rphase++;
               if (f.rphase == 3 && r.coro == nullptr) {
                 f.ridx++;
                 f.rphase = 0;
               }
               if (target != nullptr) {
-                reaction_hint.reaction_idx = ri;
-                reaction_hint.reaction_slot = rs;
                 handle_edge(ttype, target, nullptr, SLOT_PROMISE_REACTION,
                             mode == WALK_FIND ? std::string("(reaction)") : std::string());
                 descended = true;  // `f` may be stale; restart the outer walk
@@ -430,15 +436,16 @@ void cycle_walk(svalue_t* root, WalkMode mode, WalkResult* res) {
             // abandoning the frame, and settling that promise frees the
             // reaction vector this walk is iterating.
             {
-              int const ri = f.ridx;
               void* const target = reinterpret_cast<void*>(r.coro->result_promise);
               f.ridx++;
               f.rphase = 0;
               f.rsub = 0;
               f.rdefer = nullptr;
               f.rdfield = 0;
-              reaction_hint.reaction_idx = ri;
-              reaction_hint.reaction_slot = 3;
+              /* No reaction_hint here, deliberately: the only reader is
+                 handle_edge()'s WALK_BREAK path, which this edge cannot
+                 reach because it passes breakable=false below. Setting one
+                 would be a store nothing can ever load. */
               /* DETECT ONLY: cutting this edge would mean abandoning the
                  coroutine, and settling its promise mutates + frees the very
                  reaction vector the fixer is walking (use-after-free). */

--- a/src/vm/internal/base/promise.cc
+++ b/src/vm/internal/base/promise.cc
@@ -293,8 +293,11 @@ void schedule_drain() {
   /* delay 0 here is a one-shot, not a self-re-posting callback, so it cannot
    * spin the loop the way a zero-delay continuation would (see
    * schedule_drain_continue) -- it just runs on the next pass. */
+  /* std::move on both arms: exactly one runs, so neither can observe the
+   * other's moved-from `cb`, and the callback holds a std::function's heap
+   * allocation worth not copying. */
   if (backend_in_tick_events()) {
-    g_drain_event = add_gametick_event(0, cb);
+    g_drain_event = add_gametick_event(0, std::move(cb));
     g_drain_event_is_tick = true;
   } else {
     g_drain_event_is_tick = false;
@@ -304,7 +307,7 @@ void schedule_drain() {
     if (!g_draining) {
       g_drain_arms_loop_total++;
     }
-    g_drain_event = add_walltime_event(std::chrono::milliseconds(0), cb);
+    g_drain_event = add_walltime_event(std::chrono::milliseconds(0), std::move(cb));
   }
 }
 


### PR DESCRIPTION
Two Coverity findings against the async/await code merged in #1347. Both are real; neither is a false positive.

## CID 1685655 — `UNUSED_VALUE`, `packages/contrib/cycles.cc`

`reaction_hint` has exactly one reader: `handle_edge()`'s `WALK_BREAK && breakable` branch.

The `rphase == 6` site — the parked coroutine's result promise — passes **`breakable=false` explicitly**, because cutting that edge would mean abandoning the frame, and settling its promise frees the very reaction vector the walk is iterating. So the hint written there is a store nothing can ever load. Removed, with a comment recording that the asymmetry is deliberate; without one, the next reader restores it.

The `rphase < 3` site *does* feed a breakable edge, but only when `target` is non-null, so the temporary was dead on the other path. That temporary existed only because the reaction cursor is advanced between capture and use — so the hint is now written straight from `f.ridx` immediately before that advance, and the temp is gone. It is written unconditionally rather than guarded on `target`: the hint is scratch that every `SLOT_PROMISE_REACTION` `handle_edge()` sets first, so a write no edge consumes is overwritten before it can be read.

## CID 1685654 — `COPY_INSTEAD_OF_MOVE`, `vm/internal/base/promise.cc`

`schedule_drain()` copies its `TickEvent::callback_type` into whichever of `add_gametick_event()` / `add_walltime_event()` runs. Now `std::move`d on both arms — exactly one executes, so neither can observe the other's moved-from value.

`schedule_drain_continue()` and `promise_async_yield()` already construct their callbacks as inline temporaries and need no change.

## Testing

gcc Debug (with `check_memory()` after every file), gcc RelWithDebInfo, clang ASan/UBSan Debug, clang ASan/UBSan RelWithDebInfo — 709 files, exit 0, zero ref-count or sanitizer reports on every config.

The `cycles.cc` change is exercised directly by `break_cycles.lpc` (41 checks), `cycles_parked_coroutine.lpc` and `cycles_parked_defer.lpc`, all passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
