### PR TITLE
compiler: coerce mixed/call_other op= onto a declared int/float (#1365)

### DIFF
--- a/src/compiler/internal/grammar_rules_exprs.cc
+++ b/src/compiler/internal/grammar_rules_exprs.cc
@@ -429,12 +429,27 @@ void rule_expr_assign(parse_node_t** result, parse_node_t* lval, int opcode, par
      * declared type to enforce here and falls through unchanged; the
      * runtime opcode (F_ADD_EQ/f_*_eq()) then promotes it to float on a
      * float RHS, since that's the only way such a slot can ever become a
-     * float at all. */
+     * float at all.
+     *
+     * TYPE_ANY / TYPE_UNKNOWN on a *call_other* (or evaluate()) is the
+     * #1365 gap: `ob->f()` is statically mixed even when f() is declared
+     * float, so the TYPE_REAL branch above never fires and the runtime
+     * then promotes a genuine int-declared lvalue. Wrap those in
+     * to_int()/to_float(). Do NOT wrap a mixed *variable*: to_int("x")
+     * succeeds (returns 0) and would hide `str[0] += mixed_string`, which
+     * must still be a runtime type error.
+     * to_int() is a no-op on T_NUMBER, so an int-returning call_other is
+     * unchanged. */
+    const bool dyn_call =
+        rval->kind == NODE_EFUN && (rval->v.number == predefs[arrow_efun].token ||
+                                    rval->v.number == predefs[evaluate_efun].token);
+    const bool unknown_rhs =
+        dyn_call && (rval->type == TYPE_ANY || rval->type == TYPE_UNKNOWN);
     if (opcode == F_ADD_EQ || opcode == F_SUB_EQ || opcode == F_MULT_EQ || opcode == F_DIV_EQ) {
-      if (lval->type == TYPE_REAL && rval->type == TYPE_NUMBER) {
+      if (lval->type == TYPE_REAL && (rval->type == TYPE_NUMBER || unknown_rhs)) {
         (*result)->l.expr = promote_to_float(rval);
         (*result)->type = TYPE_REAL;
-      } else if (lval->type == TYPE_NUMBER && rval->type == TYPE_REAL) {
+      } else if (lval->type == TYPE_NUMBER && (rval->type == TYPE_REAL || unknown_rhs)) {
         (*result)->l.expr = promote_to_int(rval);
         (*result)->type = TYPE_NUMBER;
       } else if (opcode == F_ADD_EQ && lval->type == TYPE_BUFFER &&

--- a/src/vm/internal/base/interpret.cc
+++ b/src/vm/internal/base/interpret.cc
@@ -2962,12 +2962,13 @@ void eval_instruction(char* p) {
               lval->subtype = 0;
               /* both sides are numbers, no freeing required */
             } else if (sp->type == T_REAL) {
-              /* A statically int/float-typed lvalue never reaches here with
-               * a float rhs -- the compiler already coerced the rhs to int
-               * (rule_expr_assign, grammar_rules_exprs.cc). This is an
-               * untyped lvalue (mixed variable, mapping value): promote it
-               * to float, since op= is the only way such a slot can ever
-               * become one. */
+              /* A statically int-typed lvalue never reaches here with a
+               * float rhs -- the compiler already coerced the rhs to int
+               * (rule_expr_assign, grammar_rules_exprs.cc), including a
+               * TYPE_ANY/UNKNOWN rhs such as call_other (issue #1365).
+               * This is an untyped lvalue (mixed variable, mapping value):
+               * promote it to float, since op= is the only way such a slot
+               * can ever become one. */
               LPC_FLOAT result = lval->u.number + sp->u.real;
               lval->type = T_REAL;
               lval->u.real = result;

--- a/testsuite/single/tests/operators/compound_assign_float.lpc
+++ b/testsuite/single/tests/operators/compound_assign_float.lpc
@@ -5,13 +5,19 @@
 // A declared int/float variable, or an element of a typed array (`int *`),
 // has a real type contract the compiler can see, so the RHS is coerced to
 // match it at compile time (rule_expr_assign, grammar_rules_exprs.cc) and
-// the lvalue always keeps its declared type.
+// the lvalue always keeps its declared type. That includes a mixed /
+// call_other RHS (issue #1365): `ob->f()` is statically mixed even when
+// f() is declared float, so the compiler still emits to_int()/to_float().
 //
 // A `mixed` variable or a mapping value has no declared type to enforce.
 // Compound-assign is the only way such a slot can ever become a float, so
 // the runtime opcode (F_ADD_EQ/f_sub_eq/f_mult_eq/f_div_eq) promotes it
 // instead of truncating.
 float global_f;
+
+// Honestly typed; the gap is that this_object()->f() is still mixed.
+float give_float() { return 1.5; }
+int give_int() { return 2; }
 
 void do_tests() {
   float f, f2;
@@ -128,4 +134,40 @@ void do_tests() {
   marr[0] += 1.5;
   ASSERT_EQ(1, floatp(marr[0]));
   ASSERT_EQ(6.5, marr[0]);
+
+  // issue #1365: call_other is statically mixed even when the callee is
+  // declared float, so the TYPE_REAL compile-time coercion never fired
+  // and a declared int was promoted at runtime. Same contract as
+  // `i += 1.5` above: keep the declared type. this_object()-> is enough;
+  // a direct give_float() would be statically float and miss the gap.
+  ASSERT_EQ(1, floatp(this_object()->give_float()));
+
+  i = 10; i += this_object()->give_float(); ASSERT_EQ(1, intp(i)); ASSERT_EQ(11, i);
+  i = 10; i -= this_object()->give_float(); ASSERT_EQ(1, intp(i)); ASSERT_EQ(9, i);
+  // Same as `i *= 1.5` above: the RHS is truncated first
+  // (4 * to_int(1.5) == 4, not floor(4 * 1.5)).
+  i = 4; i *= this_object()->give_float(); ASSERT_EQ(1, intp(i)); ASSERT_EQ(4, i);
+  i = 7; i /= this_object()->give_float(); ASSERT_EQ(1, intp(i)); ASSERT_EQ(7, i);
+
+  i = 10; i += this_object()->give_int(); ASSERT_EQ(1, intp(i)); ASSERT_EQ(12, i);
+
+  int *iarr = ({ 10 });
+  iarr[0] += this_object()->give_float();
+  ASSERT_EQ(1, intp(iarr[0]));
+  ASSERT_EQ(11, iarr[0]);
+
+  // A mixed *variable* is still untyped at the use site, so op= promotes
+  // (wrapping every mixed RHS in to_int() would also swallow
+  // `str[0] += mixed_string`, which must stay a runtime error).
+  mixed held = 1.5;
+  i = 10;
+  i += held;
+  ASSERT_EQ(1, floatp(i));
+  ASSERT_EQ(11.5, i);
+
+  // Declared float + call_other stays float (symmetric wrap).
+  f = 10.0;
+  f += this_object()->give_int();
+  ASSERT_EQ(1, floatp(f));
+  ASSERT_EQ(12.0, f);
 }


### PR DESCRIPTION
Fixes #1365.

`int op= <call_other>` promoted a statically-declared `int` to float when the callee's declared return type is `float`. That is the case #1334 does not reach: `this_object()->f()` is statically `mixed` regardless of `f()`'s declared return type, so the existing compile-time `TYPE_REAL` → `to_int()` wrap never fired and `F_ADD_EQ` took the untyped-lvalue promotion path.

| RHS | static type | before | after |
| --- | --- | --- | --- |
| `i += 1.5` | float | `11`, `intp` | unchanged |
| `i += f` (`float f`) | float | `11`, `intp` | unchanged |
| `i += this_object()->give_float()` | **mixed** | **`11.5`, `floatp`** | **`11`, `intp`** |
| `mixed m; m += 1.5` | (untyped LHS) | promotes | unchanged |

`rule_expr_assign` now wraps a `TYPE_ANY` / `TYPE_UNKNOWN` RHS in `to_int()` / `to_float()` when the LHS is a declared `int` / `float`. `to_int()` is a no-op on `T_NUMBER`, so an int-returning `call_other` is unchanged.

`*=` / `/=` coerce the RHS first (same as the existing `i *= 1.5` pin: `3 * to_int(1.5) == 3`), not "compute in float then truncate".

Pinned in `compound_assign_float.lpc` with `this_object()->give_float()` / `give_int()` on the same object.