### PR TITLE
vm: put the foreach temporaries count back when an error unwinds

### DIFF
--- a/src/tests/test_lpc.cc
+++ b/src/tests/test_lpc.cc
@@ -564,6 +564,45 @@ TEST_F(DriverTest, ReplaceProgramPolymorphicShellDemoLandsForReal) {
 // behavioral difference (not just a theoretical flag mismatch) by
 // exercising apply.cc's actual permission check via a self-call-other,
 // both pre- and post-swap.
+// Debug-only: stack_in_use_as_temporary and break_point() both exist only
+// under DEBUG (interpret.cc), so there is nothing to check in a release
+// build -- and nothing to link against either.
+#ifdef DEBUG
+TEST_F(DriverTest, ForeachTemporariesRestoredOnUnwind) {
+  // foreach bumps stack_in_use_as_temporary so break_point() knows the
+  // temporaries sitting above fp are legitimate, and F_EXIT_FOREACH retires
+  // them. An error thrown out of the loop never reaches that opcode, so only
+  // the unwind can put the counter back -- and error_context_t does not carry
+  // it. Before this was fixed, one catch() of an error inside a foreach left
+  // the count at 1 for the life of the process, and break_point() only checks
+  // the stack when the count is ZERO: the check silently stopped running for
+  // all later LPC. Nothing in the LPC suite can observe that, hence a unit
+  // test reading the counter directly.
+  extern int stack_in_use_as_temporary;
+  error_context_t econ{};
+  save_context(&econ);
+  try {
+    auto* ob = find_object("/clone/foreach_unwind");
+    ASSERT_NE(ob, nullptr);
+    current_object = master_ob;
+
+    int const before = stack_in_use_as_temporary;
+    apply("caught_in_foreach", ob, 0, ORIGIN_DRIVER);
+    EXPECT_EQ(before, stack_in_use_as_temporary)
+        << "catch() of an error inside a foreach leaked temporaries";
+
+    apply("caught_in_nested_foreach", ob, 0, ORIGIN_DRIVER);
+    EXPECT_EQ(before, stack_in_use_as_temporary)
+        << "the same, unwinding through two open loops";
+    pop_context(&econ);
+  } catch (const char* e) {
+    restore_context(&econ);
+    pop_context(&econ);
+    FAIL() << "unexpected error: " << e;
+  }
+}
+#endif  // DEBUG
+
 TEST_F(DriverTest, ReplaceProgramLandedSwapSemantics) {
   // --- Bug 1 setup: last-call-wins -------------------------------------
   object_t* bug1_ob = nullptr;

--- a/src/vm/internal/base/interpret.cc
+++ b/src/vm/internal/base/interpret.cc
@@ -1363,6 +1363,9 @@ void push_control_stack(int frkind) {
   csp->function_index_offset = function_index_offset;
   csp->variable_index_offset = variable_index_offset;
   csp->defers = nullptr;
+#ifdef DEBUG
+  csp->save_temporaries = stack_in_use_as_temporary;
+#endif
   csp->trace_id.reset();
 }
 
@@ -4704,6 +4707,14 @@ void eval_instruction(char* p) {
 
 static void do_catch(char* pc, unsigned int new_pc_offset) {
   error_context_t econ;
+#ifdef DEBUG
+  /* See control_stack_t::save_temporaries. The unwind below pops the value
+   * stack back to this point, so any foreach temporaries the erroring code
+   * had open go with it; without putting the counter back, a
+   * catch(foreach { error(); }) left it elevated for the rest of the
+   * process and break_point() silently stopped checking. */
+  int const saved_temporaries = stack_in_use_as_temporary;
+#endif
 
   /*
    * Save some global variables that must be restored separately after a
@@ -4725,6 +4736,9 @@ static void do_catch(char* pc, unsigned int new_pc_offset) {
      * must be restored manually here.
      */
     restore_context(&econ);
+#ifdef DEBUG
+    stack_in_use_as_temporary = saved_temporaries;
+#endif
     STACK_INC;
     *sp = catch_value;
     catch_value = const1;

--- a/src/vm/internal/base/interpret.h
+++ b/src/vm/internal/base/interpret.h
@@ -54,6 +54,15 @@ struct control_stack_t {
    * back to it the way restore_context() would. */
   svalue_t* save_sp;
   object_t** save_cgsp;
+#ifdef DEBUG
+  /* stack_in_use_as_temporary as it stood when this frame was pushed. An
+   * unwind cuts the value stack back to the frame, taking any foreach
+   * temporaries above it along, so the counter has to come back with them.
+   * Nothing else restores it -- error_context_t carries sp/csp/cgsp and not
+   * this -- and a NONZERO count silently disables break_point()'s stack
+   * check for all later LPC, so a leak here is permanent and quiet. */
+  int save_temporaries;
+#endif
   struct defer_list* defers;
   int num_local_variables;   /* Local + arguments */
   int function_index_offset; /* Used when executing functions in inherited

--- a/src/vm/internal/base/promise.cc
+++ b/src/vm/internal/base/promise.cc
@@ -32,7 +32,12 @@ error_context_t* g_coroutine_econ = nullptr;
  * everything below lives in an anonymous namespace, and declaring it there
  * would name a DIFFERENT, never-defined symbol and fail to link. */
 extern int _in_reference_allowed;
+
 #endif
+
+/* interpret.cc's foreach-temporaries counter, defined there without a header
+ * declaration. Read only under DEBUG; see control_stack_t::save_temporaries. */
+extern int stack_in_use_as_temporary;
 
 namespace {
 
@@ -757,6 +762,13 @@ char* unwind_to_acatch_marker(control_stack_t* marker) {
       *++sp = const0;
     }
   }
+#ifdef DEBUG
+  /* Same restore do_catch() makes, from the marker frame rather than a C++
+   * local: this unwind reaches the region from the error path, not from the
+   * frame that entered it. An `await` inside a `foreach` inside an
+   * `acatch` is the shape that needs it. */
+  stack_in_use_as_temporary = marker->save_temporaries;
+#endif
   pop_control_stack();
 
   /* kill ref lvalues created at or above the frame we just left */

--- a/testsuite/clone/foreach_unwind.lpc
+++ b/testsuite/clone/foreach_unwind.lpc
@@ -1,0 +1,24 @@
+// Fixtures for DriverTest.ForeachTemporariesRestoredOnUnwind: each opens a
+// foreach (which bumps interpret.cc's stack_in_use_as_temporary) and then
+// errors out of it, so the loop's F_EXIT_FOREACH never runs and only the
+// unwind can put the counter back.
+
+private void thrower() {
+  foreach (int i in ({ 1, 2, 3 })) {
+    error("boom");
+  }
+}
+
+int caught_in_foreach() {
+  return !!catch(thrower());
+}
+
+private void nested_thrower() {
+  foreach (int i in ({ 1, 2 })) {
+    thrower();
+  }
+}
+
+int caught_in_nested_foreach() {
+  return !!catch(nested_thrower());
+}


### PR DESCRIPTION
Found while self-reviewing #1353. **Pre-existing and independent of it** — plain LPC reaches this with no async involved, which is why it is its own PR.

### The bug

`foreach` bumps `interpret.cc`'s `stack_in_use_as_temporary` so `break_point()` knows the temporaries sitting above `fp` are legitimate, and `F_EXIT_FOREACH` retires them. An error thrown out of the loop never reaches that opcode, so only the unwind can put the counter back — and nothing did. `error_context_t` carries `sp`, `csp` and `cgsp`, not this.

```lpc
catch(({ foreach (int i in ({ 1, 2, 3 })) { error("boom"); } }))
```

leaves the count at 1 for the life of the process. `break_point()` only checks the stack when the count is **zero**:

```cpp
if (!stack_in_use_as_temporary && sp - fp - csp->num_local_variables + 1 != 0) {
  fatal("Bad stack pointer.\n");
}
```

So one caught error inside a `foreach` silently switches that check off for **all later LPC**, in every Debug build, permanently — `clear_state()` runs once at backend startup, never per tick and never per error. Quiet in exactly the way that matters: nothing fails, a diagnostic just stops working, and every later stack-accounting bug goes unreported.

### The fix

`control_stack_t` records the counter when a frame is pushed (Debug only), and both unwinds restore it:

- `do_catch()` from a C++ local, since it owns the frame it entered;
- `unwind_to_acatch_marker()` from the marker frame, since it reaches the region from the error path rather than from the frame that entered it. An `await` inside a `foreach` inside an `acatch` is the shape that needs this one.

### Test

`DriverTest.ForeachTemporariesRestoredOnUnwind` pins both, through one and through two open loops, by reading the counter directly. No LPC-level test can observe this — the symptom is a check that stops running — which is why it is a unit test. **Verified to fail without the fix.**

### Verification

Debug build: GTest 393/393; LPC suite `[  PASSED  ] 716 file(s).` exit 0, no `Bad ref count`, no `LEAK`, no deferred post-run failures; `testsuite/format.sh --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)