### PR TITLE
async: define the LPC-visible promise constants once, in a shared header

### DIFF
--- a/docs/concepts/general/async.md
+++ b/docs/concepts/general/async.md
@@ -131,12 +131,19 @@ object alive and keeps its suspension slot. Note that JS cannot reach this
 state at all, since an async function's resolver is never handed out; here
 promises are first-class, so the refusal has to be explicit.
 
-There is no cancellation primitive in phase 1, and the refusal removes the
-one thing that looked like one. Two replacements, depending on which side
-you are on.
+To ask a body to stop, use `promise_cancel()`, which is the real primitive
+the refusal above pointed at: it makes the body's **next `await` raise** a
+catchable `"*async function cancelled"`, unwinding through `acatch` and
+running `defer` handlers on the way out. It is cooperative — a body part-way
+through straight-line code finishes that stretch, and one that never awaits
+again runs to completion — and the request is **consumed** by the raise, so
+a body that catches its cancellation can still `await` cleanup and return
+normally. It does not propagate into promises the body is awaiting.
 
-A body that should be able to give up early `await`s a gate the caller
-holds:
+Two patterns remain useful alongside it, depending on which side you are on.
+
+A body that wants a cheaper, purely voluntary check `await`s a gate the
+caller holds:
 
 ```c
 async int worker(promise cancel) {
@@ -167,8 +174,20 @@ The `promise_status()` guards are not optional, and this is where LPC
 differs from JS: there, settling an already-settled promise is a silent
 no-op, which is what lets `Promise.race` be written in userland. Here it is
 an **error**, so the unguarded version throws on whichever of the two paths
-finishes second — the common case, not a rare one. Note also that the
-underlying work is not stopped by either shape; only your wait ends.
+finishes second — the common case, not a rare one.
+
+In practice `promise_race()` does this for you, and is what you should reach
+for first:
+
+```c
+promise with_timeout(promise p, int secs) {
+    return promise_race(({ p, timer_that_rejects(secs) }));
+}
+```
+
+Neither shape stops the underlying work; only your wait ends. To stop the
+work as well, the operation has to be an `async` function you can
+`promise_cancel()`.
 
 `return value` fulfills the promise (a returned promise is adopted). An
 uncaught error inside the body rejects it — an async body behaves as if

--- a/docs/concepts/general/async.md
+++ b/docs/concepts/general/async.md
@@ -314,14 +314,21 @@ compile-time or runtime error, never silent misbehavior:
 2. `await` is not allowed inside `catch(...)` or `time_expression(...)`
    (their implementation recurses the C++ stack). Use `acatch`.
 3. An `await` cannot suspend while a transient reference sits on the value
-   stack. In practice this means **any `foreach` loop** (over arrays,
-   mappings, strings or buffers — the loop keeps an lvalue slot live for its
-   variable for the whole body) and a `ref` argument. It is a runtime error
+   stack that suspension cannot relocate. A `foreach` over a **local** loop
+   variable is fine — arrays, mappings, strings, buffers, nested loops
+   included — because that variable's lvalue addresses a slot inside the
+   frame, and the frame is exactly what parking copies and rebuilds, so it
+   is carried across as an offset. What is still refused is a `foreach` over
+   a **global** loop variable (its lvalue points into the object's variable
+   block, a second relocation base), a **`ref`** loop variable or `ref`
+   argument, and a string-char or buffer-byte lvalue (`s[i]`, `b[i]` —
+   those are backed by shared VM scratch state, one instance at a time by
+   construction, so they can never be per-frame). It is a runtime error
    rather than a compile error because it depends on what the awaited
-   promise turns out to be; use an indexed `for` loop when the body needs to
-   suspend. Compound assignment is *not* affected — `arr[i] += await p`,
-   `s += await p` and friends evaluate the right-hand side before pinning
-   the target, so they park and resume normally.
+   promise turns out to be; use a local loop variable, or an indexed `for`.
+   Compound assignment is *not* affected — `arr[i] += await p`, `s += await
+   p` and friends evaluate the right-hand side before pinning the target, so
+   they park and resume normally.
 4. If the object is destructed, recompiled by `recompile_object()`, or has
    its program swapped by `replace_program()` while a function is
    suspended, the resume is abandoned and the function's promise rejects

--- a/docs/efun/promises/promise_all.md
+++ b/docs/efun/promises/promise_all.md
@@ -1,0 +1,43 @@
+---
+title: promises / promise_all
+---
+# promise_all
+
+### NAME
+
+    promise_all - wait for every promise, failing on the first rejection
+
+### SYNOPSIS
+
+    promise promise_all(mixed *promises);
+
+### DESCRIPTION
+
+    Returns a promise that fulfills with an array of every input's value,
+    **positionally**: entry `i` of the result is the value of `promises[i]`,
+    whatever order they settled in.
+
+    If any input rejects, the returned promise rejects immediately with that
+    reason and the remaining inputs are ignored (they keep running -- there
+    is no cancellation implied). Only the FIRST rejection is reported; use
+    promise_all_settled(3) to see every outcome.
+
+    An element that is not a promise counts as already fulfilled with
+    itself, so the output of an ordinary `map()` can be passed straight in
+    without wrapping.
+
+    An empty array fulfills immediately with an empty array.
+
+### EXAMPLE
+```c
+async void load(string *names) {
+    mixed *rows = await promise_all(map(names, (: fetch($1) :)));
+
+    // rows[i] corresponds to names[i]
+    write("loaded " + sizeof(rows) + "\n");
+}
+```
+
+### SEE ALSO
+
+    promise_any(3), promise_race(3), promise_all_settled(3), promise_then(3)

--- a/docs/efun/promises/promise_all_settled.md
+++ b/docs/efun/promises/promise_all_settled.md
@@ -1,0 +1,58 @@
+---
+title: promises / promise_all_settled
+---
+# promise_all_settled
+
+### NAME
+
+    promise_all_settled - wait for every promise and report each outcome
+
+### SYNOPSIS
+
+    promise promise_all_settled(mixed *promises);
+
+### DESCRIPTION
+
+    Returns a promise that fulfills once every input has settled -- it never
+    rejects. The value is an array of one mapping per input, positionally,
+    describing how that input ended:
+
+        ([ "status": 1, "value":  v ])   fulfilled
+        ([ "status": 2, "reason": r ])   rejected
+
+    The status codes are promise_status(3)'s, so one vocabulary covers both.
+    A fulfilled entry has no `"reason"` key and a rejected entry has no
+    `"value"` key, so `undefinedp()` distinguishes them as reliably as
+    `"status"` does.
+
+    Use this instead of promise_all(3) when a partial failure is a result
+    rather than an error -- fanning work out over many objects and reporting
+    which succeeded, for instance.
+
+    An element that is not a promise counts as already fulfilled with
+    itself, so the output of an ordinary `map()` can be passed straight in.
+    An empty array fulfills immediately with an empty array.
+
+    The name follows JavaScript's `Promise.allSettled`. It is deliberately
+    not `promise_settle`: that already names the driver's internal "settle
+    this one promise" operation, and reusing it for "wait for all of these"
+    would read as almost the opposite.
+
+### EXAMPLE
+```c
+async void reindex(object *rooms) {
+    mixed *results = await promise_all_settled(map(rooms, (: $1->rebuild() :)));
+    int i;
+
+    foreach (mixed r in results) {
+        if (r["status"] == 2) {
+            write("room " + i + " failed: " + r["reason"] + "\n");
+        }
+        i++;
+    }
+}
+```
+
+### SEE ALSO
+
+    promise_all(3), promise_any(3), promise_race(3), promise_status(3)

--- a/docs/efun/promises/promise_any.md
+++ b/docs/efun/promises/promise_any.md
@@ -1,0 +1,40 @@
+---
+title: promises / promise_any
+---
+# promise_any
+
+### NAME
+
+    promise_any - take the first promise that succeeds
+
+### SYNOPSIS
+
+    promise promise_any(mixed *promises);
+
+### DESCRIPTION
+
+    Returns a promise that fulfills with the value of the first input to
+    **fulfill**. Rejections are tolerated: they are collected rather than
+    propagated, so one failing source does not spoil the result.
+
+    Only if EVERY input rejects does the returned promise reject, with an
+    array of the reasons, positionally (entry `i` is `promises[i]`'s reason).
+
+    Contrast promise_race(3), which is settled by the first input to settle
+    either way -- a rejection there wins the race.
+
+    An element that is not a promise counts as already fulfilled with
+    itself. An empty array rejects: there is nothing that could ever
+    satisfy it.
+
+### EXAMPLE
+```c
+async string first_reachable(string *mirrors) {
+    // whichever mirror answers first; failures are ignored unless all fail
+    return await promise_any(map(mirrors, (: fetch($1) :)));
+}
+```
+
+### SEE ALSO
+
+    promise_all(3), promise_race(3), promise_all_settled(3)

--- a/docs/efun/promises/promise_cancel.md
+++ b/docs/efun/promises/promise_cancel.md
@@ -1,0 +1,90 @@
+---
+title: promises / promise_cancel
+---
+# promise_cancel
+
+### NAME
+
+    promise_cancel - ask an async function to give up
+
+### SYNOPSIS
+
+    int promise_cancel(promise p);
+
+### DESCRIPTION
+
+    Requests cancellation of the `async` function body that owns `p`. The
+    body's **next `await` raises** a catchable error whose value is the
+    string `"*async function cancelled"`.
+
+    Cancellation is **cooperative, not preemptive**. A body part-way through
+    a stretch of straight-line code finishes that stretch first; a body that
+    never awaits again runs to completion and its cancellation is never
+    delivered at all. Nothing is torn down mid-expression.
+
+    The raise behaves like any other rejection arriving at that `await`: it
+    unwinds through enclosing `acatch` regions, runs `defer()` handlers in
+    order, and — if nothing catches it — rejects `p` with the same reason.
+
+    A body parked on a promise that will never settle is still cancelled
+    promptly: it is detached from that promise and its rejection is
+    scheduled directly, so cancellation is never hostage to the thing being
+    awaited.
+
+### RETURN VALUE
+
+    1 if a cancellation was armed, 0 if there was nothing left to cancel —
+    the body already finished, or it returned a still-pending promise and is
+    gone. A body racing its canceller to completion is a normal outcome, not
+    an error.
+
+### THE REQUEST IS CONSUMED
+
+    The raise **clears** the request. A body that catches its own
+    cancellation may go on to `await` cleanup work and even return a value,
+    in which case `p` *fulfills* normally:
+
+```c
+async int worker() {
+    mixed err = acatch(await slow_thing());
+
+    if (err) {
+        await write_log("gave up");   // does NOT re-raise
+        return 0;
+    }
+    return 1;
+}
+```
+
+    So cancellation is a request a body may decline, not a verdict. Cancel
+    again if you mean it again. The alternative — a sticky flag — would make
+    every cleanup `await` throw, leaving a body no way to release what it
+    holds.
+
+### ERRORS
+
+    It is an error to cancel a promise that is not an `async` function's.
+    Only a body has a "next await" for the cancellation to arrive at:
+
+    * a `promise_create()` promise is already settleable by whoever owns it;
+    * an async_read(3)/async_write(3)/async_getdir(3) promise cannot stop the
+      worker thread that is already doing the I/O;
+    * a `call_out(delay)` promise is not cancellable — use the classic
+      `call_out()` form and remove_call_out(3);
+    * rejecting a promise_then(3) chain link cannot stop its upstream.
+
+    To stop *waiting* for any of those without stopping the work, race them
+    against a timer — see promise_race(3).
+
+### NOTES
+
+    Cancellation does **not** propagate. If a cancelled body was awaiting
+    another async function's promise, that inner body keeps running: its
+    promise is first-class and may have other awaiters, `then` handlers, or
+    simply be stored somewhere, and rejecting it would settle it for all of
+    them. A body that wants the inner work stopped too can catch its own
+    cancellation and cancel the inner promise it holds.
+
+### SEE ALSO
+
+    promise_race(3), promise_status(3), promise_reject(3), async_info(3)

--- a/docs/efun/promises/promise_race.md
+++ b/docs/efun/promises/promise_race.md
@@ -1,0 +1,44 @@
+---
+title: promises / promise_race
+---
+# promise_race
+
+### NAME
+
+    promise_race - settle as the first input settles, either way
+
+### SYNOPSIS
+
+    promise promise_race(mixed *promises);
+
+### DESCRIPTION
+
+    Returns a promise that settles exactly as the **first input to settle**
+    does -- fulfilled with its value, or rejected with its reason. A
+    rejection wins a race; that is the difference from promise_any(3),
+    which ignores rejections until every input has failed.
+
+    The losing inputs are not cancelled. They keep running and their results
+    are discarded, so a race is a way to stop *waiting*, not a way to stop
+    work.
+
+    An element that is not a promise counts as already fulfilled with
+    itself, which therefore wins the race outright.
+
+    An **empty array is an error**, not a promise that never settles. This
+    deliberately departs from the JavaScript behaviour: here a permanently
+    pending promise that something awaits is a parked frame holding its
+    object, its program and one `max suspended async functions` slot for the
+    life of the driver, so the mistake is refused where it is made.
+
+### EXAMPLE
+```c
+// bound a wait without touching the operation's own promise
+async mixed with_timeout(promise p, int secs) {
+    return await promise_race(({ p, timeout_promise(secs) }));
+}
+```
+
+### SEE ALSO
+
+    promise_any(3), promise_all(3), promise_all_settled(3), call_out(3)

--- a/docs/lpc/types/promise.md
+++ b/docs/lpc/types/promise.md
@@ -82,3 +82,5 @@ tagged `int`; nothing re-checks it at settle time.
 * `promise_create`, `promise_resolve`, `promise_reject`, `promise_then`,
   `promise_catch`, `promise_status`, `promise_result`, `promisep`,
   `async_yield`, `async_info`
+* combinators: `promise_all`, `promise_any`, `promise_race`,
+  `promise_all_settled`

--- a/docs/lpc/types/promise.md
+++ b/docs/lpc/types/promise.md
@@ -84,3 +84,4 @@ tagged `int`; nothing re-checks it at settle time.
   `async_yield`, `async_info`
 * combinators: `promise_all`, `promise_any`, `promise_race`,
   `promise_all_settled`
+* `promise_cancel` — ask an `async` body to give up at its next `await`

--- a/docs/sidebars.generated.json
+++ b/docs/sidebars.generated.json
@@ -2464,6 +2464,12 @@
           },
           {
             "type": "doc",
+            "id": "efun/promises/promise_cancel",
+            "key": "efun/promises/promise_cancel",
+            "label": "promise_cancel"
+          },
+          {
+            "type": "doc",
             "id": "efun/promises/promise_catch",
             "key": "efun/promises/promise_catch",
             "label": "promise_catch"

--- a/docs/sidebars.generated.json
+++ b/docs/sidebars.generated.json
@@ -2446,6 +2446,24 @@
           },
           {
             "type": "doc",
+            "id": "efun/promises/promise_all",
+            "key": "efun/promises/promise_all",
+            "label": "promise_all"
+          },
+          {
+            "type": "doc",
+            "id": "efun/promises/promise_all_settled",
+            "key": "efun/promises/promise_all_settled",
+            "label": "promise_all_settled"
+          },
+          {
+            "type": "doc",
+            "id": "efun/promises/promise_any",
+            "key": "efun/promises/promise_any",
+            "label": "promise_any"
+          },
+          {
+            "type": "doc",
             "id": "efun/promises/promise_catch",
             "key": "efun/promises/promise_catch",
             "label": "promise_catch"
@@ -2455,6 +2473,12 @@
             "id": "efun/promises/promise_create",
             "key": "efun/promises/promise_create",
             "label": "promise_create"
+          },
+          {
+            "type": "doc",
+            "id": "efun/promises/promise_race",
+            "key": "efun/promises/promise_race",
+            "label": "promise_race"
           },
           {
             "type": "doc",

--- a/src/include/promise.h
+++ b/src/include/promise.h
@@ -1,0 +1,67 @@
+/*
+ * promise.h -- the LPC-visible promise surface: promise_status() codes
+ * and the rejection reasons the driver itself produces.
+ *
+ * Shared between driver and mudlib: the driver rejects with these, LPC
+ * compares against them. Defined once here so the two can never drift.
+ *
+ * Every one is a constant string with a leading "*", the driver's marker for
+ * a value it authored. None of them is an error(): they are delivered
+ * outcomes that arrive at an await() or acatch() like any other rejection,
+ * and none reaches the master's error_handler(). No trailing newline -- these
+ * are values handed to a rejection handler, not messages printed by error().
+ *
+ * They are matched by CONTENT, which means a mudlib can forge one with
+ * throw(). That is accepted: discriminating them authoritatively would need a
+ * driver-reserved value kind, and promise_status() already answers the
+ * question from outside.
+ */
+
+#ifndef _PROMISE_H_
+#define _PROMISE_H_
+
+/* promise_status() return codes. The driver's own state field is typed from
+ * these, so the two cannot disagree. */
+#define PROMISE_PENDING   0
+#define PROMISE_FULFILLED 1
+#define PROMISE_REJECTED  2
+
+/* What a cancelled body's next await raises, and what its promise rejects
+ * with if nothing catches it. Identical on every delivery path -- body
+ * running, queued, or parked -- so one comparison catches all three. */
+#define PROMISE_REASON_CANCELLED "*async function cancelled"
+
+/* The suspended body's owner went away underneath it, so the body can never
+ * continue. PROMISE_REASON_DESTRUCTED is shared by both abandon routes
+ * (destruct_object()'s eager sweep and resume_coroutine()'s check) because
+ * which route a frame takes is an internal scheduling detail. */
+#define PROMISE_REASON_DESTRUCTED "*async function owner was destructed while suspended"
+#define PROMISE_REASON_RECOMPILED "*async function owner was recompiled while suspended"
+#define PROMISE_REASON_REPLACED_PROGRAM "*async function owner's program was replaced while suspended"
+
+/* No stack left to rebuild the frame on when the body was resumed. */
+#define PROMISE_REASON_STACK_OVERFLOW "*stack overflow while resuming async function"
+
+/* A promise lost its last reference before it settled, so whoever was
+ * waiting can never be told. Which one you see says who was waiting: the
+ * adoption source of a resolve-with-promise, a parked body, or a combinator
+ * input. */
+#define PROMISE_REASON_ADOPTION_COLLECTED "*promise adoption source was collected before settling"
+#define PROMISE_REASON_AWAITED_COLLECTED "*awaited promise was collected before settling"
+#define PROMISE_REASON_COLLECTED "*promise was collected before settling"
+
+/* promise_resolve(p, p) -- a promise cannot adopt itself. */
+#define PROMISE_REASON_SELF_RESOLVED "*promise resolved with itself"
+
+/* promise_any() over an empty array: nothing can ever fulfil it. */
+#define PROMISE_REASON_ANY_EMPTY "*promise_any: no promises to wait for"
+
+/* An async_yield() still queued when the driver shut down. */
+#define PROMISE_REASON_YIELD_SHUTDOWN "*async_yield never ran: the driver shut down"
+
+/* promise_reject(p) with no reason. Substituted so a bare reject is never
+ * falsy -- acatch signals failure by yielding the reason, so a falsy reason
+ * would read as success. */
+#define PROMISE_REASON_NO_REASON "*promise rejected"
+
+#endif /* _PROMISE_H_ */

--- a/src/packages/core/core.spec
+++ b/src/packages/core/core.spec
@@ -389,6 +389,12 @@ mixed promise_result(promise);
 /* the *p() type test for T_PROMISE; `mixed`, not `promise`, because the
    whole point is to ask about a value whose type is not known statically */
 int promisep(mixed);
+/* combinators over an array of promises; a non-promise element counts as
+   already fulfilled with itself, so map() output can be passed straight in */
+promise promise_all(mixed *);
+promise promise_any(mixed *);
+promise promise_race(mixed *);
+promise promise_all_settled(mixed *);
 /* pending suspended async function frames, most recently parked last */
 mixed async_info(int default: 0);
 /* a promise fulfilled on the next pass of the event loop, after the driver

--- a/src/packages/core/core.spec
+++ b/src/packages/core/core.spec
@@ -395,6 +395,9 @@ promise promise_all(mixed *);
 promise promise_any(mixed *);
 promise promise_race(mixed *);
 promise promise_all_settled(mixed *);
+/* ask an async function body to give up: its next await raises. Returns 1 if
+   a cancellation was armed, 0 if there was nothing left to cancel. */
+int promise_cancel(promise);
 /* pending suspended async function frames, most recently parked last */
 mixed async_info(int default: 0);
 /* a promise fulfilled on the next pass of the event loop, after the driver

--- a/src/packages/core/promises.cc
+++ b/src/packages/core/promises.cc
@@ -171,6 +171,42 @@ void f_promise_result() {
 }
 #endif
 
+/* shared body of the four combinators; the array arg is spec-typed, so only
+ * its ELEMENTS need checking (AGENTS.md section 2) -- and they need none: a
+ * non-promise element is defined to count as already fulfilled with itself,
+ * so map() output drops straight in. */
+static void promise_combinator_efun(uint8_t kind) {
+  array_t* inputs = sp->u.arr;
+
+  if (kind == PROMISE_COMB_RACE && inputs->size == 0) {
+    /* JS lets this hang forever. Here a hung await is a parked frame holding
+     * its object, its program and one `max suspended async functions` slot
+     * for the life of the driver, so refuse it where the mistake is. */
+    error("promise_race: needs at least one promise; an empty array would never settle.\n");
+  }
+  promise_t* result = promise_combinator_start(kind, inputs);
+  free_svalue(sp, "promise_combinator_efun");
+  sp->type = T_PROMISE;
+  sp->subtype = 0;
+  sp->u.prom = result;
+}
+
+#ifdef F_PROMISE_ALL
+void f_promise_all() { promise_combinator_efun(PROMISE_COMB_ALL); }
+#endif
+
+#ifdef F_PROMISE_ANY
+void f_promise_any() { promise_combinator_efun(PROMISE_COMB_ANY); }
+#endif
+
+#ifdef F_PROMISE_RACE
+void f_promise_race() { promise_combinator_efun(PROMISE_COMB_RACE); }
+#endif
+
+#ifdef F_PROMISE_ALL_SETTLED
+void f_promise_all_settled() { promise_combinator_efun(PROMISE_COMB_ALL_SETTLED); }
+#endif
+
 #ifdef F_PROMISEP
 void f_promisep() {
   /* the argument is `mixed`, so unlike the rest of this file the tag has

--- a/src/packages/core/promises.cc
+++ b/src/packages/core/promises.cc
@@ -207,6 +207,16 @@ void f_promise_race() { promise_combinator_efun(PROMISE_COMB_RACE); }
 void f_promise_all_settled() { promise_combinator_efun(PROMISE_COMB_ALL_SETTLED); }
 #endif
 
+#ifdef F_PROMISE_CANCEL
+void f_promise_cancel() {
+  /* validated (and possibly error()ed) before the stack is touched */
+  int const armed = promise_request_cancel(sp->u.prom);
+
+  free_svalue(sp, "f_promise_cancel");
+  put_number(armed);
+}
+#endif
+
 #ifdef F_PROMISEP
 void f_promisep() {
   /* the argument is `mixed`, so unlike the rest of this file the tag has

--- a/src/packages/core/promises.cc
+++ b/src/packages/core/promises.cc
@@ -1,6 +1,7 @@
 #include "base/package_api.h"
 
 #include "packages/core/call_out.h"
+#include "include/promise.h"  // LPC-visible rejection reasons
 
 /*
  * Promise efuns (issue #1319 phase 1). The T_PROMISE machinery itself lives
@@ -78,7 +79,7 @@ void f_promise_reject() {
   svalue_t default_reason;
   default_reason.type = T_STRING;
   default_reason.subtype = STRING_CONSTANT;
-  default_reason.u.string = "*promise rejected";
+  default_reason.u.string = PROMISE_REASON_NO_REASON;
   promise_settle(p, (num_arg > 1) ? sp : &default_reason, 1);
   pop_n_elems(num_arg);
 }

--- a/src/vm/internal/base/promise.cc
+++ b/src/vm/internal/base/promise.cc
@@ -35,6 +35,12 @@ error_context_t* g_coroutine_econ = nullptr;
 extern int _in_reference_allowed;
 #endif
 
+#ifdef DEBUG
+/* interpret.cc's foreach-temporaries counter. Defined there without a header
+ * declaration, so name it here rather than widen its visibility. */
+extern int stack_in_use_as_temporary;
+#endif
+
 /* Combinator helpers, declared at file scope for the same reason as
  * _in_reference_allowed above: they are DEFINED below the anonymous
  * namespace but CALLED from inside it, and declaring them in there would
@@ -65,6 +71,17 @@ std::unordered_map<object_t*, std::vector<uint64_t>> g_coroutines_by_owner;
 uint64_t g_next_coroutine_id = 0;
 /* the result promise of the innermost running coroutine body */
 promise_t* g_coroutine_promise = nullptr;
+#ifdef DEBUG
+/* stack_in_use_as_temporary as it stood when the innermost body was entered.
+ * foreach bumps that GLOBAL counter to tell break_point() its temporaries are
+ * legitimately sitting above fp; anything above this base belongs to the
+ * running body, and moves into the parked frame with it. Without the split, a
+ * body that parks inside a foreach leaves the count elevated for whatever
+ * runs next, and -- because reset_machine() zeroes it between top-level calls
+ * -- arrives at its resume with the temporaries restored but the count gone,
+ * which is a "Bad stack pointer" fatal on Debug builds. */
+int g_coroutine_temp_base = 0;
+#endif
 
 void free_coroutine(lpc_coroutine_t* coro, svalue_t* reject_with, bool run_lpc);
 bool run_coroutine_body(char* entry_pc, promise_t* p, control_stack_t* async_frame);
@@ -832,6 +849,10 @@ bool run_coroutine_body(char* entry_pc, promise_t* p, control_stack_t* async_fra
   promise_t* prev_promise = g_coroutine_promise;
   g_coroutine_econ = &econ;
   g_coroutine_promise = p;
+#ifdef DEBUG
+  int const prev_temp_base = g_coroutine_temp_base;
+  g_coroutine_temp_base = stack_in_use_as_temporary;
+#endif
   /* RAII, not a tail assignment: `econ` lives on THIS C++ frame, so if an
    * exception ever escapes this function the globals must not be left
    * pointing at it (error_handler() compares current_error_context against
@@ -839,6 +860,9 @@ bool run_coroutine_body(char* entry_pc, promise_t* p, control_stack_t* async_fra
   DEFER {
     g_coroutine_econ = prev_econ;
     g_coroutine_promise = prev_promise;
+#ifdef DEBUG
+    g_coroutine_temp_base = prev_temp_base;
+#endif
     pop_context(&econ);
   };
   bool propagate_eval_error = false;
@@ -1142,6 +1166,21 @@ void resume_coroutine(lpc_coroutine_t* coro, promise_t* source) {
   fp = sp + 1;
   if (coro->frame_size > 0) {
     memcpy(fp, coro->frame, coro->frame_size * sizeof(svalue_t));
+    /* re-derive the frame-relative lvalues against the NEW fp (see the
+     * matching conversion in coroutine_await_pending) */
+    for (int slot : coro->frame_lvalues) {
+      svalue_t* target = fp + fp[slot].u.number;
+      fp[slot].type = T_LVALUE;
+      fp[slot].subtype = 0;
+      fp[slot].u.lvalue = target;
+    }
+    coro->frame_lvalues.clear();
+#ifdef DEBUG
+    /* the temporaries are back on the stack, so the count is owed again --
+     * F_EXIT_FOREACH will retire them one loop at a time as before */
+    stack_in_use_as_temporary += coro->temporaries;
+    coro->temporaries = 0;
+#endif
   }
   sp = fp + coro->frame_size - 1;
   delete[] coro->frame;
@@ -1917,14 +1956,34 @@ void coroutine_await_pending(promise_t* awaited) {
       error("await: too many suspended async functions (limit %d).\n", static_cast<int>(limit));
     }
   }
-  /* transient references into the stacks cannot be parked */
+  /* Transient references into the stacks. A plain T_LVALUE that addresses a
+   * slot INSIDE this frame is fine and is relocated across the suspension
+   * (see the frame copy below) -- that is what every ordinary `foreach`
+   * leaves on the stack for its loop variable, so refusing it blanket-wise
+   * made `await` illegal in any foreach at all.
+   *
+   * Everything else here genuinely cannot be parked, and for different
+   * reasons worth keeping straight:
+   *   - T_LVALUE addressing something outside the frame (a GLOBAL loop
+   *     variable goes through find_value() into the object's variable
+   *     block) has a second relocation base and its own lifetime questions;
+   *     refused for now rather than guessed at.
+   *   - T_LVALUE_BYTE / _CODEPOINT / _RANGE are backed by SHARED VM globals
+   *     (AGENTS.md section 13.9), one instance at a time by construction, so
+   *     they can never be per-frame state -- these stay refused permanently.
+   *   - T_REF and T_ERROR_HANDLER own heap state whose unwind is tied to
+   *     this C++ frame. */
   for (svalue_t* v = fp; v < sp; v++) {
+    if (v->type == T_LVALUE && v->u.lvalue >= fp && v->u.lvalue < sp) {
+      continue; /* relocatable */
+    }
     if (v->type &
         (T_LVALUE | T_LVALUE_BYTE | T_LVALUE_RANGE | T_LVALUE_CODEPOINT | T_REF | T_ERROR_HANDLER)) {
       error(
           "await: cannot suspend while a reference or lvalue is pending on the stack. "
-          "Inside a `foreach` loop, use an indexed `for` loop instead; for a `ref` "
-          "argument, await into a plain variable first and pass that.\n");
+          "A `foreach` over a GLOBAL loop variable or a `ref` one cannot hold an await -- "
+          "use a local loop variable, or an indexed `for`; for a `ref` argument, await "
+          "into a plain variable first and pass that.\n");
     }
   }
 
@@ -1971,7 +2030,32 @@ void coroutine_await_pending(promise_t* awaited) {
   if (n > 0) {
     coro->frame = new svalue_t[n];
     memcpy(coro->frame, fp, n * sizeof(svalue_t));
+    /* Relocate frame-relative lvalues. The resume rebuilds this slice at a
+     * DIFFERENT fp, so a T_LVALUE pointing into it (a foreach loop variable
+     * is the common one) would be stale on arrival. Held as an OFFSET while
+     * parked, and as a T_NUMBER rather than a T_LVALUE carrying an offset in
+     * its pointer, so nothing in between -- free_svalue on the frame, the
+     * debug ref checker's mark_svalue -- can be handed a pointer that no
+     * longer addresses anything. The scan above has already refused every
+     * lvalue kind that is NOT relocatable this way. */
+    for (int i = 0; i < n; i++) {
+      if (coro->frame[i].type != T_LVALUE) {
+        continue;
+      }
+      coro->frame_lvalues.push_back(i);
+      coro->frame[i].type = T_NUMBER;
+      coro->frame[i].subtype = 0;
+      coro->frame[i].u.number = coro->frame[i].u.lvalue - fp;
+    }
   }
+
+#ifdef DEBUG
+  /* The foreach temporaries above fp leave the stack with the frame, so the
+   * global count hands its body-owned part over to the coroutine and drops
+   * back to what the enclosing frames legitimately have. */
+  coro->temporaries = stack_in_use_as_temporary - g_coroutine_temp_base;
+  stack_in_use_as_temporary = g_coroutine_temp_base;
+#endif
 
   /* registered from the moment it exists: every free_coroutine() erases */
   g_live_coroutines[coro->id] = coro;

--- a/src/vm/internal/base/promise.cc
+++ b/src/vm/internal/base/promise.cc
@@ -34,6 +34,13 @@ error_context_t* g_coroutine_econ = nullptr;
 extern int _in_reference_allowed;
 #endif
 
+/* Combinator helpers, declared at file scope for the same reason as
+ * _in_reference_allowed above: they are DEFINED below the anonymous
+ * namespace but CALLED from inside it, and declaring them in there would
+ * name a different, never-defined symbol. */
+void free_combinator(promise_combinator_t* c);
+void deliver_combinator(promise_combinator_t* c, int index, svalue_t* value, bool rejected);
+
 namespace {
 
 /* set by coroutine_await_pending(); read by run_coroutine_body() to tell a
@@ -69,6 +76,8 @@ struct QueuedReaction {
   promise_t* next;
   object_t* command_giver;
   lpc_coroutine_t* coro;
+  promise_combinator_t* comb;
+  int comb_index;
   promise_t* source;
 };
 
@@ -409,6 +418,12 @@ void free_queued_reaction(QueuedReaction* qr) {
     free_coroutine(qr->coro, nullptr, false);
     qr->coro = nullptr;
   }
+  if (qr->comb) {
+    /* never delivered (shutdown): this input simply never reports, and the
+     * aggregate dies with the last of its reactions */
+    free_combinator(qr->comb);
+    qr->comb = nullptr;
+  }
   if (qr->source) {
     free_promise(qr->source);
     qr->source = nullptr;
@@ -417,7 +432,8 @@ void free_queued_reaction(QueuedReaction* qr) {
 
 void enqueue_reaction(promise_t* source, promise_reaction_t* r) {
   source->ref++;
-  QueuedReaction qr{r->on_fulfilled, r->on_rejected, r->next, r->command_giver, r->coro, source};
+  QueuedReaction qr{r->on_fulfilled, r->on_rejected, r->next,       r->command_giver,
+                    r->coro,         r->comb,        r->comb_index, source};
   if (qr.coro != nullptr) {
     qr.coro->queued = true;
   }
@@ -507,6 +523,15 @@ void deliver_reaction(QueuedReaction* qr) {
   }
 
   bool const rejected = (src->state == PROMISE_REJECTED);
+
+  if (qr->comb) {
+    /* Pure aggregation: runs no LPC, so it needs neither an eval budget nor
+     * the command_giver dance below, and cannot re-enter the drain. */
+    deliver_combinator(qr->comb, qr->comb_index, &src->result, rejected);
+    free_queued_reaction(qr);
+    return;
+  }
+
   funptr_t* handler = rejected ? qr->on_rejected : qr->on_fulfilled;
 
   object_t* giver = qr->command_giver;
@@ -1368,6 +1393,19 @@ void dealloc_promise(promise_t* p) {
         err.u.string = "*awaited promise was collected before settling";
         free_coroutine(r.coro, &err, false);
       }
+      if (r.comb) {
+        /* This input died unsettled, so it can never report. Deliver a
+         * rejection on its behalf rather than just dropping the reference:
+         * otherwise `remaining` never reaches zero and a promise_all() whose
+         * input was collected stays pending forever -- the same stranded
+         * shape the r.next arm above exists to prevent. */
+        svalue_t err;
+        err.type = T_STRING;
+        err.subtype = STRING_CONSTANT;
+        err.u.string = "*promise was collected before settling";
+        deliver_combinator(r.comb, r.comb_index, &err, true);
+        free_combinator(r.comb);
+      }
     }
     delete p->reactions;
     p->reactions = nullptr;
@@ -1423,7 +1461,7 @@ void promise_add_reaction(promise_t* p, funptr_t* on_fulfilled, funptr_t* on_rej
   if (on_rejected || next) {
     p->handled = true;
   }
-  promise_reaction_t r{on_fulfilled, on_rejected, next, giver, nullptr};
+  promise_reaction_t r{on_fulfilled, on_rejected, next, giver, nullptr, nullptr, 0};
   if (p->state == PROMISE_PENDING) {
     if (!p->reactions) {
       p->reactions = new std::vector<promise_reaction_t>();
@@ -1434,11 +1472,215 @@ void promise_add_reaction(promise_t* p, funptr_t* on_fulfilled, funptr_t* on_rej
   }
 }
 
+/*
+ * Combinators: promise_all / promise_any / promise_race / promise_all_settled.
+ *
+ * One promise_combinator_t is shared by every input's reaction; each holds a
+ * reference, so the aggregate dies with the last input however that input
+ * ends. Aggregation runs no LPC, so it happens inside the delivery like a
+ * pass-through link -- ordering stays the drain's, and a combinator can never
+ * settle its result synchronously from the efun unless every input was a
+ * plain value.
+ */
+
+#ifdef DEBUGMALLOC_EXTENSIONS
+/* Marked from here, once per combinator, NOT from each reaction that points
+ * at it: N reactions share one aggregate holding ONE reference to `result`
+ * and `slots`, so per-reaction marking would report N-1 phantom refs. Same
+ * reason g_active_body_promises exists. */
+std::vector<promise_combinator_t*> g_live_combinators;
+#endif
+
+void free_combinator(promise_combinator_t* c) {
+  if (--c->ref > 0) {
+    return;
+  }
+#ifdef DEBUGMALLOC_EXTENSIONS
+  for (auto it = g_live_combinators.begin(); it != g_live_combinators.end(); ++it) {
+    if (*it == c) {
+      g_live_combinators.erase(it);
+      break;
+    }
+  }
+#endif
+  if (c->result) {
+    free_promise(c->result);
+  }
+  if (c->slots) {
+    free_array(c->slots);
+  }
+  delete c;
+}
+
+/* Insert a constant-named key and return its value slot, ready to overwrite.
+ *
+ * A local mirror of mapping.cc's insert_in_mapping(), which is static there.
+ * Do not be tempted to hand find_for_insert() a reused key svalue: its hash
+ * (svalue_to_int) CONVERTS the key IN PLACE from a constant to a ref-bumped
+ * shared string, so a second insert through the same svalue carries subtype
+ * STRING_SHARED over a string literal and INC_COUNTED_REF writes into
+ * read-only memory. The ref that conversion took is ours to release, on the
+ * throwing path too -- hence the DEFER, exactly as the original explains. */
+svalue_t* promise_map_slot(mapping_t* m, const char* key) {
+  svalue_t lv;
+
+  lv.type = T_STRING;
+  lv.subtype = STRING_CONSTANT;
+  lv.u.string = key;
+  DEFER { free_string(lv.u.string); };
+  return find_for_insert(m, &lv, 1);
+}
+
+/* One input settled (or was a plain value). Records it and settles the result
+ * if this input decided the outcome. Runs no LPC. */
+void deliver_combinator(promise_combinator_t* c, int index, svalue_t* value, bool rejected) {
+  switch (c->kind) {
+    case PROMISE_COMB_RACE:
+      /* first to settle decides, either way */
+      (void)promise_settle(c->result, value, rejected ? 1 : 0);
+      break;
+
+    case PROMISE_COMB_ALL:
+      if (rejected) {
+        (void)promise_settle(c->result, value, 1); /* fail fast */
+      } else {
+        assign_svalue(&c->slots->item[index], value);
+      }
+      break;
+
+    case PROMISE_COMB_ANY:
+      if (rejected) {
+        assign_svalue(&c->slots->item[index], value);
+      } else {
+        (void)promise_settle(c->result, value, 0); /* first success wins */
+      }
+      break;
+
+    case PROMISE_COMB_ALL_SETTLED: {
+      /* ([ "status": 1|2, "value"|"reason": v ]) -- the status codes are
+       * promise_status()'s, so one vocabulary covers both. */
+      mapping_t* m = allocate_mapping(2);
+      svalue_t* slot = promise_map_slot(m, "status");
+      slot->type = T_NUMBER;
+      slot->subtype = 0;
+      slot->u.number = rejected ? PROMISE_REJECTED : PROMISE_FULFILLED;
+      slot = promise_map_slot(m, rejected ? "reason" : "value");
+      assign_svalue_no_free(slot, value);
+      free_svalue(&c->slots->item[index], "deliver_combinator");
+      c->slots->item[index].type = T_MAPPING;
+      c->slots->item[index].u.map = m;
+      break;
+    }
+
+    default:
+      break;
+  }
+
+  /* Decrement unconditionally, including on the paths that already settled
+   * above: a later settle is a silent no-op, so one counter serves every
+   * kind and no arm can forget to advance it. */
+  if (--c->remaining == 0) {
+    if (c->kind == PROMISE_COMB_ALL || c->kind == PROMISE_COMB_ALL_SETTLED) {
+      svalue_t all = const0;
+      all.type = T_ARRAY;
+      all.u.arr = c->slots;
+      (void)promise_settle(c->result, &all, 0);
+    } else if (c->kind == PROMISE_COMB_ANY) {
+      /* every input rejected: reject with the array of reasons */
+      svalue_t all = const0;
+      all.type = T_ARRAY;
+      all.u.arr = c->slots;
+      (void)promise_settle(c->result, &all, 1);
+    }
+  }
+}
+
+promise_t* promise_combinator_start(uint8_t kind, array_t* inputs) {
+  int const n = inputs->size;
+  promise_t* result = promise_alloc();
+
+  if (n == 0) {
+    /* Decided here rather than left to the loop, and deliberately not
+     * uniform: an empty promise_all()/promise_all_settled() has trivially
+     * met its condition, an empty promise_any() can never be satisfied, and
+     * an empty promise_race() would wait forever -- which in a driver is a
+     * parked frame holding an object, a program and a suspension slot for
+     * the life of the process, so it is refused by the efun before it gets
+     * here rather than reproduced from JS. */
+    if (kind == PROMISE_COMB_ANY) {
+      svalue_t err = const0;
+      err.type = T_STRING;
+      err.subtype = STRING_CONSTANT;
+      err.u.string = "*promise_any: no promises to wait for";
+      (void)promise_settle(result, &err, 1);
+    } else {
+      svalue_t empty = const0;
+      empty.type = T_ARRAY;
+      empty.u.arr = &the_null_array;
+      (void)promise_settle(result, &empty, 0);
+    }
+    return result;
+  }
+
+  /* Plain new, not DMALLOC: every TAG_PROMISE block is cast straight to
+   * promise_t* by checkmemory.cc's sweep, so borrowing that tag would be a
+   * type confusion, and a new tag would have to be taught to all of its
+   * walkers. lpc_coroutine_t -- a bigger off-graph struct holding far more
+   * references -- is allocated the same way for the same reason; what the
+   * checker needs is the MARKING below, not the block. */
+  auto* c = new promise_combinator_t{};
+  c->ref = 1; /* held by this function until every input is attached */
+  c->kind = kind;
+  c->result = result;
+  result->ref++;
+  c->slots = allocate_empty_array(n);
+  for (int i = 0; i < n; i++) {
+    c->slots->item[i] = const0;
+  }
+  c->remaining = n;
+#ifdef DEBUGMALLOC_EXTENSIONS
+  g_live_combinators.push_back(c);
+#endif
+
+  /* Two passes. Attaching first means a plain value can never drive
+   * `remaining` to zero while later inputs are still being hooked up, which
+   * would settle the result early and leave the rest writing into a decided
+   * aggregate. */
+  for (int i = 0; i < n; i++) {
+    if (inputs->item[i].type != T_PROMISE) {
+      continue;
+    }
+    promise_t* src = inputs->item[i].u.prom;
+    src->handled = true; /* the combinator observes the rejection */
+    c->ref++;
+    promise_reaction_t r{nullptr, nullptr, nullptr, nullptr, nullptr, c, i};
+    if (src->state == PROMISE_PENDING) {
+      if (!src->reactions) {
+        src->reactions = new std::vector<promise_reaction_t>();
+      }
+      src->reactions->push_back(r);
+    } else {
+      enqueue_reaction(src, &r);
+    }
+  }
+  for (int i = 0; i < n; i++) {
+    if (inputs->item[i].type == T_PROMISE) {
+      continue;
+    }
+    /* A non-promise counts as already fulfilled with itself, so the output of
+     * an ordinary map() can be passed straight in. */
+    deliver_combinator(c, i, &inputs->item[i], false);
+  }
+
+  free_combinator(c); /* release the arming reference */
+  return result;
+}
+
 /* Attach a parked coroutine to the promise it awaits. Ownership of `coro`
  * transfers to the promise machinery. */
 static void promise_add_coroutine(promise_t* p, lpc_coroutine_t* coro) {
   p->handled = true; /* the await observes a rejection */
-  promise_reaction_t r{nullptr, nullptr, nullptr, nullptr, coro};
+  promise_reaction_t r{nullptr, nullptr, nullptr, nullptr, coro, nullptr, 0};
   if (p->state == PROMISE_PENDING) {
     if (!p->reactions) {
       p->reactions = new std::vector<promise_reaction_t>();
@@ -1904,6 +2146,21 @@ void mark_promise_queue() {
    * registry, which is a C++ global the allocation sweep never walks. */
   for (auto* p : g_pending_yields) {
     p->extra_ref++;
+  }
+  /* Combinators, likewise off-graph -- and marked ONCE per aggregate rather
+   * than from each of the N reactions pointing at it, because those N share
+   * a single reference to `result` and `slots`. Marking per reaction would
+   * report N-1 references nobody holds. */
+  for (auto* c : g_live_combinators) {
+    if (c->result) {
+      c->result->extra_ref++;
+    }
+    if (c->slots) {
+      c->slots->extra_ref++;
+      for (int i = 0; i < c->slots->size; i++) {
+        mark_svalue(&c->slots->item[i]);
+      }
+    }
   }
   auto mark_one = [](QueuedReaction& qr) {
     if (qr.on_fulfilled) {

--- a/src/vm/internal/base/promise.cc
+++ b/src/vm/internal/base/promise.cc
@@ -10,6 +10,7 @@
 #include "thirdparty/scope_guard/scope_guard.hpp"  // DEFER
 #include "vm/internal/eval_limit.h"
 #include "vm/internal/simulate.h"  // throw_error (cancellation raise)
+#include "include/promise.h"  // LPC-visible rejection reasons
 
 /*
  * Native LPC promises (issue #1319 phase 1). See promise.h for the ownership
@@ -211,14 +212,14 @@ constexpr LPC_INT kDefaultDrainBudgetUs = 1000;
  * They previously differed in wording and in whether they carried a trailing
  * newline. No trailing newline: this is a value handed to a rejection
  * handler, not a message printed by error(). */
-constexpr const char* kDestructedRejection = "*async function owner was destructed while suspended";
+constexpr const char* kDestructedRejection = PROMISE_REASON_DESTRUCTED;
 /* What a cancelled body's next await raises, and what its promise rejects
  * with if nothing catches it. Matched by CONTENT, like every other reason in
  * this family -- a plain string is forgeable by throw(), which is accepted:
  * discriminating cancellation authoritatively would need a driver-reserved
  * value kind, and promise_status() already answers the question from
  * outside. */
-constexpr const char* kCancelledRejection = "*async function cancelled";
+constexpr const char* kCancelledRejection = PROMISE_REASON_CANCELLED;
 
 /* Consecutive slices that ended with work still queued. Routine under load;
  * a long run of them means the queue is not keeping up. Reset by any slice
@@ -1077,9 +1078,9 @@ void resume_coroutine(lpc_coroutine_t* coro, promise_t* source) {
     if (coro->ob->flags & O_DESTRUCTED) {
       err.u.string = const_cast<char*>(kDestructedRejection);
     } else if (coro->prog_generation != coro->ob->prog_generation) {
-      err.u.string = "*async function owner was recompiled while suspended";
+      err.u.string = PROMISE_REASON_RECOMPILED;
     } else {
-      err.u.string = "*async function owner's program was replaced while suspended";
+      err.u.string = PROMISE_REASON_REPLACED_PROGRAM;
     }
     free_coroutine(coro, &err, true);
     return;
@@ -1119,7 +1120,7 @@ void resume_coroutine(lpc_coroutine_t* coro, promise_t* source) {
     svalue_t err;
     err.type = T_STRING;
     err.subtype = STRING_CONSTANT;
-    err.u.string = "*stack overflow while resuming async function";
+    err.u.string = PROMISE_REASON_STACK_OVERFLOW;
     free_coroutine(coro, &err, true);
     return;
   }
@@ -1450,7 +1451,7 @@ void dealloc_promise(promise_t* p) {
           svalue_t err;
           err.type = T_STRING;
           err.subtype = STRING_CONSTANT;
-          err.u.string = "*promise adoption source was collected before settling";
+          err.u.string = PROMISE_REASON_ADOPTION_COLLECTED;
           (void)promise_settle(r.next, &err, 1);
         }
         free_promise(r.next);
@@ -1464,7 +1465,7 @@ void dealloc_promise(promise_t* p) {
         svalue_t err;
         err.type = T_STRING;
         err.subtype = STRING_CONSTANT;
-        err.u.string = "*awaited promise was collected before settling";
+        err.u.string = PROMISE_REASON_AWAITED_COLLECTED;
         free_coroutine(r.coro, &err, false);
       }
       if (r.comb) {
@@ -1476,7 +1477,7 @@ void dealloc_promise(promise_t* p) {
         svalue_t err;
         err.type = T_STRING;
         err.subtype = STRING_CONSTANT;
-        err.u.string = "*promise was collected before settling";
+        err.u.string = PROMISE_REASON_COLLECTED;
         deliver_combinator(r.comb, r.comb_index, &err, true);
         free_combinator(r.comb);
       }
@@ -1514,7 +1515,7 @@ void promise_resolve_with(promise_t* p, svalue_t* value) {
       svalue_t err;
       err.type = T_STRING;
       err.subtype = STRING_CONSTANT;
-      err.u.string = "*promise resolved with itself";
+      err.u.string = PROMISE_REASON_SELF_RESOLVED;
       promise_settle(p, &err, 1);
       return;
     }
@@ -1685,7 +1686,7 @@ promise_t* promise_combinator_start(uint8_t kind, array_t* inputs) {
       svalue_t err = const0;
       err.type = T_STRING;
       err.subtype = STRING_CONSTANT;
-      err.u.string = "*promise_any: no promises to wait for";
+      err.u.string = PROMISE_REASON_ANY_EMPTY;
       (void)promise_settle(result, &err, 1);
     } else {
       svalue_t empty = const0;
@@ -2492,7 +2493,7 @@ void promise_cleanup() {
     svalue_t err;
     err.type = T_STRING;
     err.subtype = STRING_CONSTANT;
-    err.u.string = "*async_yield never ran: the driver shut down";
+    err.u.string = PROMISE_REASON_YIELD_SHUTDOWN;
     (void)promise_settle(p, &err, 1);
     free_promise(p);
   }

--- a/src/vm/internal/base/promise.cc
+++ b/src/vm/internal/base/promise.cc
@@ -9,6 +9,7 @@
 #include "backend.h"
 #include "thirdparty/scope_guard/scope_guard.hpp"  // DEFER
 #include "vm/internal/eval_limit.h"
+#include "vm/internal/simulate.h"  // throw_error (cancellation raise)
 
 /*
  * Native LPC promises (issue #1319 phase 1). See promise.h for the ownership
@@ -194,6 +195,13 @@ constexpr LPC_INT kDefaultDrainBudgetUs = 1000;
  * newline. No trailing newline: this is a value handed to a rejection
  * handler, not a message printed by error(). */
 constexpr const char* kDestructedRejection = "*async function owner was destructed while suspended";
+/* What a cancelled body's next await raises, and what its promise rejects
+ * with if nothing catches it. Matched by CONTENT, like every other reason in
+ * this family -- a plain string is forgeable by throw(), which is accepted:
+ * discriminating cancellation authoritatively would need a driver-reserved
+ * value kind, and promise_status() already answers the question from
+ * outside. */
+constexpr const char* kCancelledRejection = "*async function cancelled";
 
 /* Consecutive slices that ended with work still queued. Routine under load;
  * a long run of them means the queue is not keeping up. Reset by any slice
@@ -1021,7 +1029,11 @@ void free_coroutine(lpc_coroutine_t* coro, svalue_t* reject_with, bool run_lpc) 
 }
 
 void resume_coroutine(lpc_coroutine_t* coro, promise_t* source) {
-  bool const rejected = (source->state == PROMISE_REJECTED);
+  bool rejected = (source->state == PROMISE_REJECTED);
+  /* what the resumed await yields, or rejects with -- the source's result
+   * unless a cancellation overrides it below */
+  svalue_t cancel_reason;
+  svalue_t* reason = &source->result;
 
   /* Three ways the owner can invalidate the parked frame: destruction,
    * recompile_object() (bumps prog_generation), and replace_program()
@@ -1049,11 +1061,33 @@ void resume_coroutine(lpc_coroutine_t* coro, promise_t* source) {
     return;
   }
 
+  /* A cancellation requested while this frame was already QUEUED: it is
+   * sitting AT an await, so converting the delivery in flight into the
+   * cancellation raise is exactly what "raises at the next await" means for
+   * it. Letting the value through and raising one await later would silently
+   * run one more stretch of the body.
+   *
+   * Deliberately AFTER the destruct/staleness block above, which must win: a
+   * frame whose owner is gone cannot run acatch or defer LPC at all, so the
+   * reason that names the real reason it can never continue is the useful
+   * one. A cancellation that loses that race is simply consumed with the
+   * frame. If the queued delivery was itself a rejection, cancellation
+   * overrides its reason -- deterministic, and the canceller has declared
+   * disinterest in the outcome either way. */
+  if (coro->result_promise->cancelled) {
+    coro->result_promise->cancelled = false; /* consume-once */
+    cancel_reason.type = T_STRING;
+    cancel_reason.subtype = STRING_CONSTANT;
+    cancel_reason.u.string = kCancelledRejection;
+    reason = &cancel_reason;
+    rejected = true;
+  }
+
   if (rejected && coro->markers.empty()) {
     /* no acatch() region spans the await: the rejection propagates
      * straight to the coroutine's own promise, no need to rebuild the
      * frame at all (no catch may span an await by construction). */
-    free_coroutine(coro, &source->result, true);
+    free_coroutine(coro, reason, true);
     return;
   }
 
@@ -1165,11 +1199,11 @@ void resume_coroutine(lpc_coroutine_t* coro, promise_t* source) {
   if (!rejected) {
     /* the await expression's value */
     STACK_INC;
-    assign_svalue_no_free(sp, &source->result);
+    assign_svalue_no_free(sp, reason);
     entry = coro->prog->program + coro->pc_offset;
   } else {
     /* re-raise at the await point; the innermost acatch() catches it */
-    assign_svalue(&catch_value, &source->result);
+    assign_svalue(&catch_value, reason);
     entry = unwind_to_acatch_marker(csp);
   }
   /* The eval-cost flag is deliberately NOT consumed here, unlike the
@@ -1259,6 +1293,7 @@ promise_t* promise_alloc() {
   p->handled = false;
   p->resolving = false;
   p->body_owned = false;
+  p->cancelled = false;
   p->value_type = 0;
   p->result = const0;
   p->reactions = nullptr;
@@ -1676,6 +1711,94 @@ promise_t* promise_combinator_start(uint8_t kind, array_t* inputs) {
   return result;
 }
 
+int promise_request_cancel(promise_t* p) {
+  if (!p->body_owned) {
+    /* Only an async function body has a "next await" for a cancellation to
+     * arrive at. Everything else the driver hands out is refused rather than
+     * quietly ignored: a promise_create() promise is already settleable by
+     * whoever owns it (and cancelling someone else's channel is what the
+     * body_owned refusal exists to prevent); an async_read()/async_write()
+     * promise cannot stop the worker thread that is already reading the
+     * file; a call_out(delay) promise is documented as non-cancellable (use
+     * the classic form and remove_call_out()); and rejecting a then-chain
+     * link cannot stop its upstream. */
+    error("promise_cancel: promise does not belong to an async function.\n");
+  }
+  if (p->state != PROMISE_PENDING || p->resolving) {
+    /* Already finished, or the body returned a still-pending promise and is
+     * gone -- in both cases there is no frame left to interrupt. NOT an
+     * error: a body racing to completion against its canceller is the
+     * documented normal outcome, and erroring would make every cancel a
+     * race against its target. */
+    return 0;
+  }
+
+  p->cancelled = true;
+  /* The canceller has forced the outcome, so the rejection below is not
+   * "unhandled" even if nobody attached a handler; without this a
+   * fire-and-forget cancel logs a rejection report when the promise dies. */
+  p->handled = true;
+
+  /* Find the parked frame, if there is one. A linear scan over at most
+   * `max suspended async functions` entries, on a rare user-initiated efun.
+   * Deliberately NOT an index keyed by result promise: that would add two
+   * more sync points to the park/free pair, which is exactly the
+   * "one sibling path forgot" hazard of AGENTS.md section 13.15 -- and the
+   * owner index already needed a Debug sweep to police the two it has. */
+  lpc_coroutine_t* coro = nullptr;
+  for (auto& entry : g_live_coroutines) {
+    if (entry.second->result_promise == p && !entry.second->abandoned) {
+      coro = entry.second;
+      break;
+    }
+  }
+  /* No frame parked on a promise right now: the body is running (its first
+   * synchronous stretch, or after an acatch caught an earlier cancel), or it
+   * is already queued for resumption. Both consume the flag at their own
+   * boundary -- coroutine_await_pending() and resume_coroutine() -- so there
+   * is no window where the request is lost. */
+  if (coro == nullptr || coro->queued || coroutine_is_running(coro)) {
+    return 1;
+  }
+
+  /* Parked on a promise that may never settle, so waiting for it is not an
+   * option: detach the frame and schedule its own rejection delivery. From
+   * here to the enqueue nothing may run LPC or throw -- the coroutine is
+   * owned by a raw local in between. */
+  promise_t* awaited = coro->awaiting;
+  if (awaited != nullptr && awaited->reactions != nullptr) {
+    for (auto rit = awaited->reactions->begin(); rit != awaited->reactions->end(); ++rit) {
+      if (rit->coro == coro) {
+        awaited->reactions->erase(rit);
+        break;
+      }
+    }
+  }
+
+  /* A synthetic already-rejected source to deliver through. coro->awaiting is
+   * REPOINTED at it, which is load-bearing rather than tidiness:
+   * build_async_info() dereferences coro->awaiting unconditionally and it is
+   * deliberately not ref-held, so after the detach above the original could
+   * be freed by its other holders at any moment -- leaving a dangling read
+   * reachable from an ordinary async_info() call. The queued reaction holds a
+   * ref on this one for exactly as long as the coroutine is queued, so the
+   * lifetimes match. */
+  promise_t* s = promise_alloc();
+  svalue_t reason;
+  reason.type = T_STRING;
+  reason.subtype = STRING_CONSTANT;
+  reason.u.string = kCancelledRejection;
+  (void)promise_settle(s, &reason, 1);
+  /* nothing will attach a handler to a promise only the driver can see */
+  s->handled = true;
+  coro->awaiting = s;
+
+  promise_reaction_t r{nullptr, nullptr, nullptr, nullptr, coro, nullptr, 0};
+  enqueue_reaction(s, &r); /* takes its own ref on s, marks coro queued */
+  free_promise(s);         /* the queue is now the sole owner */
+  return 1;
+}
+
 /* Attach a parked coroutine to the promise it awaits. Ownership of `coro`
  * transfers to the promise machinery. */
 static void promise_add_coroutine(promise_t* p, lpc_coroutine_t* coro) {
@@ -1744,6 +1867,29 @@ void coroutine_await_pending(promise_t* awaited) {
   }
   if (!async_frame || !g_coroutine_promise) {
     error("await: not directly inside an async function body.\n");
+  }
+  /* A cancellation requested while this body was RUNNING (its own first
+   * synchronous stretch, or the code after an acatch caught an earlier one)
+   * is delivered here, at the next await -- which is what makes cancellation
+   * cooperative rather than preemptive.
+   *
+   * Raised through the throw path rather than error(), for two reasons: the
+   * caught value is then the IDENTICAL constant the parked route delivers
+   * (an error() would wrap it in its own "*...\n" formatting, so acatch
+   * would see two different spellings depending on where the cancel landed),
+   * and cancellation is a delivered outcome, not a fault, so it should not
+   * reach the error handler's log. f_throw()/throw_error() is the precedent.
+   *
+   * Placed before ANY STACK_INC or allocation below, so the unwind has no
+   * half-initialised slot to trip over (AGENTS.md section 4). */
+  if (g_coroutine_promise->cancelled) {
+    g_coroutine_promise->cancelled = false; /* consume-once */
+    /* the value travels in catch_value, exactly as f_throw() does it */
+    free_svalue(&catch_value, "coroutine_await_pending: cancelled");
+    catch_value.type = T_STRING;
+    catch_value.subtype = STRING_CONSTANT;
+    catch_value.u.string = kCancelledRejection;
+    throw_error();
   }
   /* Parking inside an object that is ALREADY destructed would create a frame
    * nothing can ever clean up: abandon_coroutines_of_object() runs once, from

--- a/src/vm/internal/base/promise.h
+++ b/src/vm/internal/base/promise.h
@@ -98,6 +98,16 @@ struct promise_t {
    * state unreachable by never handing out an async function's resolver;
    * here promises are first-class, so the refusal has to be explicit. */
   bool body_owned;
+  /* A cancellation has been requested on this async body and not yet
+   * delivered. CONSUME-ONCE: the raise clears it, so a body that catches its
+   * cancellation in acatch() can still await cleanup and even return a value
+   * -- cancel is a request the body may decline, not a verdict. Lives on the
+   * promise rather than on lpc_coroutine_t because the promise is the only
+   * LPC-reachable handle AND the durable identity of the body across all its
+   * parks: each park allocates a fresh coroutine and each resume frees it,
+   * and a body running its first synchronous stretch has no coroutine at
+   * all. */
+  bool cancelled;
   /* the declared payload tag of an `async T f()`'s promise, as the runtime
    * T_* mask (0 = unannotated, e.g. promise_create()). The authoritative
    * copy lives in the svalue's subtype -- this is the record that survives
@@ -142,6 +152,12 @@ void push_refed_promise(promise_t* p);
  * Never settles the result before the caller receives it unless every input
  * was a plain value. */
 promise_t* promise_combinator_start(uint8_t kind, struct array_t* inputs);
+
+/* Request cancellation of the async function body that owns `p`. Returns 1
+ * if a cancellation was armed, 0 if there was nothing left to cancel (the
+ * body already finished, or its fate is already committed to an adoption).
+ * error()s if `p` is not an async function's promise. Runs no LPC. */
+int promise_request_cancel(promise_t* p);
 
 /* A promise fulfilled with 0 on the next pass of the event loop -- after the
  * driver has polled sockets, queued commands and fired due timers. This is

--- a/src/vm/internal/base/promise.h
+++ b/src/vm/internal/base/promise.h
@@ -30,11 +30,10 @@
  * any value.
  */
 
-enum : uint8_t {
-  PROMISE_PENDING = 0,
-  PROMISE_FULFILLED = 1,
-  PROMISE_REJECTED = 2,
-};
+/* The state codes are LPC-visible (promise_status() returns them), so they
+ * are defined in include/promise.h and shared with the mudlib rather than
+ * duplicated here. */
+#include "include/promise.h"
 
 /* promise_all() / promise_any() / promise_race() / promise_all_settled() */
 enum : uint8_t {

--- a/src/vm/internal/base/promise.h
+++ b/src/vm/internal/base/promise.h
@@ -225,6 +225,16 @@ struct lpc_coroutine_t {
   struct defer_list* defers; /* the async frame's defers */
   svalue_t* frame;           /* owned bitwise copy of [fp .. sp] */
   int frame_size;
+  /* Slots of `frame` that held a T_LVALUE pointing INTO the frame -- a
+   * foreach loop variable, typically. The resume rebuilds the slice at a
+   * different fp, so those are stored as offsets (and as T_NUMBER, so no
+   * stale pointer exists at any point) and re-derived on arrival. */
+  std::vector<int> frame_lvalues;
+#ifdef DEBUG
+  /* open foreach loops whose temporaries travel inside `frame`. Handed back
+   * to the global counter on resume; see g_coroutine_temp_base. */
+  int temporaries;
+#endif
   /* True from the moment a settle hands this coroutine to the microtask queue
    * until the delivery consumes it. Ownership has moved to the queue by then,
    * so destruct-time abandonment must leave it alone -- freeing it would

--- a/src/vm/internal/base/promise.h
+++ b/src/vm/internal/base/promise.h
@@ -36,12 +36,39 @@ enum : uint8_t {
   PROMISE_REJECTED = 2,
 };
 
+/* promise_all() / promise_any() / promise_race() / promise_all_settled() */
+enum : uint8_t {
+  PROMISE_COMB_ALL = 0,
+  PROMISE_COMB_ANY = 1,
+  PROMISE_COMB_RACE = 2,
+  PROMISE_COMB_ALL_SETTLED = 3,
+};
+
+/* Aggregation state shared by every input reaction of ONE combinator call.
+ * Ref-counted with one reference per outstanding input reaction, so it dies
+ * with the last of them however they end (delivered, or dropped at shutdown).
+ *
+ * It is an OFF-GRAPH holder of `result` and `slots` (AGENTS.md section 3):
+ * reachable only from reaction records, and reachable from SEVERAL of them at
+ * once. That is why the debug ref checker marks it from its own registry
+ * rather than from each reaction -- marking per reaction would bump
+ * extra_ref once per input against a single real reference. */
+struct promise_combinator_t {
+  uint32_t ref;
+  uint8_t kind;             /* PROMISE_COMB_* */
+  struct promise_t* result; /* ref held; settled when the rule below is met */
+  struct array_t* slots;    /* ref held; one entry per input, filled in place */
+  int remaining;            /* inputs not yet settled */
+};
+
 struct promise_reaction_t {
   struct funptr_t* on_fulfilled;    /* ref held; may be null (pass-through) */
   struct funptr_t* on_rejected;     /* ref held; may be null (pass-through) */
   struct promise_t* next;           /* ref held; chained promise to settle; may be null */
   struct object_t* command_giver;   /* ref held; may be null */
   struct lpc_coroutine_t* coro;     /* owned; a parked await to resume; may be null */
+  struct promise_combinator_t* comb; /* ref held; may be null */
+  int comb_index;                   /* which input of `comb` this reaction is */
 };
 
 struct promise_t {
@@ -108,6 +135,13 @@ void promise_add_reaction(promise_t* p, funptr_t* on_fulfilled, funptr_t* on_rej
                           promise_t* next, object_t* giver);
 
 void push_refed_promise(promise_t* p);
+
+/* Build a combinator over `inputs` and return its result promise with one
+ * reference for the caller. An element that is not a promise counts as
+ * already fulfilled with itself (so the output of an ordinary map() works).
+ * Never settles the result before the caller receives it unless every input
+ * was a plain value. */
+promise_t* promise_combinator_start(uint8_t kind, struct array_t* inputs);
 
 /* A promise fulfilled with 0 on the next pass of the event loop -- after the
  * driver has polled sockets, queued commands and fired due timers. This is

--- a/testsuite/single/tests/efuns/async_foreach.lpc
+++ b/testsuite/single/tests/efuns/async_foreach.lpc
@@ -1,0 +1,130 @@
+// `await` inside a foreach loop.
+//
+// Every foreach pushes a T_LVALUE for its loop variable (interpret.cc's
+// F_FOREACH, the branch after the iterable setup), and the suspension used
+// to refuse ANY lvalue on the stack -- so an await was illegal in every
+// foreach shape, including the plain local-variable one.
+//
+// A loop variable's lvalue addresses a slot INSIDE the frame, and the frame
+// is exactly what parking copies and rebuilds. So it is relocatable: held as
+// an offset across the suspension and re-derived against the new fp. What
+// stays refused is the rest, for reasons that differ:
+//
+//   * a GLOBAL loop variable's lvalue points into the object's variable
+//     block -- a second relocation base, not attempted here;
+//   * a `ref` loop variable owns heap state tied to the C++ frame;
+//   * string-char and buffer-byte lvalues are backed by SHARED VM globals
+//     (AGENTS.md 13.9), one instance at a time by construction, so they can
+//     never be per-frame state and are refused permanently.
+
+#include "/include/tests.h"
+
+nosave promise gate;
+nosave int g_loopvar;
+
+private async int sum_array() {
+  int total;
+
+  foreach (int i in ({ 1, 2, 3 })) {
+    total += i * await gate;
+  }
+
+  return total;
+}
+
+private async string cat_string() {
+  string out = "";
+
+  foreach (int c in "abc") {
+    await gate;
+    out += sprintf("%c", c);
+  }
+
+  return out;
+}
+
+private async int sum_mapping() {
+  int total;
+
+  foreach (string k, int v in ([ "a": 1, "b": 2 ])) {
+    total += v * await gate;
+    total += strlen(k);
+  }
+
+  return total;
+}
+
+private async int nested() {
+  int total;
+
+  foreach (int i in ({ 1, 2 })) {
+    foreach (int j in ({ 10, 20 })) {
+      total += (i * j) * await gate;
+    }
+  }
+
+  return total;
+}
+
+private async int global_loopvar() {
+  foreach (g_loopvar in ({ 1, 2 })) {
+    await gate;
+  }
+
+  return 0;
+}
+
+private async int ref_loopvar() {
+  int *a = ({ 1, 2 });
+
+  foreach (int ref x in a) {
+    x = await gate;
+  }
+
+  return 0;
+}
+
+void do_tests() {
+  gate = promise_create();
+  promise_resolve(gate, 2);
+
+  EXPECT_LATCH("array");
+  promise_then(sum_array(), function(mixed v) {
+    ASSERT_EQ(12, v);  // (1+2+3) * 2
+    RELEASE_LATCH("array");
+  });
+
+  EXPECT_LATCH("string");
+  promise_then(cat_string(), function(mixed v) {
+    ASSERT_EQ("abc", v);
+    RELEASE_LATCH("string");
+  });
+
+  EXPECT_LATCH("mapping");
+  promise_then(sum_mapping(), function(mixed v) {
+    ASSERT_EQ(8, v);  // (1+2)*2 + 1 + 1
+    RELEASE_LATCH("mapping");
+  });
+
+  EXPECT_LATCH("nested");
+  promise_then(nested(), function(mixed v) {
+    ASSERT_EQ(180, v);  // (10+20+20+40) * 2
+    RELEASE_LATCH("nested");
+  });
+
+  // Still refused, with a diagnostic that now says which shapes are the
+  // problem rather than blaming foreach as a whole.
+  EXPECT_LATCH("global-refused");
+  promise_catch(global_loopvar(), function(mixed reason) {
+    ASSERT2(stringp(reason) && strsrch(reason, "GLOBAL loop variable") != -1,
+      "a global loop variable is refused, and named: " + reason);
+    RELEASE_LATCH("global-refused");
+  });
+
+  EXPECT_LATCH("ref-refused");
+  promise_catch(ref_loopvar(), function(mixed reason) {
+    ASSERT2(stringp(reason) && strsrch(reason, "cannot suspend") != -1,
+      "a ref loop variable is refused: " + reason);
+    RELEASE_LATCH("ref-refused");
+  });
+}

--- a/testsuite/single/tests/efuns/promise_cancel.lpc
+++ b/testsuite/single/tests/efuns/promise_cancel.lpc
@@ -1,0 +1,127 @@
+// promise_cancel(): ask an async function body to give up.
+//
+// Cooperative, not preemptive. The body's NEXT await raises a catchable
+// cancellation; a stretch of straight-line code already running finishes
+// first, and a body that never awaits again runs to completion. It unwinds
+// through acatch() and runs defer() handlers like any other rejection.
+//
+// CONSUME-ONCE: the raise clears the request, so a body that catches its
+// cancellation can still await cleanup and even return normally. Cancel is a
+// request the body may decline, not a verdict.
+//
+// The awkward case the machinery exists for is a frame parked on a promise
+// that never settles: waiting for it would mean the cancellation never
+// arrives, so the frame is detached from that promise and its rejection is
+// scheduled directly.
+
+#include "/include/tests.h"
+
+nosave promise never, gate;
+nosave promise held, caught_body, defer_body;
+nosave int body_ran_past_await, defer_ran, cleanup_awaited;
+nosave mixed caught;
+
+// Parked on a promise nothing will ever settle.
+private async int stuck() {
+  await never;
+  body_ran_past_await = 1;
+
+  return 1;
+}
+
+// Catches its own cancellation, then does async cleanup and returns anyway.
+private async int recovers() {
+  mixed err = acatch(await never);
+
+  caught = err;
+  // Consume-once: this second await must NOT re-raise.
+  cleanup_awaited = await gate;
+
+  return 42;
+}
+
+private async int with_defer() {
+  defer(function() { defer_ran = 1; });
+  await never;
+
+  return 0;
+}
+
+private async int quick() { return 3; }
+
+private void check_stuck() {
+  EXPECT_LATCH("stuck");
+  held = stuck();
+  ASSERT_EQ(0, promise_status(held));
+  ASSERT_EQ(1, promise_cancel(held));
+
+  promise_catch(held, function(mixed reason) {
+    ASSERT_EQ("*async function cancelled", reason);
+    ASSERT_EQ(0, body_ran_past_await);
+    ASSERT_EQ(2, promise_status(held));
+    RELEASE_LATCH("stuck");
+  });
+}
+
+private void check_recovers() {
+  EXPECT_LATCH("recovers");
+  caught_body = recovers();
+  ASSERT_EQ(1, promise_cancel(caught_body));
+
+  promise_then(caught_body, function(mixed v) {
+    // The body declined the cancellation: its promise FULFILS.
+    ASSERT_EQ(42, v);
+    ASSERT_EQ("*async function cancelled", caught);
+    ASSERT_EQ(9, cleanup_awaited);
+    RELEASE_LATCH("recovers");
+  });
+}
+
+private void check_defer() {
+  EXPECT_LATCH("defer");
+  defer_body = with_defer();
+  ASSERT_EQ(1, promise_cancel(defer_body));
+
+  promise_catch(defer_body, function(mixed reason) {
+    ASSERT_EQ("*async function cancelled", reason);
+    ASSERT_EQ(1, defer_ran);
+    RELEASE_LATCH("defer");
+  });
+}
+
+private void check_refusals() {
+  mixed err;
+  promise done;
+
+  // Not an async function's promise: refused, loudly.
+  err = catch(promise_cancel(promise_create()));
+  ASSERT2(err, "promise_create() promise cannot be cancelled");
+  ASSERT2(stringp(err) && strsrch(err, "does not belong to an async function") != -1,
+    "the refusal says why: " + err);
+
+  err = catch(promise_cancel(promise_then(promise_create(), function(mixed v) { return v; })));
+  ASSERT2(err, "a then-chain link cannot be cancelled");
+
+  err = catch(promise_cancel(call_out(60)));
+  ASSERT2(err, "a call_out(delay) promise cannot be cancelled");
+
+  // An async body that already finished: 0, not an error. A body racing its
+  // canceller to completion is the normal outcome, not a mistake.
+  done = quick();
+  ASSERT_EQ(1, promise_status(done));
+  ASSERT_EQ(0, promise_cancel(done));
+}
+
+void do_tests() {
+  never = promise_create();
+  gate = promise_create();
+
+  check_stuck();
+  check_recovers();
+  check_defer();
+  check_refusals();
+
+  // Lets recovers()' cleanup await through; `never` is deliberately never
+  // settled, which is the whole point of the first three.
+  promise_resolve(gate, 9);
+}

--- a/testsuite/single/tests/efuns/promise_combinators.lpc
+++ b/testsuite/single/tests/efuns/promise_combinators.lpc
@@ -1,0 +1,172 @@
+// promise_all / promise_any / promise_race / promise_all_settled.
+//
+// One aggregate is shared by every input's reaction and dies with the last
+// of them. Aggregation runs no LPC, so it happens inside the delivery like a
+// pass-through chain link: ordering is the drain's, and nothing settles
+// synchronously from the efun unless every input was a plain value.
+//
+// A non-promise element counts as already fulfilled with itself, so the
+// output of an ordinary map() drops straight in without wrapping.
+
+#include "/include/tests.h"
+
+nosave promise a, b, c;
+
+private async int slow(int n, int fail) {
+  await a;
+  if (fail) {
+    error("boom " + n);
+  }
+
+  return n;
+}
+
+private void check_all() {
+  EXPECT_LATCH("all");
+  promise_then(promise_all(({ b, c, 99 })), function(mixed v) {
+    ASSERT2(pointerp(v), "promise_all fulfils with an array");
+    ASSERT_EQ(3, sizeof(v));
+    // Positional: slot i is input i, whatever order they settled in.
+    ASSERT_EQ(1, v[0]);
+    ASSERT_EQ(2, v[1]);
+    ASSERT_EQ(99, v[2]);
+    RELEASE_LATCH("all");
+  });
+}
+
+private void check_all_fail() {
+  promise x = promise_create();
+  promise y = promise_create();
+
+  EXPECT_LATCH("all-fail");
+  promise_catch(promise_all(({ x, y })), function(mixed reason) {
+    ASSERT_EQ("*first to fail", reason);
+    RELEASE_LATCH("all-fail");
+  });
+  promise_reject(x, "*first to fail");
+  promise_reject(y, "*second, ignored");
+}
+
+private void check_any() {
+  promise x = promise_create();
+  promise y = promise_create();
+
+  EXPECT_LATCH("any");
+  promise_then(promise_any(({ x, y })), function(mixed v) {
+    ASSERT_EQ(7, v);
+    RELEASE_LATCH("any");
+  });
+  promise_reject(x, "*this one failed");
+  promise_resolve(y, 7);
+}
+
+private void check_any_all_reject() {
+  promise x = promise_create();
+  promise y = promise_create();
+
+  EXPECT_LATCH("any-none");
+  promise_catch(promise_any(({ x, y })), function(mixed reason) {
+    ASSERT2(pointerp(reason), "promise_any rejects with the array of reasons");
+    ASSERT_EQ(2, sizeof(reason));
+    ASSERT_EQ("*no", reason[0]);
+    ASSERT_EQ("*nope", reason[1]);
+    RELEASE_LATCH("any-none");
+  });
+  promise_reject(x, "*no");
+  promise_reject(y, "*nope");
+}
+
+private void check_race() {
+  promise x = promise_create();
+  promise y = promise_create();
+
+  // A REJECTION wins a race too -- race is first-settled, not first-fulfilled.
+  EXPECT_LATCH("race");
+  promise_catch(promise_race(({ x, y })), function(mixed reason) {
+    ASSERT_EQ("*lost the race", reason);
+    RELEASE_LATCH("race");
+  });
+  promise_reject(x, "*lost the race");
+  promise_resolve(y, 1);
+}
+
+private void check_all_settled() {
+  promise x = promise_create();
+  promise y = promise_create();
+
+  EXPECT_LATCH("settled");
+  promise_then(promise_all_settled(({ x, y })), function(mixed v) {
+    ASSERT_EQ(2, sizeof(v));
+    // status uses promise_status()'s codes, so one vocabulary covers both.
+    ASSERT_EQ(1, v[0]["status"]);
+    ASSERT_EQ("ok", v[0]["value"]);
+    ASSERT_EQ(2, v[1]["status"]);
+    ASSERT_EQ("*bad", v[1]["reason"]);
+    ASSERT2(undefinedp(v[0]["reason"]), "a fulfilled entry carries no reason");
+    ASSERT2(undefinedp(v[1]["value"]), "a rejected entry carries no value");
+    RELEASE_LATCH("settled");
+  });
+  promise_resolve(x, "ok");
+  promise_reject(y, "*bad");
+}
+
+private void check_edges() {
+  mixed err;
+
+  // Empty promise_all/all_settled have trivially met their condition.
+  EXPECT_LATCH("empty-all");
+  promise_then(promise_all(({})), function(mixed v) {
+    ASSERT_EQ(0, sizeof(v));
+    RELEASE_LATCH("empty-all");
+  });
+
+  EXPECT_LATCH("empty-settled");
+  promise_then(promise_all_settled(({})), function(mixed v) {
+    ASSERT_EQ(0, sizeof(v));
+    RELEASE_LATCH("empty-settled");
+  });
+
+  // Empty promise_any can never be satisfied, so it rejects rather than
+  // hanging -- and the reason is truthy, as acatch() requires.
+  EXPECT_LATCH("empty-any");
+  promise_catch(promise_any(({})), function(mixed reason) {
+    ASSERT2(reason, "an empty promise_any rejects with a truthy reason");
+    RELEASE_LATCH("empty-any");
+  });
+
+  // Empty promise_race would wait forever, which here means a parked frame
+  // holding an object, a program and a suspension slot for the life of the
+  // driver. Refused where the mistake is instead of reproduced from JS.
+  err = catch(promise_race(({})));
+  ASSERT2(err, "an empty promise_race is refused");
+  ASSERT2(stringp(err) && strsrch(err, "never settle") != -1,
+    "the refusal says why: " + err);
+
+  // All-plain input settles without any promise being involved.
+  EXPECT_LATCH("plain");
+  promise_then(promise_all(({ 1, "two", 3 })), function(mixed v) {
+    ASSERT_EQ(3, sizeof(v));
+    ASSERT_EQ("two", v[1]);
+    RELEASE_LATCH("plain");
+  });
+}
+
+void do_tests() {
+  a = promise_create();
+  b = slow(1, 0);
+  c = slow(2, 0);
+
+  ASSERT_EQ("promise", typeof(promise_all(({}))));
+  ASSERT2(promisep(promise_race(({ promise_create() }))), "promise_race returns a promise");
+
+  check_all();
+  check_all_fail();
+  check_any();
+  check_any_all_reject();
+  check_race();
+  check_all_settled();
+  check_edges();
+
+  // Releases both async bodies; promise_all above then completes.
+  promise_resolve(a, 0);
+}

--- a/testsuite/single/tests/operators/await.lpc
+++ b/testsuite/single/tests/operators/await.lpc
@@ -85,24 +85,48 @@ async void local_compound_ok() {
   RELEASE_LATCH("local compound assign across a park");
 }
 
-// What the guard DOES cover: a foreach loop keeps an lvalue slot live for
-// its loop variable for the whole body, so a pending await inside one
-// refuses to suspend and acatch observes the error.
-async void foreach_guarded() {
+// A foreach keeps an lvalue slot live for its loop variable across the whole
+// body. For a LOCAL loop variable that lvalue addresses a slot inside the
+// frame, which is exactly what parking copies and rebuilds, so it is
+// relocated across the suspension and the loop resumes normally. (This used
+// to be refused along with everything else; see async_foreach.lpc.)
+async void foreach_local_suspends() {
   int *a = ({ 1, 2 });
   int completed = 0;
+  int total = 0;
   mixed err;
 
   err = acatch {
     foreach (int v in a) {
+      total += v * await pend;
+    }
+    completed = 1;
+  };
+  ASSERT_EQ(0, err);
+  ASSERT_EQ(1, completed);
+  ASSERT_EQ(30, total);  // (1 + 2) * 10
+  RELEASE_LATCH("foreach lvalue relocates across a park");
+}
+
+// What the guard still DOES cover: a GLOBAL loop variable's lvalue points
+// into the object's variable block, a second relocation base this does not
+// attempt, so it refuses and acatch observes the error.
+nosave int foreach_global;
+
+async void foreach_global_guarded() {
+  int completed = 0;
+  mixed err;
+
+  err = acatch {
+    foreach (foreach_global in ({ 1, 2 })) {
       await pend;
     }
     completed = 1;  // must stay 0: the loop must NOT resume normally
   };
-  ASSERT_EQ(0, completed);  // the loop must NOT have resumed normally
+  ASSERT_EQ(0, completed);
   ASSERT(stringp(err));
   ASSERT(strsrch(err, "cannot suspend") != -1);
-  RELEASE_LATCH("foreach lvalue refuses to suspend");
+  RELEASE_LATCH("foreach global lvalue refuses to suspend");
 }
 
 // suspension-limit fixtures: park on a promise that never settles during
@@ -157,8 +181,11 @@ void do_tests() {
   compound_ok();
   EXPECT_LATCH("local compound assign across a park");
   local_compound_ok();
-  EXPECT_LATCH("foreach lvalue refuses to suspend");
-  foreach_guarded();
+  EXPECT_LATCH("foreach lvalue relocates across a park");
+  foreach_local_suspends();
+
+  EXPECT_LATCH("foreach global lvalue refuses to suspend");
+  foreach_global_guarded();
 
   // the runaway-exhaustion guard: parking past the configured limit is a
   // clean error at the await point. 256 + 66 is __RC_MAX_SUSPENDED_ASYNC__


### PR DESCRIPTION
Targets `claude/async-phase15` rather than `master`, since it builds directly on the `promise_cancel()` and combinator work in #1353.

### The problem

The rejection reasons the driver produces are inline string literals at their raise sites, and the promise state codes are an anonymous enum in `vm/internal/base/promise.h`. Neither is visible to a mudlib.

That matters most for cancellation. `promise_cancel()` is a normal control-flow signal — a body that catches it and cleans up is doing the expected thing — but the only way for LPC to tell it apart from a genuine failure is:

```lpc
if(err == "*async function cancelled")
```

A hardcoded literal against a string that lives in the driver's `.cc`, with nothing connecting the two. Reword the reason and every mudlib matching on it breaks silently.

### The change

Move both sets into `src/include/promise.h`, alongside `type.h` and `socket_err.h` — the directory whose README says its contents are "shared between driver and mudlib", and which `ffi.h` and `socket_err.h` already use in exactly this way (`#include`d by the driver's own C++ *and* shipped to the lib).

```
PROMISE_PENDING / _FULFILLED / _REJECTED   promise_status() return codes
PROMISE_REASON_*                           the twelve rejection reasons
```

The driver rejects with those macros; the mudlib compares against them. One definition, so there is nothing to keep in sync.

`vm/internal/base/promise.h` drops its state enum and includes the shared header, so the `state` field and `promise_status()` cannot disagree. `kDestructedRejection` and `kCancelledRejection` keep their explanatory comments and are now initialised from the macros.

The reasons carry their own `PROMISE_REASON_` prefix because the header is included into the driver's C++, where a bare `PROMISE_REJECTED` already means the state code — the two collided on the first build, which is what settled the naming.

### No behaviour change

Every string is byte-identical to what it replaced. Verified against a build of this branch:

```
promise_status(promise_any(({}))) == PROMISE_REJECTED          → 1
promise_result(promise_any(({}))) == PROMISE_REASON_ANY_EMPTY  → 1
```

### Feel free to cherry-pick instead

No need to merge this into your branch if you'd rather not carry a merge commit on an open PR — it is a single self-contained commit on top of `a5ce203a`, so `git cherry-pick` onto `claude/async-phase15` works cleanly and I will close this. Squashing it into whichever commit introduced the reasons is fine too. Whatever keeps #1353 tidiest.