### PR TITLE
Fix a segfault on the first error reported from a 65536-line file

### DIFF
--- a/src/compiler/internal/compiler.cc
+++ b/src/compiler/internal/compiler.cc
@@ -3950,11 +3950,35 @@ void prepare_cases(parse_node_t* pn, int start) {
 }
 
 void save_file_info(int file_id, int lines) {
-  short fi[2];
+  /* The count is 16 bits wide (the whole table is unsigned short pairs), so
+   * a file -- or one contiguous stretch of a file between #includes -- of
+   * 65536 lines used to wrap to 0. translate_absolute_line()'s first pass
+   * then subtracts 0 without ever reducing the line it is looking for, walks
+   * off the end of the table, and returns whatever garbage it lands on as a
+   * file index; the caller feeds that straight to progp->strings[idx - 1].
+   * The first runtime error reported from such a file segfaults the driver.
+   *
+   * Emit the count in chunks of at most 65535 carrying the same file id.
+   * The format is unchanged and the decoder needs no change either: its
+   * second pass already sums every earlier entry with the same file id when
+   * it reconstructs the file-relative line, so a split file decodes exactly
+   * as an unsplit one would have.
+   *
+   * do/while, not while: a zero-line entry is legitimate (an #include on the
+   * first line of a file leaves no lines before it) and must still emit
+   * exactly one entry, as it always did. */
+  do {
+    unsigned short fi[2];
+    int const chunk = (lines > 0xffff) ? 0xffff : lines;
 
-  fi[0] = lines;
-  fi[1] = file_id;
-  add_to_mem_block(A_FILE_INFO, (char*)&fi[0], sizeof(fi));
+    /* unsigned short, not short: this is how the table is read back, and
+     * storing a count above 32767 through a signed short was needless
+     * implementation-defined behaviour. */
+    fi[0] = static_cast<unsigned short>(chunk);
+    fi[1] = static_cast<unsigned short>(file_id);
+    add_to_mem_block(A_FILE_INFO, (char*)&fi[0], sizeof(fi));
+    lines -= chunk;
+  } while (lines > 0);
 }
 
 int add_program_file(const char* name, int top) {

--- a/src/vm/internal/base/interpret.cc
+++ b/src/vm/internal/base/interpret.cc
@@ -4978,14 +4978,22 @@ void call_direct(object_t* ob, int offset, int origin, int num_arg) {
 }
 
 void translate_absolute_line(int abs_line, unsigned short* file_info, int* ret_file,
-                             int* ret_line) {
+                             int* ret_line, unsigned short* end) {
   unsigned short *p1, *p2;
   int file;
   int line_tmp = abs_line;
 
-  /* two passes: first, find out what file we're interested in */
+  /* two passes: first, find out what file we're interested in.
+   *
+   * The `end` bound is defence in depth, not decoration. A zero count here
+   * (which a 16-bit truncation used to produce for a 65536-line file, see
+   * save_file_info) makes this loop advance without ever reducing line_tmp,
+   * so it runs off the table and returns whatever it lands on as a file
+   * index -- which the caller uses to index progp->strings. An out-of-bounds
+   * table walk feeding a string index is a far worse failure than a wrong
+   * line number, so stop at the last entry and report that file instead. */
   p1 = file_info;
-  while (line_tmp > *p1) {
+  while (line_tmp > *p1 && (end == nullptr || p1 + 2 < end)) {
     line_tmp -= *p1;
     p1 += 2;
   }
@@ -5045,7 +5053,10 @@ static int find_line(char* p, const program_t* progp, const char** ret_file, int
   COPY4(&abs_line, lns + 1);
 #endif
 
-  translate_absolute_line(abs_line, &progp->file_info[2], &file_idx, ret_line);
+  /* entries run from file_info[2] up to the line-number block at
+   * file_info[file_info[1]] */
+  translate_absolute_line(abs_line, &progp->file_info[2], &file_idx, ret_line,
+                          &progp->file_info[progp->file_info[1]]);
 
   *ret_file = progp->strings[file_idx - 1];
   return 0;

--- a/src/vm/internal/base/interpret.h
+++ b/src/vm/internal/base/interpret.h
@@ -199,7 +199,7 @@ void call___INIT(object_t*);
 array_t* call_all_other(array_t*, const char*, int);
 const char* function_exists(const char*, object_t*, int);
 void mark_apply_low_cache(void);
-void translate_absolute_line(int, unsigned short*, int*, int*);
+void translate_absolute_line(int, unsigned short*, int*, int*, unsigned short* end = nullptr);
 char* add_slash(const char* const);
 int strpref(const char*, const char*);
 void do_trace(const char*, const char*, const char*);

--- a/testsuite/.gitignore
+++ b/testsuite/.gitignore
@@ -23,3 +23,4 @@ testfile.zerolength
 /sqlite.db
 /tmp.o
 /testrun.log
+/data/huge_line_table.c

--- a/testsuite/single/tests/compiler/huge_file_line_table.lpc
+++ b/testsuite/single/tests/compiler/huge_file_line_table.lpc
@@ -1,0 +1,78 @@
+// A file of 65536+ lines must not corrupt the line table.
+//
+// The per-file line count in prog->file_info is 16 bits (the table is
+// unsigned short pairs), and save_file_info() stored it without capping. At
+// exactly 65536 lines the count wrapped to 0, and
+// translate_absolute_line()'s first pass -- `while (line_tmp > *p1)
+// { line_tmp -= *p1; p1 += 2; }` -- then advanced without ever reducing
+// line_tmp, walked off the end of the table, and returned whatever it landed
+// on as a file index. The caller feeds that straight to
+// progp->strings[idx - 1], so the FIRST runtime error reported from such a
+// file segfaulted the driver.
+//
+// Not exotic: it is one large generated or accumulated mudlib file. The
+// count is now emitted in <=65535 chunks carrying the same file id, which
+// the decoder already reassembles (its second pass sums earlier entries with
+// a matching id), and the decoder's walk is bounded as well.
+//
+// This test drives the reporting path that crashed -- catching an error
+// forces the driver to translate an absolute line into (file, line).
+
+#include "/include/tests.h"
+
+#define GEN "/data/huge_line_table.c"
+
+private void build(int pad_lines) {
+  string chunk = "";
+  int i;
+
+  rm(GEN);
+  // Batch the padding: write_file() appends, and one call per line is far
+  // too slow at this size.
+  for (i = 0; i < 500; i++) {
+    chunk += "//\n";
+  }
+  for (i = 0; i < pad_lines / 500; i++) {
+    write_file(GEN, chunk);
+  }
+  for (i = 0; i < pad_lines % 500; i++) {
+    write_file(GEN, "//\n");
+  }
+  write_file(GEN, "int boom() { error(\"line table probe\"); }\n");
+  write_file(GEN, "int fine() { return 1; }\n");
+}
+
+private void probe(int pad_lines, string what) {
+  object ob;
+  mixed err;
+
+  build(pad_lines);
+  ob = load_object(GEN);
+  ASSERT2(ob, what + ": the generated file compiles");
+  if (!ob) {
+    return;
+  }
+
+  // The call that used to segfault: reporting the error has to translate an
+  // absolute line through the file-info table.
+  err = catch(ob->boom());
+  ASSERT2(stringp(err) && strsrch(err, "line table probe") != -1,
+    what + ": the error is reported, not fatal: " + err);
+  // And the object still works afterwards.
+  ASSERT_EQ(1, ob->fine());
+
+  destruct(ob);
+  rm(GEN);
+}
+
+void do_tests() {
+  // Just under the boundary: the case that always worked, kept as a control
+  // so a regression that breaks ordinary files is distinguishable from one
+  // that only breaks huge ones.
+  probe(60000, "60000 lines");
+  // The boundary itself, where the count wrapped to exactly 0.
+  probe(65536, "65536 lines");
+  // Past it, where the count wrapped to a small non-zero value and
+  // misattributed rather than looping.
+  probe(70003, "70003 lines");
+}


### PR DESCRIPTION
**Any file of 65,536 or more lines takes the driver down on the first runtime error reported from it.** Not an exotic input — that is one large generated or accumulated mudlib file, and an ordinary `error()` in it is enough.

## The bug

The per-file line count in `prog->file_info` is 16 bits (the whole table is `unsigned short` pairs), and `save_file_info()` stored it with no cap. At exactly 65536 lines the count wrapped to **0**, and `translate_absolute_line()`'s first pass

```c
while (line_tmp > *p1) { line_tmp -= *p1; p1 += 2; }
```

then advanced without ever reducing `line_tmp` — running off the end of the table and returning whatever it landed on as a file index. The caller feeds that straight to `progp->strings[file_idx - 1]`. Past 65536 the count wrapped to a small non-zero value instead and merely misattributed the line.

## The fix

At the cause: `save_file_info()` emits the count in chunks of at most 65535 carrying the same file id.

**The on-disk format is unchanged and the decoder needs no change to read it** — its second pass already sums every earlier entry with a matching file id when reconstructing the file-relative line, so a split file decodes exactly as an unsplit one would have. The entry is now written through `unsigned short` rather than `short`, matching how the table is read back. The emit stays a `do`/`while` so a zero-line entry (legitimate: an `#include` on a file's first line leaves no lines before it) still produces exactly one entry.

Also **bounded the decoder's walk**, as defence in depth. That loop's failure mode is an out-of-bounds table read whose result becomes a `prog->strings[]` index; stopping at the last entry and reporting that file is strictly better, and it holds even if a future encoder change reintroduces a bad count.

## Testing

`huge_file_line_table.lpc` drives **60000, 65536 and 70003** lines — building each file at runtime, loading it, and catching an error from it, since catching is what forces the driver to translate an absolute line into (file, line), the path that crashed.

**Verified: exit 139 (segfault) on the unfixed binary, clean on the fixed one.** The 60000-line case is a deliberate control, so a future regression that breaks *ordinary* files is distinguishable from one that only breaks huge ones.

Validated on gcc Debug (with `check_memory()` after every file), gcc RelWithDebInfo, clang ASan/UBSan Debug and clang ASan/UBSan RelWithDebInfo — 710 files, exit 0, zero ref-count or sanitizer reports.

## Deliberately not fixed here

`file_info[0]` and `file_info[1]` (in `epilog()`) are also 16-bit and written with unchecked casts. `[0]` is dead — written, never read anywhere in the tree — but `[1]` (`lnoff`) is load-bearing and would wrap for a program with a very large number of file segments. Different threshold, no reproduction in hand, and changing a format field speculatively alongside a crasher fix would muddy the revert. Worth its own issue.

Found while investigating a user report about wrong line numbers, which turned out to be a stale program rather than a driver defect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
