### PR TITLE
tracing: stop a trace that fills its buffer from wedging tracing for good

### DIFF
--- a/src/base/internal/tracing.h
+++ b/src/base/internal/tracing.h
@@ -87,10 +87,14 @@ class Tracer {
   static void end(const std::string_view&, const EventCategory& category);
 
   static inline void start(const char* file) {
-    // If there is already events, flush it out first.
-    if (is_enabled) {
-      collect();
-    }
+    // Flush any pending events first -- unconditionally, NOT only when still
+    // enabled. A trace that hit MAX_EVENTS has already had is_enabled cleared
+    // by TraceWriter::log() while its buffer stayed full, and gating here
+    // both stranded those events and then re-pointed `filename` at the new
+    // trace below, so the old trace's million events would eventually be
+    // dumped under the NEW trace's name. collect() self-guards on an empty
+    // filename, so this is a no-op when there is genuinely nothing pending.
+    collect();
 #ifdef _WIN32
     QueryPerformanceCounter(&basetime);
 #else

--- a/src/packages/core/trace.cc
+++ b/src/packages/core/trace.cc
@@ -8,9 +8,17 @@ void f_dump_trace() { push_array(get_svalue_trace()); }
 
 #ifdef F_TRACE_START
 void f_trace_start() {
-  if (Tracer::enabled()) {
-    Tracer::collect();
-  }
+  // Unconditional: Tracer::collect() self-guards on an empty filename, and
+  // gating it on enabled() is what wedged tracing for the life of the
+  // process. When a trace hits MAX_EVENTS, TraceWriter::log() calls
+  // Tracer::stop() -- it cannot flush from there, since flush() takes the
+  // same lock log() already holds -- so the buffer is left FULL with
+  // is_enabled false. Every flush path was then gated behind enabled(), so
+  // nothing ever drained it: the next trace_start() re-enabled, logged one
+  // event, immediately re-tripped the cap and disabled itself again, and no
+  // file was ever written. Silently -- the "dumping N events" line only
+  // prints from inside flush(). Recovered only by a restart.
+  Tracer::collect();
 
   auto duration_secs = sp->u.number;
   if (duration_secs < 0 || duration_secs > 5 * 60) {
@@ -29,19 +37,20 @@ void f_trace_start() {
   Tracer::start(filename.c_str());
   Tracer::setThreadName("FluffOS Main");
   // register closure.
-  add_walltime_event(std::chrono::seconds(duration_secs), TickEvent::callback_type([] {
-                       if (Tracer::enabled()) {
-                         Tracer::collect();
-                       }
-                     }));
+  // Also unconditional, and this is the one that matters most: it is the
+  // only thing that ends an ordinary trace window, so a trace that overflowed
+  // mid-window has to be able to drain here.
+  add_walltime_event(std::chrono::seconds(duration_secs),
+                     TickEvent::callback_type([] { Tracer::collect(); }));
   pop_2_elems();
 }
 #endif
 
 #ifdef F_TRACE_END
 void f_trace_end() {
-  if (!Tracer::enabled()) return;
-
+  // No enabled() gate: a trace that filled its buffer is exactly the case
+  // that needs ending, and collect() already no-ops when there is nothing
+  // pending.
   Tracer::collect();
 }
 #endif

--- a/testsuite/single/tests/efuns/trace_overflow_recovery.lpc
+++ b/testsuite/single/tests/efuns/trace_overflow_recovery.lpc
@@ -1,0 +1,80 @@
+// Tracing must survive a trace that fills its event buffer.
+//
+// TraceWriter::log() caps the buffer at MAX_EVENTS and calls Tracer::stop()
+// when it fills. It cannot flush there -- flush() takes the lock log() is
+// already holding -- so the buffer is left FULL with is_enabled false. Every
+// path that flushed was then gated behind Tracer::enabled():
+// f_trace_start(), f_trace_end(), the walltime collect callback, and
+// Tracer::start(). None of them ran again, so the buffer was never drained
+// and tracing was dead for the rest of the process: each later trace_start()
+// re-enabled, logged one event, immediately re-tripped the cap, disabled
+// itself again, and wrote nothing. Silently -- the "dumping N events" line
+// only prints from inside flush(). Reported from a live mud that had run 26
+// hours with tracing wedged (issue #1348); only a restart recovered it.
+//
+// Tracer::collect() already self-guards on an empty filename, so the gates
+// were redundant as well as harmful, and they are gone.
+//
+// The overflow trace deliberately targets a directory that does not exist:
+// trace_start() accepts the path, and the dump thread then fails to open it
+// and discards the buffer. A million events would otherwise write ~134 MB of
+// JSON, and the events are not what this file is about.
+
+#define TRACE_FILE "/data/trace_after_overflow.json"
+// Two events per LPC function call, against a 1,000,000 cap. Costs ~260 ms.
+#define OVERFLOW_CALLS 600000
+#define MAX_TRIES 8
+
+nosave int tries;
+
+private void check_file();
+
+// Traced as an LPC function call, which is what generates the events --
+// efun calls and individual instructions are only traced in builds that
+// compile those hooks in.
+private int noop(int x) {
+  return x;
+}
+
+private void burn(int count) {
+  int i;
+
+  for (i = 0; i < count; i++) {
+    noop(i);
+  }
+}
+
+void do_tests() {
+#if efun_defined(trace_start)
+  EXPECT_LATCH("tracing recovers after overflow");
+
+  // Fill the buffer, then end the window.
+  trace_start("/data/no_such_dir/overflow.json", 300);
+  burn(OVERFLOW_CALLS);
+  trace_end();
+
+  // An ordinary short trace afterwards. On the unfixed driver this produces
+  // no file at all.
+  rm(TRACE_FILE);
+  trace_start(TRACE_FILE, 300);
+  burn(50);
+  trace_end();
+
+  // The dump runs on its own thread, so poll for the file rather than
+  // assuming it has landed.
+  call_out((: check_file :), 1);
+#endif
+}
+
+private void check_file() {
+  if (file_size(TRACE_FILE) <= 0 && ++tries < MAX_TRIES) {
+    call_out((: check_file :), 1);
+    return;
+  }
+
+  ASSERT2(file_size(TRACE_FILE) > 0,
+    "after one trace filled its event buffer, a later trace wrote no file at all -- "
+    "tracing is wedged for the life of the process and only a restart recovers it");
+  rm(TRACE_FILE);
+  RELEASE_LATCH("tracing recovers after overflow");
+}


### PR DESCRIPTION
Fixes #1348, reported from a live mud that had run ~26 hours with tracing silently dead.

## The bug

`TraceWriter::log()` caps the buffer at `MAX_EVENTS` and calls `Tracer::stop()` when it fills. It cannot flush there — `flush()` takes the lock `log()` is already holding — so the buffer is left **full, with `is_enabled` false**. Every path that would have drained it was gated behind `Tracer::enabled()`:

* `f_trace_start()` (`packages/core/trace.cc`)
* `f_trace_end()` — `if (!Tracer::enabled()) return;`
* the walltime collect callback that ends a trace window
* `Tracer::start()` (`base/internal/tracing.h`)

So none of them ran again. Each later `trace_start()` re-enabled, logged one event, immediately re-tripped the cap, disabled itself again, and wrote **nothing at all** — silently, because the `dumping N events` line only prints from inside `flush()`. Only a restart recovered it.

`Tracer::collect()` already self-guards on an empty filename, so all four gates were redundant as well as harmful. They are removed.

The gate in `Tracer::start()` was doing a second kind of damage: it skipped the flush and then re-pointed `filename` at the *new* trace, so the stranded million events would eventually be dumped under a later trace's name. That is exactly what the reporter's shutdown log shows — 1000002 events with a 26-hour duration, written at exit by the unconditional `collect()` in `main()`.

Credit to @michaelprograms: the issue diagnosed the root cause correctly and proposed this fix.

## Regression test

`testsuite/single/tests/efuns/trace_overflow_recovery.lpc` fills the buffer (600 000 LPC calls, ~260 ms — two events per call against the 1 000 000 cap), ends that window, then runs an ordinary short trace and asserts a file appears. **Verified to fail on the unfixed binary** with exactly that check.

The overflow trace deliberately targets a directory that does not exist: `trace_start()` accepts the path, and the dump thread then fails to open it and discards the buffer. A million events would otherwise write ~134 MB of JSON, and the events are not what the test is about.

Two details worth knowing if this test ever needs changing: only **LPC function calls** generate events in a normal build (per-efun and per-instruction hooks are compiled out), and the dump runs on its own thread, so the test polls for the file rather than assuming it has landed.

## Validation

Full LPC suite clean on **gcc RelWithDebInfo** and **gcc Debug** (with `check_memory()` after every file); corpus format check clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Pg3YXAaLsiWJrv8AYqdYh3)_