### PR TITLE
explode: stop rescanning ASCII on every token (#1366)

### DIFF
--- a/src/base/internal/EGCIterator.h
+++ b/src/base/internal/EGCIterator.h
@@ -2,6 +2,7 @@
 #define FLUFFOS_SRC_BASE_INTERNAL_STRUTILS_CC_EGCSTRINGVIEW_H_
 
 #include <algorithm>
+#include <cstdint>
 #include <functional>
 #include <cctype>
 #include <locale>
@@ -179,12 +180,19 @@ class EGCIterator {
     src_ = src;
     len_ = slen;
 
-    if (prev_ascii && slen >= 0 && src >= prev_src &&
-        static_cast<size_t>(src - prev_src) + static_cast<size_t>(slen) <=
-            static_cast<size_t>(prev_len)) {
-      ascii_ = true;
-      ok_ = true;
-      return;
+    // Subrange test is overflow-safe on 32-bit (wasm32): check slen against
+    // prev_len first so (prev_len - slen) cannot wrap, then compare the
+    // pointer offset as uintptr_t rather than subtracting pointers from
+    // possibly distinct objects.
+    if (prev_ascii && slen >= 0 && slen <= prev_len) {
+      const auto src_u = reinterpret_cast<uintptr_t>(src);
+      const auto prev_u = reinterpret_cast<uintptr_t>(prev_src);
+      if (src_u >= prev_u &&
+          src_u - prev_u <= static_cast<uintptr_t>(prev_len) - static_cast<uintptr_t>(slen)) {
+        ascii_ = true;
+        ok_ = true;
+        return;
+      }
     }
 
     ascii_ = all_ascii(src, slen);

--- a/src/base/internal/EGCIterator.h
+++ b/src/base/internal/EGCIterator.h
@@ -161,10 +161,31 @@ class EGCIterator {
   [[nodiscard]] const char* data() const { return src_; }
   [[nodiscard]] int32_t len() const { return len_; }
   void reset(const char* src, int32_t slen) {
+    // explode() (and similar token walks) call reset() once per delimiter
+    // with a suffix/prefix of the same buffer. all_ascii() is a full scan,
+    // so doing it on every remaining slice is O(n²) in token count — that
+    // is issue #1366: explode of 50k ASCII tokens went from ~8 ms to ~237 ms
+    // after reset() started scanning. A subrange of a known-ASCII string is
+    // still ASCII (the CR / high-bit exclusion is closed under substring),
+    // so skip the scan when the new range sits inside the previous one.
+    // icu_ready_ is always dropped: a BreakIterator setText()'d on the old
+    // range must not be reused on the new one.
+    const bool prev_ascii = ok_ && ascii_;
+    const char* const prev_src = src_;
+    const int32_t prev_len = len_;
+
     ok_ = false;
     icu_ready_ = false;
     src_ = src;
     len_ = slen;
+
+    if (prev_ascii && slen >= 0 && src >= prev_src &&
+        static_cast<size_t>(src - prev_src) + static_cast<size_t>(slen) <=
+            static_cast<size_t>(prev_len)) {
+      ascii_ = true;
+      ok_ = true;
+      return;
+    }
 
     ascii_ = all_ascii(src, slen);
     if (ascii_) {

--- a/src/base/internal/EGCIterator.h
+++ b/src/base/internal/EGCIterator.h
@@ -111,6 +111,10 @@ class EGCIterator {
   // Auto-vectorizes to a few bytes per cycle, against ICU's ~50 instructions
   // per cluster.
   static bool all_ascii(const char* src, int32_t slen) {
+    // slen < 0 is not a counted length (ICU uses -1 for NUL-terminated).
+    // The empty loop would otherwise return true, and callers that then
+    // did `size_t n = slen` built a ~2^32/2^64-byte view — SIGSEGV.
+    if (slen < 0) return false;
     unsigned char acc = 0;
     unsigned char cr = 0;
     for (int32_t i = 0; i < slen; i++) {
@@ -161,7 +165,10 @@ class EGCIterator {
   static bool scan_is_ascii(const char* src, int32_t slen) { return all_ascii(src, slen); }
   [[nodiscard]] const char* data() const { return src_; }
   [[nodiscard]] int32_t len() const { return len_; }
-  void reset(const char* src, int32_t slen) {
+  // Virtual so EGCSmartIterator can drop its cached count / cursor. The
+  // EGCIterator constructor calls this by name (C++ does not dispatch to
+  // the derived override during base construction); that is intentional.
+  virtual void reset(const char* src, int32_t slen) {
     // explode() (and similar token walks) call reset() once per delimiter
     // with a suffix/prefix of the same buffer. all_ascii() is a full scan,
     // so doing it on every remaining slice is O(n²) in token count — that
@@ -177,8 +184,16 @@ class EGCIterator {
 
     ok_ = false;
     icu_ready_ = false;
+    ascii_ = false;
     src_ = src;
     len_ = slen;
+
+    // Only -1 means NUL-terminated (ICU convention). Other negatives are
+    // not a length: explode used to pass them after a strstr match that
+    // started inside the counted range and ran past it.
+    if (slen < -1) {
+      return;
+    }
 
     // Subrange test is overflow-safe on 32-bit (wasm32): check slen against
     // prev_len first so (prev_len - slen) cannot wrap, then compare the
@@ -195,10 +210,10 @@ class EGCIterator {
       }
     }
 
-    ascii_ = all_ascii(src, slen);
-    if (ascii_) {
+    if (slen >= 0 && all_ascii(src, slen)) {
       // Pure ASCII is always well-formed UTF-8; defer ICU until something
       // actually asks for the underlying break iterator.
+      ascii_ = true;
       ok_ = true;
       return;
     }

--- a/src/base/internal/strutils.cc
+++ b/src/base/internal/strutils.cc
@@ -196,6 +196,14 @@ int32_t u8_offset_to_egc_index(EGCIterator& iter, int32_t offset) {
   if (offset <= 0) return offset;
   if (!iter.ok()) return -1;
 
+  // CR-free ASCII: every byte is a cluster boundary, so the EGC index is
+  // the byte offset. Driving ICU here (via operator->) is what made
+  // strsrch() of a long ASCII haystack pay a full setText + walk after
+  // strchr already found the match — same class of miss as #1366.
+  if (iter.is_ascii()) {
+    return offset > iter.len() ? -1 : offset;
+  }
+
   int idx = -1;
   int pos = 0;
 
@@ -590,17 +598,20 @@ size_t u8_width(const char* src, int len) {
 
 std::vector<std::string_view> u8_egc_split(const char* src, int32_t slen) {
   std::vector<std::string_view> result;
-  result.reserve(16);
+  if (slen <= 0) return result;
 
   EGCSmartIterator iter(src, slen);
   if (!iter.ok()) return result;
 
-  iter->first();
-  auto start = iter->current();
-  while (iter->next() != icu::BreakIterator::DONE) {
-    auto size = iter->current() - start;
-    result.emplace_back(src + start, size);
-    start = iter->current();
+  // Walk via EGCSmartIterator, not operator->(): the latter ensure_icu()'s
+  // the whole string, so explode(s, "") on ASCII paid a BreakIterator walk
+  // of every byte. first()/next() are arithmetic on the ASCII path.
+  result.reserve(static_cast<size_t>(slen));
+  int32_t start = iter.first();
+  int32_t cur;
+  while ((cur = iter.next()) != icu::BreakIterator::DONE) {
+    result.emplace_back(src + start, cur - start);
+    start = cur;
   }
 
   return result;

--- a/src/base/internal/strutils.cc
+++ b/src/base/internal/strutils.cc
@@ -78,6 +78,28 @@ int32_t u8_egc_find_as_offset(EGCIterator& iter, const char* needle, size_t need
   }
   if (!iter.ok()) return -1;
 
+  // Haystack already proven CR-free ASCII: every byte is a grapheme
+  // boundary, so find/rfind is EGC-correct and must not touch ICU.
+  // explode()'s trailing-delimiter walk used the reverse path, which
+  // previously always called isBoundary() and so ensure_icu()'d the
+  // whole remaining string on every token. A needle with a high bit or
+  // CR cannot occur in this haystack.
+  if (iter.is_ascii()) {
+    bool needle_ascii = true;
+    for (size_t i = 0; i < needle_len; i++) {
+      auto c = static_cast<unsigned char>(needle[i]);
+      if (c >= 0x80u || c == '\r') {
+        needle_ascii = false;
+        break;
+      }
+    }
+    if (!needle_ascii) return -1;
+    std::string_view const hay(haystack, haystack_len);
+    std::string_view const ndl(needle, needle_len);
+    auto pos = reverse ? hay.rfind(ndl) : hay.find(ndl);
+    return pos == std::string_view::npos ? -1 : static_cast<int32_t>(pos);
+  }
+
   // fast track ascii string search upto 4 characters.
   if (!reverse) {
     bool is_all_ascii = false;

--- a/src/base/internal/strutils.cc
+++ b/src/base/internal/strutils.cc
@@ -69,14 +69,19 @@ size_t u8_incomplete_tail(std::string_view buf) {
 // Search "needle' in 'haystack', making sure it matches EGC boundary, returning byte offset.
 int32_t u8_egc_find_as_offset(EGCIterator& iter, const char* needle, size_t needle_len,
                               bool reverse) {
+  if (!iter.ok()) return -1;
+
   const char* haystack = iter.data();
-  size_t const haystack_len = iter.len() == -1 ? strlen(haystack) : iter.len();
+  int32_t const raw_len = iter.len();
+  // Only -1 means NUL-terminated. Casting any other negative to size_t
+  // made the ASCII string_view path scan off the mapping (SIGSEGV).
+  if (raw_len < -1) return -1;
+  size_t const haystack_len = raw_len == -1 ? strlen(haystack) : static_cast<size_t>(raw_len);
 
   // no way
   if (needle_len > haystack_len) {
     return -1;
   }
-  if (!iter.ok()) return -1;
 
   // Haystack already proven CR-free ASCII: every byte is a grapheme
   // boundary, so find/rfind is EGC-correct and must not touch ICU.
@@ -111,11 +116,17 @@ int32_t u8_egc_find_as_offset(EGCIterator& iter, const char* needle, size_t need
       if (i == 3) is_all_ascii = false;
     }
     if (is_all_ascii) {
-      // strstr doesn't follow haystack_len, so we may overrun, wasting some cycles.
+      // strstr does not honor haystack_len. explode()'s trailing-delimiter
+      // trim shortens the count but leaves the C string intact, so a match
+      // can start inside the counted range and extend past it. Accepting
+      // that made sourcelen go negative. Reject unless the whole needle
+      // sits in [0, haystack_len).
       const auto* res = strstr(haystack, needle);
       auto ret = res == nullptr ? -1 : (decltype(haystack))res - haystack;
-      if (ret >= haystack_len) ret = -1;
-      return ret;
+      if (ret < 0 || static_cast<size_t>(ret) > haystack_len - needle_len) {
+        return -1;
+      }
+      return static_cast<int32_t>(ret);
     }
   }
 
@@ -606,7 +617,7 @@ std::vector<std::string_view> u8_egc_split(const char* src, int32_t slen) {
   // Walk via EGCSmartIterator, not operator->(): the latter ensure_icu()'s
   // the whole string, so explode(s, "") on ASCII paid a BreakIterator walk
   // of every byte. first()/next() are arithmetic on the ASCII path.
-  result.reserve(static_cast<size_t>(slen));
+  result.reserve(iter.is_ascii() ? static_cast<size_t>(slen) : 16);
   int32_t start = iter.first();
   int32_t cur;
   while ((cur = iter.next()) != icu::BreakIterator::DONE) {

--- a/src/base/internal/strutils.h
+++ b/src/base/internal/strutils.h
@@ -110,6 +110,12 @@ inline void ReplaceStringInPlace(std::string& subject, const std::string& search
 class EGCSmartIterator : public EGCIterator {
  public:
   EGCSmartIterator(const char* src, int32_t slen) : EGCIterator(src, slen) {}
+  void reset(const char* src, int32_t slen) override {
+    EGCIterator::reset(src, slen);
+    current_idx_ = 0;
+    count_ = -1;
+    ascii_pos_ = 0;
+  }
   size_t count() {
     if (count_ == -1) {
       // ASCII: one cluster per byte, so the count is the byte length. This is

--- a/src/tests/test_lpc.cc
+++ b/src/tests/test_lpc.cc
@@ -255,8 +255,8 @@ TEST_F(DriverTest, ExplodeReversibleAllDelimiters) {
 
 // issue #1366: explode() became superlinear in token count because
 // EGCIterator::reset() rescanned the remaining string for ASCII on every
-// delimiter. Pin the many-token ASCII split; the testsuite's
-// `maximum array size` is 15000, so stay under that.
+// delimiter. Pin the many-token ASCII split. config.test sets
+// `maximum array size` to 100000; stay well under that.
 TEST_F(DriverTest, ExplodeManyAsciiTokens) {
   constexpr int kTokens = 8000;
   std::string s;

--- a/src/tests/test_lpc.cc
+++ b/src/tests/test_lpc.cc
@@ -253,6 +253,25 @@ TEST_F(DriverTest, ExplodeReversibleAllDelimiters) {
   EXPECT_EQ(v->size, 0);
 }
 
+// issue #1366: explode() became superlinear in token count because
+// EGCIterator::reset() rescanned the remaining string for ASCII on every
+// delimiter. Pin the many-token ASCII split; the testsuite's
+// `maximum array size` is 15000, so stay under that.
+TEST_F(DriverTest, ExplodeManyAsciiTokens) {
+  constexpr int kTokens = 8000;
+  std::string s;
+  s.reserve(kTokens * 11);
+  for (int i = 0; i < kTokens; i++) {
+    if (i) s.push_back(' ');
+    s += "abcdefghij";
+  }
+  array_t* v = explode_string(s.c_str(), static_cast<int>(s.size()), " ", 1, false);
+  ASSERT_EQ(v->size, kTokens);
+  EXPECT_STREQ(v->item[0].u.string, "abcdefghij");
+  EXPECT_STREQ(v->item[kTokens - 1].u.string, "abcdefghij");
+  free_array(v);
+}
+
 // Regression test for a heap-use-after-free in dealloc_object()
 // (src/vm/internal/base/object.cc): destruct_object() pushes the object
 // onto the global obj_list_destruct queue (simulate.cc); on the unfixed

--- a/src/tests/test_lpc.cc
+++ b/src/tests/test_lpc.cc
@@ -272,6 +272,59 @@ TEST_F(DriverTest, ExplodeManyAsciiTokens) {
   free_array(v);
 }
 
+// strstr used to accept a delimiter that started inside the counted
+// length and ran into bytes past it (left behind by trailing-delimiter
+// trim). ASCII find/rfind was already correct; the non-ASCII strstr
+// path then let sourcelen go negative and SIGSEGV'd. Pin both.
+TEST_F(DriverTest, ExplodeDelimiterMustNotMatchPastCountedLength) {
+  array_t* v = explode_string("ab---", 5, "--", 2, false);
+  ASSERT_EQ(v->size, 1);
+  EXPECT_STREQ(v->item[0].u.string, "ab-");
+  free_array(v);
+
+  std::string han = "\xe4\xbd\xa0-----";  // 你-----
+  v = explode_string(han.c_str(), static_cast<int>(han.size()), "--", 2, false);
+  ASSERT_EQ(v->size, 1);
+  EXPECT_STREQ(v->item[0].u.string, "\xe4\xbd\xa0-");
+  free_array(v);
+
+  v = explode_string(han.c_str(), static_cast<int>(han.size()), "--", 2, true);
+  ASSERT_EQ(v->size, 3);
+  EXPECT_STREQ(v->item[0].u.string, "\xe4\xbd\xa0-");
+  EXPECT_STREQ(v->item[1].u.string, "");
+  EXPECT_STREQ(v->item[2].u.string, "");
+  char* joined = implode_string(v, "--", 2);
+  EXPECT_STREQ(joined, han.c_str());
+  FREE_MSTR(joined);
+  free_array(v);
+
+  std::string cafe = "caf\xc3\xa9 text\n\n\n\n\n";
+  v = explode_string(cafe.c_str(), static_cast<int>(cafe.size()), "\n\n", 2, false);
+  ASSERT_EQ(v->size, 2);
+  EXPECT_STREQ(v->item[0].u.string, "caf\xc3\xa9 text\n");
+  EXPECT_STREQ(v->item[1].u.string, "");
+  free_array(v);
+
+  std::string cr = "a\r\nb-----";
+  v = explode_string(cr.c_str(), static_cast<int>(cr.size()), "--", 2, false);
+  ASSERT_EQ(v->size, 1);
+  EXPECT_STREQ(v->item[0].u.string, "a\r\nb-");
+  free_array(v);
+}
+
+// Trailing-delimiter walk reset()s to a shrinking prefix once per match.
+// Pin many trailing ASCII delimiters (sibling of ExplodeManyAsciiTokens).
+TEST_F(DriverTest, ExplodeManyTrailingDelimiters) {
+  constexpr int kDelims = 8000;
+  std::string s = "x";
+  s.append(kDelims, ' ');
+  array_t* v = explode_string(s.c_str(), static_cast<int>(s.size()), " ", 1, false);
+  ASSERT_EQ(v->size, kDelims);  // "x" plus (n-1) trailing empties after skipping one
+  EXPECT_STREQ(v->item[0].u.string, "x");
+  EXPECT_STREQ(v->item[kDelims - 1].u.string, "");
+  free_array(v);
+}
+
 // Regression test for a heap-use-after-free in dealloc_object()
 // (src/vm/internal/base/object.cc): destruct_object() pushes the object
 // onto the global obj_list_destruct queue (simulate.cc); on the unfixed

--- a/src/tests/test_lpc.cc
+++ b/src/tests/test_lpc.cc
@@ -282,10 +282,19 @@ TEST_F(DriverTest, ExplodeDelimiterMustNotMatchPastCountedLength) {
   EXPECT_STREQ(v->item[0].u.string, "ab-");
   free_array(v);
 
-  std::string han = "\xe4\xbd\xa0-----";  // 你-----
-  v = explode_string(han.c_str(), static_cast<int>(han.size()), "--", 2, false);
+  // Three dashes: one trailing `--` is skipped, leftover dash stays in
+  // the field. Five dashes: two trailing `--`, skip one, keep one empty.
+  std::string han3 = "\xe4\xbd\xa0---";  // 你---
+  v = explode_string(han3.c_str(), static_cast<int>(han3.size()), "--", 2, false);
   ASSERT_EQ(v->size, 1);
   EXPECT_STREQ(v->item[0].u.string, "\xe4\xbd\xa0-");
+  free_array(v);
+
+  std::string han = "\xe4\xbd\xa0-----";  // 你-----
+  v = explode_string(han.c_str(), static_cast<int>(han.size()), "--", 2, false);
+  ASSERT_EQ(v->size, 2);
+  EXPECT_STREQ(v->item[0].u.string, "\xe4\xbd\xa0-");
+  EXPECT_STREQ(v->item[1].u.string, "");
   free_array(v);
 
   v = explode_string(han.c_str(), static_cast<int>(han.size()), "--", 2, true);
@@ -307,8 +316,9 @@ TEST_F(DriverTest, ExplodeDelimiterMustNotMatchPastCountedLength) {
 
   std::string cr = "a\r\nb-----";
   v = explode_string(cr.c_str(), static_cast<int>(cr.size()), "--", 2, false);
-  ASSERT_EQ(v->size, 1);
+  ASSERT_EQ(v->size, 2);
   EXPECT_STREQ(v->item[0].u.string, "a\r\nb-");
+  EXPECT_STREQ(v->item[1].u.string, "");
   free_array(v);
 }
 

--- a/src/tests/test_strutils.cc
+++ b/src/tests/test_strutils.cc
@@ -1,4 +1,5 @@
 #include <gtest/gtest.h>
+#include <string>
 #include "base/std.h"
 
 #include "base/internal/strutils.h"
@@ -223,6 +224,49 @@ TEST(EGCAsciiFastPath, CrLfIsTheOnlyAsciiJoin) {
           << "ASCII pair (" << a << "," << b << ") clustered unexpectedly";
     }
   }
+}
+
+// explode() reset()s the iterator to a shrinking suffix once per token.
+// A subrange of a known-ASCII string must stay on the ASCII path without
+// a fresh all_ascii() scan (issue #1366). Resetting to a different buffer
+// still has to rescan — including the ASCII → non-ASCII direction.
+TEST(EGCAsciiFastPath, ResetToSuffixStaysAscii) {
+  std::string s(2048, 'x');
+  for (size_t i = 10; i < s.size(); i += 11) s[i] = ' ';
+  EGCIterator it(s.data(), static_cast<int32_t>(s.size()));
+  ASSERT_TRUE(it.is_ascii());
+  for (int32_t off = 0; off + 11 <= static_cast<int32_t>(s.size()); off += 11) {
+    it.reset(s.data() + off, static_cast<int32_t>(s.size()) - off);
+    EXPECT_TRUE(it.ok()) << "offset " << off;
+    EXPECT_TRUE(it.is_ascii()) << "offset " << off;
+    EXPECT_EQ(s.data() + off, it.data());
+  }
+}
+
+TEST(EGCAsciiFastPath, ResetToUnrelatedStringRescans) {
+  EGCIterator it("hello", 5);
+  ASSERT_TRUE(it.is_ascii());
+  const char* wide = "a\xe4\xbd\xa0z";  // a 你 z
+  it.reset(wide, 5);
+  EXPECT_TRUE(it.ok());
+  EXPECT_FALSE(it.is_ascii());
+  it.reset("abc", 3);
+  EXPECT_TRUE(it.ok());
+  EXPECT_TRUE(it.is_ascii());
+}
+
+TEST(U8EgcFind, AsciiForwardAndReverse) {
+  const char* s = "ab cd ab";
+  EGCIterator it(s, 8);
+  ASSERT_TRUE(it.is_ascii());
+  EXPECT_EQ(2, u8_egc_find_as_offset(it, " ", 1, false));
+  EXPECT_EQ(5, u8_egc_find_as_offset(it, " ", 1, true));
+  EXPECT_EQ(0, u8_egc_find_as_offset(it, "ab", 2, false));
+  EXPECT_EQ(6, u8_egc_find_as_offset(it, "ab", 2, true));
+  EXPECT_EQ(-1, u8_egc_find_as_offset(it, "zz", 2, false));
+  EXPECT_EQ(-1, u8_egc_find_as_offset(it, "zz", 2, true));
+  // Non-ASCII needle cannot occur in a CR-free ASCII haystack.
+  EXPECT_EQ(-1, u8_egc_find_as_offset(it, "\xe4\xbd\xa0", 3, false));
 }
 
 // And confirm a CR-bearing string is routed to ICU rather than the fast path.

--- a/src/tests/test_strutils.cc
+++ b/src/tests/test_strutils.cc
@@ -256,6 +256,23 @@ TEST(EGCAsciiFastPath, ResetToUnrelatedStringRescans) {
   EXPECT_TRUE(it.is_ascii());
 }
 
+// explode()'s trailing-delimiter walk reset()s to a prefix (same pointer,
+// shorter length). The empty suffix at the end is the all-delimiters case.
+TEST(EGCAsciiFastPath, ResetToPrefixAndEmptyEndStayAscii) {
+  const char* s = "hello world";
+  EGCIterator it(s, 11);
+  ASSERT_TRUE(it.is_ascii());
+  it.reset(s, 5);  // prefix "hello"
+  EXPECT_TRUE(it.ok());
+  EXPECT_TRUE(it.is_ascii());
+  EXPECT_EQ(s, it.data());
+  EXPECT_EQ(5, it.len());
+  it.reset(s + 11, 0);  // empty suffix at the end
+  EXPECT_TRUE(it.ok());
+  EXPECT_TRUE(it.is_ascii());
+  EXPECT_EQ(0, it.len());
+}
+
 TEST(U8EgcFind, AsciiForwardAndReverse) {
   const char* s = "ab cd ab";
   EGCIterator it(s, 8);
@@ -268,6 +285,7 @@ TEST(U8EgcFind, AsciiForwardAndReverse) {
   EXPECT_EQ(-1, u8_egc_find_as_offset(it, "zz", 2, true));
   // Non-ASCII needle cannot occur in a CR-free ASCII haystack.
   EXPECT_EQ(-1, u8_egc_find_as_offset(it, "\xe4\xbd\xa0", 3, false));
+  EXPECT_EQ(-1, u8_egc_find_as_offset(it, "\r", 1, false));
 }
 
 // u8_offset_to_egc_index used to drive ICU through operator->() even when
@@ -340,6 +358,15 @@ TEST(U8EgcSplit, MatchesIcuOnNonAscii) {
 
 TEST(U8EgcSplit, EmptyInput) {
   EXPECT_TRUE(u8_egc_split("", 0).empty());
+}
+
+TEST(U8EgcSplit, CrLfIsOneCluster) {
+  const char* s = "a\r\nb";
+  auto parts = u8_egc_split(s, 4);
+  ASSERT_EQ(3u, parts.size());
+  EXPECT_EQ("a", parts[0]);
+  EXPECT_EQ(std::string_view("\r\n", 2), parts[1]);
+  EXPECT_EQ("b", parts[2]);
 }
 
 // And confirm a CR-bearing string is routed to ICU rather than the fast path.

--- a/src/tests/test_strutils.cc
+++ b/src/tests/test_strutils.cc
@@ -257,7 +257,9 @@ TEST(EGCAsciiFastPath, ResetToUnrelatedStringRescans) {
 }
 
 // explode()'s trailing-delimiter walk reset()s to a prefix (same pointer,
-// shorter length). The empty suffix at the end is the all-delimiters case.
+// shorter length). The empty suffix at the end is the all-delimiters case
+// and must be taken from the *full* remembered range — after a prefix
+// reset the remembered span is only that prefix, so s+11 is outside it.
 TEST(EGCAsciiFastPath, ResetToPrefixAndEmptyEndStayAscii) {
   const char* s = "hello world";
   EGCIterator it(s, 11);
@@ -267,10 +269,20 @@ TEST(EGCAsciiFastPath, ResetToPrefixAndEmptyEndStayAscii) {
   EXPECT_TRUE(it.is_ascii());
   EXPECT_EQ(s, it.data());
   EXPECT_EQ(5, it.len());
+  it.reset(s, 11);  // restore the full range so the empty end is a subrange
+  ASSERT_TRUE(it.is_ascii());
   it.reset(s + 11, 0);  // empty suffix at the end
   EXPECT_TRUE(it.ok());
   EXPECT_TRUE(it.is_ascii());
   EXPECT_EQ(0, it.len());
+}
+
+TEST(EGCAsciiFastPath, NegativeLenIsNotAscii) {
+  EXPECT_FALSE(EGCIterator::scan_is_ascii("hello", -3));
+  EXPECT_FALSE(EGCIterator::scan_is_ascii("hello", -1));
+  EGCIterator it("hello", -3);
+  EXPECT_FALSE(it.ok());
+  EXPECT_FALSE(it.is_ascii());
 }
 
 TEST(U8EgcFind, AsciiForwardAndReverse) {
@@ -286,6 +298,26 @@ TEST(U8EgcFind, AsciiForwardAndReverse) {
   // Non-ASCII needle cannot occur in a CR-free ASCII haystack.
   EXPECT_EQ(-1, u8_egc_find_as_offset(it, "\xe4\xbd\xa0", 3, false));
   EXPECT_EQ(-1, u8_egc_find_as_offset(it, "\r", 1, false));
+}
+
+// strstr ignores the counted length. A needle that starts inside the
+// counted range and runs into bytes past it is not a match — explode's
+// trailing trim leaves those bytes in the C string. The ASCII path
+// already used string_view; this pins the non-ASCII strstr path.
+TEST(U8EgcFind, MatchMustFitInCountedLength) {
+  const char ascii[] = "ab--";
+  EGCIterator ita(ascii, 3);  // "ab-"
+  ASSERT_TRUE(ita.is_ascii());
+  EXPECT_EQ(-1, u8_egc_find_as_offset(ita, "--", 2, false));
+
+  const char wide[] = "\xe4\xbd\xa0--";  // 你-- (5 bytes + NUL)
+  EGCIterator itw(wide, 4);              // 你-
+  ASSERT_FALSE(itw.is_ascii());
+  EXPECT_EQ(-1, u8_egc_find_as_offset(itw, "--", 2, false));
+
+  EGCIterator it_full(wide, 5);
+  ASSERT_FALSE(it_full.is_ascii());
+  EXPECT_EQ(3, u8_egc_find_as_offset(it_full, "--", 2, false));
 }
 
 // u8_offset_to_egc_index used to drive ICU through operator->() even when
@@ -358,6 +390,14 @@ TEST(U8EgcSplit, MatchesIcuOnNonAscii) {
 
 TEST(U8EgcSplit, EmptyInput) {
   EXPECT_TRUE(u8_egc_split("", 0).empty());
+}
+
+TEST(EGCSmartIterator, ResetClearsCachedCount) {
+  EGCSmartIterator it("abcd", 4);
+  EXPECT_EQ(4u, it.count());
+  it.reset("xy", 2);
+  EXPECT_TRUE(it.ok());
+  EXPECT_EQ(2u, it.count());
 }
 
 TEST(U8EgcSplit, CrLfIsOneCluster) {

--- a/src/tests/test_strutils.cc
+++ b/src/tests/test_strutils.cc
@@ -1,5 +1,6 @@
 #include <gtest/gtest.h>
 #include <string>
+#include <vector>
 #include "base/std.h"
 
 #include "base/internal/strutils.h"
@@ -267,6 +268,78 @@ TEST(U8EgcFind, AsciiForwardAndReverse) {
   EXPECT_EQ(-1, u8_egc_find_as_offset(it, "zz", 2, true));
   // Non-ASCII needle cannot occur in a CR-free ASCII haystack.
   EXPECT_EQ(-1, u8_egc_find_as_offset(it, "\xe4\xbd\xa0", 3, false));
+}
+
+// u8_offset_to_egc_index used to drive ICU through operator->() even when
+// the iterator had already classified the haystack as ASCII. strsrch()
+// converts a byte offset to an EGC index through this helper, so ASCII
+// search paid a full setText + walk. Pin against ICU, including the
+// non-boundary case (CRLF) the fast path must not mis-report.
+TEST(U8OffsetToEgcIndex, AsciiOffsetIsIndex) {
+  const char* s = "hello";
+  EGCIterator it(s, 5);
+  ASSERT_TRUE(it.is_ascii());
+  for (int32_t off = 0; off <= 5; off++) {
+    EXPECT_EQ(off, u8_offset_to_egc_index(it, off)) << "offset " << off;
+  }
+  EXPECT_EQ(-1, u8_offset_to_egc_index(it, 6));
+}
+
+TEST(U8OffsetToEgcIndex, CrLfInteriorIsNotABoundary) {
+  const char* s = "a\r\nb";  // clusters: a, CRLF, b — offsets 0, 1, 3, 4
+  EGCIterator it(s, 4);
+  ASSERT_FALSE(it.is_ascii());
+  EXPECT_EQ(0, u8_offset_to_egc_index(it, 0));
+  EXPECT_EQ(1, u8_offset_to_egc_index(it, 1));
+  EXPECT_EQ(-1, u8_offset_to_egc_index(it, 2)) << "interior of CRLF";
+  EXPECT_EQ(2, u8_offset_to_egc_index(it, 3));
+  EXPECT_EQ(3, u8_offset_to_egc_index(it, 4));
+}
+
+TEST(U8OffsetToEgcIndex, MatchesIcuOnNonAscii) {
+  const char* s = "a\xe4\xbd\xa0z";  // a 你 z — 5 bytes, 3 clusters
+  EGCIterator it(s, 5);
+  ASSERT_FALSE(it.is_ascii());
+  EXPECT_EQ(0, u8_offset_to_egc_index(it, 0));
+  EXPECT_EQ(1, u8_offset_to_egc_index(it, 1));
+  EXPECT_EQ(-1, u8_offset_to_egc_index(it, 2));  // interior of 你
+  EXPECT_EQ(-1, u8_offset_to_egc_index(it, 3));
+  EXPECT_EQ(2, u8_offset_to_egc_index(it, 4));
+  EXPECT_EQ(3, u8_offset_to_egc_index(it, 5));
+}
+
+// explode(s, "") walks u8_egc_split, which used to call operator->() and
+// so ensure_icu() on every ASCII string. Drive the real helper against
+// an ICU walk of the same bytes.
+TEST(U8EgcSplit, AsciiOneBytePerCluster) {
+  const char* s = "hello";
+  auto parts = u8_egc_split(s, 5);
+  ASSERT_EQ(5u, parts.size());
+  for (int i = 0; i < 5; i++) {
+    EXPECT_EQ(1u, parts[i].size());
+    EXPECT_EQ(s[i], parts[i][0]);
+  }
+}
+
+TEST(U8EgcSplit, MatchesIcuOnNonAscii) {
+  const char* s = "a\xe4\xbd\xa0z";  // a 你 z
+  auto parts = u8_egc_split(s, 5);
+  EGCIterator ref(s, 5);
+  std::vector<std::string_view> expect;
+  ref->first();
+  auto start = ref->current();
+  while (ref->next() != icu::BreakIterator::DONE) {
+    expect.emplace_back(s + start, ref->current() - start);
+    start = ref->current();
+  }
+  ASSERT_EQ(expect.size(), parts.size());
+  for (size_t i = 0; i < parts.size(); i++) {
+    EXPECT_EQ(expect[i], parts[i]) << "cluster " << i;
+  }
+}
+
+TEST(U8EgcSplit, EmptyInput) {
+  EXPECT_TRUE(u8_egc_split("", 0).empty());
 }
 
 // And confirm a CR-bearing string is routed to ICU rather than the fast path.

--- a/src/vm/internal/base/array.cc
+++ b/src/vm/internal/base/array.cc
@@ -403,11 +403,13 @@ char* implode_string(array_t* arr, const char* del, int del_len) {
   for (i = 0, num = 0; i < arr->size; i++) {
     if (arr->item[i].type == T_STRING) {
       if (num) {
-        strncpy(p, del, del_len);
+        // del_len is the counted LPC string length, so a byte-for-byte copy
+        // is both correct (even with embedded NULs) and faster than strncpy.
+        memcpy(p, del, del_len);
         p += del_len;
       }
       size = SVALUE_STRLEN(&arr->item[i]);
-      strncpy(p, arr->item[i].u.string, size);
+      memcpy(p, arr->item[i].u.string, size);
       p += size;
       num++;
     }

--- a/src/vm/internal/base/array.cc
+++ b/src/vm/internal/base/array.cc
@@ -264,6 +264,9 @@ array_t* explode_string(const char* str, int slen, const char* del, int dellen, 
   auto num_leading = 0;
   auto num_trailing = 0;
 
+  // One iterator over the whole input. Each delimiter match then reset()s
+  // it to the remaining suffix/prefix; for ASCII that must not rescan (see
+  // EGCIterator::reset and issue #1366).
   EGCIterator iter(source, sourcelen);
   /*
    * Count leading 'del' strings.

--- a/testsuite/single/tests/efuns/explode.lpc
+++ b/testsuite/single/tests/efuns/explode.lpc
@@ -128,11 +128,12 @@ void do_tests() {
   // sourcelen went negative and the ASCII string_view path scanned
   // (size_t)-N bytes.
   ASSERT_EQ(({ "ab-" }), explode("ab---", "--"));
-  ASSERT_EQ(({ "你-" }), explode("你-----", "--"));
+  ASSERT_EQ(({ "你-" }), explode("你---", "--"));
+  ASSERT_EQ(({ "你-", "" }), explode("你-----", "--"));
   ASSERT_EQ(({ "你-", "", "" }), explode_reversible("你-----", "--"));
   ASSERT_EQ("你-----", implode(explode_reversible("你-----", "--"), "--"));
   ASSERT_EQ(({ "café text\n", "" }), explode("café text\n\n\n\n\n", "\n\n"));
-  ASSERT_EQ(({ "a\r\nb-" }), explode("a\r\nb-----", "--"));
+  ASSERT_EQ(({ "a\r\nb-", "" }), explode("a\r\nb-----", "--"));
 
   {
     int n = 8000;

--- a/testsuite/single/tests/efuns/explode.lpc
+++ b/testsuite/single/tests/efuns/explode.lpc
@@ -119,4 +119,27 @@ void do_tests() {
     ASSERT_EQ("a", chars[<1]);
     ASSERT_EQ(many, implode(chars, ""));
   }
+
+  // Multi-byte delimiter leftover after trailing trim. Master's strstr
+  // path accepted a match that started inside the counted length and
+  // ran past it, so explode("ab---", "--") returned ({ "ab", "-" }).
+  // ASCII find/rfind was already correct; the strstr end-bound check
+  // makes UTF-8 haystacks match. The UTF-8 cases SIGSEGV'd when
+  // sourcelen went negative and the ASCII string_view path scanned
+  // (size_t)-N bytes.
+  ASSERT_EQ(({ "ab-" }), explode("ab---", "--"));
+  ASSERT_EQ(({ "你-" }), explode("你-----", "--"));
+  ASSERT_EQ(({ "你-", "", "" }), explode_reversible("你-----", "--"));
+  ASSERT_EQ("你-----", implode(explode_reversible("你-----", "--"), "--"));
+  ASSERT_EQ(({ "café text\n", "" }), explode("café text\n\n\n\n\n", "\n\n"));
+  ASSERT_EQ(({ "a\r\nb-" }), explode("a\r\nb-----", "--"));
+
+  {
+    int n = 8000;
+    string many = "x" + repeat_string(" ", n);
+    mixed *parts = explode(many, " ");
+    ASSERT_EQ(n, sizeof(parts));
+    ASSERT_EQ("x", parts[0]);
+    ASSERT_EQ("", parts[<1]);
+  }
 }

--- a/testsuite/single/tests/efuns/explode.lpc
+++ b/testsuite/single/tests/efuns/explode.lpc
@@ -94,4 +94,18 @@ void do_tests() {
   ASSERT_EQ(
     ({ "lh15970183750", "abcdefghigk", "werert" }),
     explode("lh15970183750║abcdefghigk║werert", "║"));
+
+  // issue #1366: many ASCII tokens must still split correctly (and in
+  // linear time — the C++ side of this is EGCIterator::reset skipping
+  // a rescan on suffixes of a known-ASCII string). Stay under the
+  // testsuite `maximum array size` of 15000.
+  {
+    int n = 8000;
+    string many = repeat_string("abcdefghij ", n);
+    mixed *parts = explode(many, " ");
+    ASSERT_EQ(n, sizeof(parts));
+    ASSERT_EQ("abcdefghij", parts[0]);
+    ASSERT_EQ("abcdefghij", parts[<1]);
+    ASSERT_EQ(many, implode(explode_reversible(many, " "), " "));
+  }
 }

--- a/testsuite/single/tests/efuns/explode.lpc
+++ b/testsuite/single/tests/efuns/explode.lpc
@@ -97,8 +97,8 @@ void do_tests() {
 
   // issue #1366: many ASCII tokens must still split correctly (and in
   // linear time — the C++ side of this is EGCIterator::reset skipping
-  // a rescan on suffixes of a known-ASCII string). Stay under the
-  // testsuite `maximum array size` of 15000.
+  // a rescan on suffixes of a known-ASCII string). config.test sets
+  // `maximum array size` to 100000; stay well under that.
   {
     int n = 8000;
     string many = repeat_string("abcdefghij ", n);

--- a/testsuite/single/tests/efuns/explode.lpc
+++ b/testsuite/single/tests/efuns/explode.lpc
@@ -108,4 +108,15 @@ void do_tests() {
     ASSERT_EQ("abcdefghij", parts[<1]);
     ASSERT_EQ(many, implode(explode_reversible(many, " "), " "));
   }
+
+  // explode(s, "") splits on grapheme clusters. The C++ helper used to
+  // drive ICU through operator->() even for ASCII (sibling of #1366).
+  {
+    string many = repeat_string("a", 8000);
+    mixed *chars = explode(many, "");
+    ASSERT_EQ(8000, sizeof(chars));
+    ASSERT_EQ("a", chars[0]);
+    ASSERT_EQ("a", chars[<1]);
+    ASSERT_EQ(many, implode(chars, ""));
+  }
 }

--- a/testsuite/single/tests/efuns/strsrch.lpc
+++ b/testsuite/single/tests/efuns/strsrch.lpc
@@ -43,5 +43,9 @@ TEXT;
     ASSERT_EQ(10, strsrch(many, " "));
     ASSERT_EQ(10, strsrch(many, ' '));
     ASSERT_EQ(sizeof(many) - 1, strsrch(many, " ", 1));
+    // Single-char needles take strchr in f_strsrch; a multi-char needle
+    // is the one that actually reaches u8_egc_find_as_offset.
+    ASSERT_EQ(8, strsrch(many, "ij "));
+    ASSERT_EQ(sizeof(many) - 3, strsrch(many, "ij ", 1));
   }
 }

--- a/testsuite/single/tests/efuns/strsrch.lpc
+++ b/testsuite/single/tests/efuns/strsrch.lpc
@@ -35,4 +35,13 @@ Content-Type: application/json; charset=UTF-8
 {"code":0,"session":"E4EtZGu4"}
 TEXT;
   ASSERT_EQ(155, strsrch(txt, "{"));
+
+  // Sibling of #1366: strsrch converts a byte offset to an EGC index
+  // through u8_offset_to_egc_index, which used to walk ICU even on ASCII.
+  {
+    string many = repeat_string("abcdefghij ", 800);
+    ASSERT_EQ(10, strsrch(many, " "));
+    ASSERT_EQ(10, strsrch(many, ' '));
+    ASSERT_EQ(sizeof(many) - 1, strsrch(many, " ", 1));
+  }
 }


### PR DESCRIPTION
Fixes #1366.

`explode()` became superlinear in token count after #1344. `EGCIterator::reset()` started scanning the remaining string for high-bit bytes / CR on every call so it could skip ICU on pure ASCII. `explode()` calls `reset()` once per delimiter with a suffix of the same buffer, so that scan was O(remaining length) per token.

On the reporter's harness (RelWithDebInfo, same shape: `repeat_string("abcdefghij ", n)` then `explode(s, " ")`):

| tokens | v2026.0801.0 | 20260820 (bad) | this PR |
| --- | --- | --- | --- |
| 1,000 | 172 µs | 410 µs | 110 µs |
| 50,000 | 8,041 µs | 236,905 µs | **1,786 µs** |

A subrange of a known-ASCII string is still ASCII (the CR / high-bit exclusion is closed under substring), so `reset()` now skips the scan when the new range sits inside the previous one. `icu_ready_` is still dropped so a `BreakIterator` `setText()`'d on the old range cannot be reused. The subrange check is overflow-safe on 32-bit (`size_t` wrap on wasm32).

`u8_egc_find_as_offset()` on an already-ASCII haystack uses `find`/`rfind` directly: every byte is a grapheme boundary, so the reverse trailing-delimiter walk no longer `ensure_icu()`'s the remaining string either. A needle with a high bit or CR cannot occur in that haystack.

## Crash: strstr match past the counted length

The ASCII `find`/`rfind` path respects the counted length. The older `strstr` fast path (non-ASCII haystack, short ASCII needle) did not: it only rejected a match that *started* at or past `haystack_len`. `explode()`'s trailing-delimiter trim shortens the count but leaves the C string intact, so a multi-byte delimiter could start on the last counted byte and extend into the trimmed tail.

`explode` then did `sourcelen -= dellen`, which went negative. `all_ascii()` on a negative length returned true (the scan loop never ran), and `haystack_len = (size_t)(-N)` made the new ASCII `string_view` path scan off the mapping — SIGSEGV on UTF-8 haystacks such as `explode("你-----", "--")` / `explode("café text\n\n\n\n\n", "\n\n")`. Master survived because it never built that view, but it accepted the overrun match, so `explode("ab---", "--")` returned `({ "ab", "-" })`.

This PR rejects the match unless the whole needle sits in `[0, haystack_len)`. Only `-1` is treated as NUL-terminated; other negatives are invalid. `all_ascii()` returns false for `slen < 0`. ASCII and UTF-8 now agree: `explode("ab---", "--")` and `explode("你---", "--")` are `({ "ab-" })` / `({ "你-" })`.

## Same class, two more callers

The ASCII fast path lives on `EGCIterator` / `EGCSmartIterator`, but two helpers still reached the `BreakIterator` through `operator->()` and so `ensure_icu()`'d the whole string:

- **`u8_offset_to_egc_index()`** — `strsrch()` converts a byte offset to an EGC index through this. On CR-free ASCII the index *is* the offset; the ICU walk after `strchr` already found the match was pure overhead. Non-ASCII (including CRLF) still walks ICU.
- **`u8_egc_split()`** — `explode(s, "")`. It already constructed an `EGCSmartIterator`, then ignored `first()`/`next()` and drove ICU. ASCII is now arithmetic.

`replace_string()`, `sizeof()`, and `implode()` were checked and are not in this class: replace is a byte skip-table walk, sizeof already uses the memoized ASCII tag, implode never built an EGC iterator.

## Tests
- `EGCAsciiFastPath.ResetToSuffixStaysAscii` / `ResetToPrefixAndEmptyEndStayAscii` / `ResetToUnrelatedStringRescans` / `NegativeLenIsNotAscii`
- `U8EgcFind.AsciiForwardAndReverse` / `MatchMustFitInCountedLength`
- `U8OffsetToEgcIndex.*`, `U8EgcSplit.*` (including CRLF as one cluster)
- `EGCSmartIterator.ResetClearsCachedCount`
- `DriverTest.ExplodeManyAsciiTokens` (8000 tokens), `ExplodeManyTrailingDelimiters`, `ExplodeDelimiterMustNotMatchPastCountedLength` (ASCII + UTF-8 leftover after trailing trim)
- LPC `explode.lpc` (including the SIGSEGV reproducers) and `strsrch.lpc` of a long ASCII haystack with a multi-char needle (single-char `" "` / `' '` take `strchr` in `f_strsrch`)

Validated locally: GTest `strutils_tests` + `DriverTest.Explode*`, LPC `explode.lpc` + `strsrch.lpc`, RelWithDebInfo gcc. CI covers wasm32 / sanitizers.