### PR TITLE
compiler: store the file_info line table as int words (#1359)

### DIFF
--- a/src/compiler/internal/compiler.cc
+++ b/src/compiler/internal/compiler.cc
@@ -3297,7 +3297,8 @@ static void handle_functions() {
  * The program has been compiled. Prepare a 'program_t' to be returned.
  */
 static program_t* epilog(void) {
-  int size, i, lnsz, lnoff;
+  int size, i;
+  size_t lnsz, lnoff;
   char* p;
   int num_func;
   ident_hash_elem_t* ihe;
@@ -3449,6 +3450,20 @@ static program_t* epilog(void) {
     size += align(num_func * sizeof(unsigned short));
   }
 
+  /* file_info header is two ints:
+   *   [0] total bytes of the file_info+line_info allocation
+   *       (dump_line_numbers / dump_prog_json use it as li_end)
+   *   [1] offset in lpc_file_info_t units to the line-number bytes
+   *       (find_line, main_lpcc, the disassembler)
+   * Then (count, file-id) pairs. Words are int so they match current_line
+   * and the rest of the line-number pipeline (issue #1359). Compute the
+   * sizes in size_t to avoid signed overflow, then store as int -- they
+   * fit whenever mem_block could build the table.
+   */
+  lnoff = 2 + static_cast<size_t>(mem_block[A_FILE_INFO].current_size) / sizeof(lpc_file_info_t);
+  lnsz = lnoff * sizeof(lpc_file_info_t) +
+         static_cast<size_t>(mem_block[A_LINENUMBERS].current_size);
+
   p = reinterpret_cast<char*>(DMALLOC(size, TAG_PROGRAM, "epilog: 1"));
   prog = new (p) program_t;
   prog->total_size = size;
@@ -3470,16 +3485,13 @@ static program_t* epilog(void) {
   total_num_prog_blocks++;
   total_prog_block_size += size;
 
-  /* Format is now:
-   * <short total size> <short line_info_offset> <file info> <line info>
+  /* Format:
+   * <int total size> <int line_info_offset> <file info> <line info>
    */
-  lnoff = 2 + (mem_block[A_FILE_INFO].current_size / sizeof(short));
-  lnsz = lnoff * sizeof(short) + mem_block[A_LINENUMBERS].current_size;
+  prog->file_info = reinterpret_cast<lpc_file_info_t*>(DMALLOC(lnsz, TAG_LINENUMBERS, "epilog"));
 
-  prog->file_info = reinterpret_cast<unsigned short*>(DMALLOC(lnsz, TAG_LINENUMBERS, "epilog"));
-
-  prog->file_info[0] = static_cast<unsigned short>(lnsz);
-  prog->file_info[1] = static_cast<unsigned short>(lnoff);
+  prog->file_info[0] = static_cast<lpc_file_info_t>(lnsz);
+  prog->file_info[1] = static_cast<lpc_file_info_t>(lnoff);
 
   memcpy((reinterpret_cast<char*>(&prog->file_info[2])), mem_block[A_FILE_INFO].block,
          mem_block[A_FILE_INFO].current_size);
@@ -3902,11 +3914,12 @@ void prepare_cases(parse_node_t* pn, int start) {
       save_file_info(current_file_id, current_line - current_line_saved);
       current_line_saved = current_line;
 
-      translate_absolute_line(
-          (*ce)->line, reinterpret_cast<unsigned short*>(mem_block[A_FILE_INFO].block), &fi1, &l1);
-      translate_absolute_line((*(ce - 1))->line,
-                              reinterpret_cast<unsigned short*>(mem_block[A_FILE_INFO].block), &fi2,
-                              &l2);
+      {
+        auto* fi_base = reinterpret_cast<lpc_file_info_t*>(mem_block[A_FILE_INFO].block);
+        auto* fi_end = fi_base + mem_block[A_FILE_INFO].current_size / sizeof(lpc_file_info_t);
+        translate_absolute_line((*ce)->line, fi_base, &fi1, &l1, fi_end);
+        translate_absolute_line((*(ce - 1))->line, fi_base, &fi2, &l2, fi_end);
+      }
       f1 = PROG_STRING(fi1 - 1);
       f2 = PROG_STRING(fi2 - 1);
 
@@ -3950,35 +3963,16 @@ void prepare_cases(parse_node_t* pn, int start) {
 }
 
 void save_file_info(int file_id, int lines) {
-  /* The count is 16 bits wide (the whole table is unsigned short pairs), so
-   * a file -- or one contiguous stretch of a file between #includes -- of
-   * 65536 lines used to wrap to 0. translate_absolute_line()'s first pass
-   * then subtracts 0 without ever reducing the line it is looking for, walks
-   * off the end of the table, and returns whatever garbage it lands on as a
-   * file index; the caller feeds that straight to progp->strings[idx - 1].
-   * The first runtime error reported from such a file segfaults the driver.
-   *
-   * Emit the count in chunks of at most 65535 carrying the same file id.
-   * The format is unchanged and the decoder needs no change either: its
-   * second pass already sums every earlier entry with the same file id when
-   * it reconstructs the file-relative line, so a split file decodes exactly
-   * as an unsplit one would have.
-   *
-   * do/while, not while: a zero-line entry is legitimate (an #include on the
-   * first line of a file leaves no lines before it) and must still emit
-   * exactly one entry, as it always did. */
-  do {
-    unsigned short fi[2];
-    int const chunk = (lines > 0xffff) ? 0xffff : lines;
+  /* One (count, file-id) pair per contiguous stretch. Words are int, so
+   * a 65536-line file is a single entry -- the 16-bit wrap that used to
+   * make translate_absolute_line() walk off the table (issue #1355 /
+   * #1359) cannot happen. A zero-line entry is still legitimate (an
+   * #include on the first line of a file) and must emit exactly one pair. */
+  lpc_file_info_t fi[2];
 
-    /* unsigned short, not short: this is how the table is read back, and
-     * storing a count above 32767 through a signed short was needless
-     * implementation-defined behaviour. */
-    fi[0] = static_cast<unsigned short>(chunk);
-    fi[1] = static_cast<unsigned short>(file_id);
-    add_to_mem_block(A_FILE_INFO, (char*)&fi[0], sizeof(fi));
-    lines -= chunk;
-  } while (lines > 0);
+  fi[0] = lines < 0 ? 0 : lines;
+  fi[1] = file_id;
+  add_to_mem_block(A_FILE_INFO, reinterpret_cast<char*>(&fi[0]), sizeof(fi));
 }
 
 int add_program_file(const char* name, int top) {

--- a/src/compiler/internal/disassembler.cc
+++ b/src/compiler/internal/disassembler.cc
@@ -927,7 +927,7 @@ static void disassemble(DisSink& sink, char* code, int start, int end, program_t
 #define INCLUDE_DEPTH 10
 
 static void dump_line_numbers(FILE* f, program_t* prog) {
-  unsigned short* fi;
+  lpc_file_info_t* fi;
   unsigned char* li_start;
   unsigned char* li_end;
   unsigned char* li;
@@ -941,13 +941,15 @@ static void dump_line_numbers(FILE* f, program_t* prog) {
   }
 
   fi = prog->file_info;
+  /* fi[0] is the allocation size in bytes; fi[1] is the offset in
+   * lpc_file_info_t units to the line-number bytes. */
   li_end = reinterpret_cast<unsigned char*>((reinterpret_cast<char*>(fi)) + fi[0]);
   li_start = reinterpret_cast<unsigned char*>(fi + fi[1]);
 
   fi += 2;
   fprintf(f, "\nabsolute line -> (file, line) table:\n");
-  while (fi < reinterpret_cast<unsigned short*>(li_start)) {
-    fprintf(f, "%i lines from %i [%s]\n", fi[0], fi[1], prog->strings[fi[1] - 1]);
+  while (fi < reinterpret_cast<lpc_file_info_t*>(li_start)) {
+    fprintf(f, "%d lines from %d [%s]\n", fi[0], fi[1], prog->strings[fi[1] - 1]);
     fi += 2;
   }
 
@@ -1021,12 +1023,13 @@ static nlohmann::json prog_details_json(program_t* prog, int flags) {
 
   if ((flags & 2) && prog->line_info != nullptr && prog->file_info != nullptr) {
     // Mirrors dump_line_numbers()'s walk.
-    unsigned short* fi = prog->file_info;
+    lpc_file_info_t* fi = prog->file_info;
+    // Same bounds as dump_line_numbers(): fi[0] bytes, fi[1] words.
     auto* li_end = reinterpret_cast<unsigned char*>((reinterpret_cast<char*>(fi)) + fi[0]);
     auto* li_start = reinterpret_cast<unsigned char*>(fi + fi[1]);
 
     p["line_files"] = nlohmann::json::array();
-    for (unsigned short* q = fi + 2; q < reinterpret_cast<unsigned short*>(li_start); q += 2) {
+    for (lpc_file_info_t* q = fi + 2; q < reinterpret_cast<lpc_file_info_t*>(li_start); q += 2) {
       p["line_files"].push_back({{"lines", q[0]}, {"file", prog->strings[q[1] - 1]}});
     }
 

--- a/src/main_lpcc.cc
+++ b/src/main_lpcc.cc
@@ -227,10 +227,10 @@ static int lpcc_main(int argc, char** argv) {
     // mappings. Consumers accumulate `segments` in order to translate an
     // absolute line to (file, line-within-file).
     nlohmann::json seg = nlohmann::json::array();
-    unsigned short* fi = obj->prog->file_info;
+    lpc_file_info_t* fi = obj->prog->file_info;
     if (obj->prog->line_info != nullptr && fi != nullptr) {
       auto* li_start = reinterpret_cast<unsigned char*>(fi + fi[1]);
-      for (unsigned short* p = fi + 2; p < reinterpret_cast<unsigned short*>(li_start); p += 2) {
+      for (lpc_file_info_t* p = fi + 2; p < reinterpret_cast<lpc_file_info_t*>(li_start); p += 2) {
         seg.push_back({{"lines", p[0]}, {"file", obj->prog->strings[p[1] - 1]}});
       }
     }

--- a/src/vm/internal/base/interpret.cc
+++ b/src/vm/internal/base/interpret.cc
@@ -4992,9 +4992,9 @@ void call_direct(object_t* ob, int offset, int origin, int num_arg) {
   call_program(current_prog, funp->address);
 }
 
-void translate_absolute_line(int abs_line, unsigned short* file_info, int* ret_file,
-                             int* ret_line, unsigned short* end) {
-  unsigned short *p1, *p2;
+void translate_absolute_line(int abs_line, lpc_file_info_t* file_info, int* ret_file,
+                             int* ret_line, lpc_file_info_t* end) {
+  lpc_file_info_t *p1, *p2;
   int file;
   int line_tmp = abs_line;
 

--- a/src/vm/internal/base/interpret.h
+++ b/src/vm/internal/base/interpret.h
@@ -208,7 +208,7 @@ void call___INIT(object_t*);
 array_t* call_all_other(array_t*, const char*, int);
 const char* function_exists(const char*, object_t*, int);
 void mark_apply_low_cache(void);
-void translate_absolute_line(int, unsigned short*, int*, int*, unsigned short* end = nullptr);
+void translate_absolute_line(int, lpc_file_info_t*, int*, int*, lpc_file_info_t* end = nullptr);
 char* add_slash(const char* const);
 int strpref(const char*, const char*);
 void do_trace(const char*, const char*, const char*);

--- a/src/vm/internal/base/program.h
+++ b/src/vm/internal/base/program.h
@@ -1,6 +1,7 @@
 #ifndef PROGRAM_H
 #define PROGRAM_H
 
+#include <cstddef>
 #include <cstdint>
 
 #include "vm/internal/base/svalue.h" /* lpc_type_t */
@@ -168,6 +169,10 @@ typedef struct {
 #define ADDRESS_MAX UINT16_MAX
 #endif
 
+/* file_info header and (count, file-id) pairs. int matches current_line,
+ * save_file_info(), and translate_absolute_line() (issue #1359). */
+using lpc_file_info_t = int;
+
 struct function_t {
   const char* funcname;
   lpc_type_t type;
@@ -218,7 +223,10 @@ struct program_t {
 #endif
   char* program;            /* The binary instructions */
   unsigned char* line_info; /* Line number information */
-  unsigned short* file_info;
+  /* file_info[0] = total bytes of this block (disassembler li_end);
+   * file_info[1] = offset in lpc_file_info_t units to line_info; then
+   * (count, file-id) pairs up to that offset. */
+  lpc_file_info_t* file_info;
   int line_swap_index; /* Where line number info is swapped */
   function_t* function_table;
   unsigned short* function_flags; /* separate for alignment reasons */

--- a/testsuite/single/tests/compiler/file_info_header.lpc
+++ b/testsuite/single/tests/compiler/file_info_header.lpc
@@ -1,0 +1,103 @@
+// The file_info table is int words (header and (count, file-id) pairs).
+// A 16-bit header used to wrap: [0] (total bytes, used as li_end by
+// dump_line_numbers) and [1] (offset to the line-number bytes). A 16-bit
+// per-file count wrapped at 65536 lines (#1355). Those sizes must compile
+// and run.
+//
+// A single huge function hits Bison's "memory exhausted" stack first
+// (~10k statements), so the [0] case is many tiny functions. The [1]
+// case is sequential includes of one header (~32767 entries used to wrap).
+// Error-report translation of a 65536-line file is huge_file_line_table.lpc.
+
+#include "/include/tests.h"
+
+#define GEN_OK "/data/file_info_header_ok.c"
+#define GEN_BIG "/data/file_info_header_big.c"
+#define GEN_INC "/data/file_info_header_inc.c"
+#define HDR "/data/file_info_hdr.h"
+
+private void write_increments(string path, int n) {
+  string chunk;
+  int i;
+
+  rm(path);
+  write_file(path, "int probe() {\n  int x = 0;\n");
+  chunk = "";
+  for (i = 0; i < n; i++) {
+    chunk += "  x++;\n";
+    if (sizeof(chunk) > 4000) {
+      write_file(path, chunk);
+      chunk = "";
+    }
+  }
+  write_file(path, chunk);
+  write_file(path, "  return x;\n}\n");
+}
+
+private void write_functions(string path, int n) {
+  string chunk;
+  int i;
+
+  rm(path);
+  chunk = "";
+  for (i = 0; i < n; i++) {
+    chunk += "int f" + i + "() { return " + i + "; }\n";
+    if (sizeof(chunk) > 4000) {
+      write_file(path, chunk);
+      chunk = "";
+    }
+  }
+  write_file(path, chunk);
+}
+
+private void write_includes(string path, int n) {
+  string chunk;
+  int i;
+
+  rm(HDR);
+  write_file(HDR, "//\n");
+  rm(path);
+  chunk = "";
+  for (i = 0; i < n; i++) {
+    chunk += "#include \"file_info_hdr.h\"\n";
+    if (sizeof(chunk) > 4000) {
+      write_file(path, chunk);
+      chunk = "";
+    }
+  }
+  write_file(path, chunk);
+  write_file(path, "int ok() { return 1; }\n");
+}
+
+void do_tests() {
+  object ob;
+
+  write_increments(GEN_OK, 2000);
+  ob = load_object(GEN_OK);
+  ASSERT2(ob, "2000 statements compile");
+  if (ob) {
+    ASSERT_EQ(2000, ob->probe());
+    destruct(ob);
+  }
+  rm(GEN_OK);
+
+  write_functions(GEN_BIG, 15000);
+  ob = load_object(GEN_BIG);
+  ASSERT2(ob, "15000 functions compile");
+  if (ob) {
+    ASSERT_EQ(0, ob->f0());
+    ASSERT_EQ(14999, ob->f14999());
+    destruct(ob);
+  }
+  rm(GEN_BIG);
+
+  write_includes(GEN_INC, 32800);
+  ob = load_object(GEN_INC);
+  ASSERT2(ob, "32800 includes compile");
+  if (ob) {
+    ASSERT_EQ(1, ob->ok());
+    destruct(ob);
+  }
+  rm(GEN_INC);
+  rm(HDR);
+}

--- a/testsuite/single/tests/compiler/huge_file_line_table.lpc
+++ b/testsuite/single/tests/compiler/huge_file_line_table.lpc
@@ -1,22 +1,16 @@
 // A file of 65536+ lines must not corrupt the line table.
 //
-// The per-file line count in prog->file_info is 16 bits (the table is
-// unsigned short pairs), and save_file_info() stored it without capping. At
-// exactly 65536 lines the count wrapped to 0, and
-// translate_absolute_line()'s first pass -- `while (line_tmp > *p1)
-// { line_tmp -= *p1; p1 += 2; }` -- then advanced without ever reducing
-// line_tmp, walked off the end of the table, and returned whatever it landed
-// on as a file index. The caller feeds that straight to
-// progp->strings[idx - 1], so the FIRST runtime error reported from such a
-// file segfaulted the driver.
+// The per-file line count used to be 16 bits. At exactly 65536 lines it
+// wrapped to 0, and translate_absolute_line()'s first pass --
+// `while (line_tmp > *p1) { line_tmp -= *p1; p1 += 2; }` -- then advanced
+// without ever reducing line_tmp, walked off the table, and returned
+// whatever it landed on as a file index. The caller feeds that to
+// progp->strings[idx - 1], so the FIRST runtime error reported from such
+// a file segfaulted the driver.
 //
-// Not exotic: it is one large generated or accumulated mudlib file. The
-// count is now emitted in <=65535 chunks carrying the same file id, which
-// the decoder already reassembles (its second pass sums earlier entries with
-// a matching id), and the decoder's walk is bounded as well.
-//
-// This test drives the reporting path that crashed -- catching an error
-// forces the driver to translate an absolute line into (file, line).
+// Counts are int now (lpc_file_info_t), so a 65536-line stretch is one
+// entry. The decoder walk is still bounded. This drives the reporting
+// path that crashed -- catching an error forces a line-table translate.
 
 #include "/include/tests.h"
 


### PR DESCRIPTION
Fixes #1359.

`file_info[0]` (total bytes) and `file_info[1]` (line_info offset) were 16-bit and stored with unchecked casts. `[0]` is not dead — `dump_line_numbers()` / `dump_prog_json()` use it as `li_end`. A wrap of `[1]` points `line_info` at the wrong place. Per-file counts were the same 16-bit width and wrapped at 65536 lines (#1355).

The table is now `int` (`lpc_file_info_t`): header and `(count, file-id)` pairs, matching `current_line`, `save_file_info()`, and `translate_absolute_line()`. A large file is one entry.

This is an in-memory format change only (line info is not a swapped on-disk program image).

Pinned in `file_info_header.lpc`: 15000 functions and 32800 includes compile and run. The 65536-line error-report crash remains `huge_file_line_table.lpc`.