### PR TITLE
efun: add include_list() for compiled #include files (#1356)

### DIFF
--- a/docs/efun/system/include_list.md
+++ b/docs/efun/system/include_list.md
@@ -1,0 +1,41 @@
+---
+title: system / include_list
+---
+# include_list
+
+### NAME
+
+    include_list() - list the files an object #included
+
+### SYNOPSIS
+
+    string *include_list( object obj );
+
+### DESCRIPTION
+
+    Returns an array of filenames of every file the object's program
+    actually `#include`d when it was compiled -- nested includes included,
+    first-seen order, duplicates dropped. The object's own source file is
+    omitted. Each filename carries a leading slash.
+
+    The configured global include file is listed when the compiler opened
+    it. An `#include` inside a false `#if` branch is not listed: that file
+    was not opened.
+
+    This is the include-side counterpart of `inherit_list()`. Mudlibs that
+    rebuild only changed objects can walk `include_list(ob)` to see which
+    headers would force `ob` to recompile.
+
+    If no object is supplied, this efun defaults to this_object().
+
+### EXAMPLE
+
+    // Given a file that begins:
+    //   #include <globals.h>          // globals.h itself #includes tests.h
+    //   #include "/std/room.h"
+    include_list(ob);
+    // ({ "/include/globals.h", "/include/tests.h", "/std/room.h" })
+
+### SEE ALSO
+
+    inherit_list(3), deep_inherit_list(3), recompile_object(3)

--- a/docs/efun/system/inherit_list.md
+++ b/docs/efun/system/inherit_list.md
@@ -21,5 +21,5 @@ title: system / inherit_list
 
 ### SEE ALSO
 
-    deep_inherit_list(3), inherits(3)
+    deep_inherit_list(3), inherits(3), include_list(3)
 

--- a/docs/i18n/zh-CN/docusaurus-plugin-content-docs/current.json
+++ b/docs/i18n/zh-CN/docusaurus-plugin-content-docs/current.json
@@ -2143,6 +2143,10 @@
     "message": "function_profile",
     "description": "The label for the doc item 'function_profile' in sidebar 'docs', linking to the doc efun/system/function_profile"
   },
+  "sidebar.docs.doc.efun/system/include_list": {
+    "message": "include_list",
+    "description": "The label for the doc item 'include_list' in sidebar 'docs', linking to the doc efun/system/include_list"
+  },
   "sidebar.docs.doc.efun/system/inherit_list": {
     "message": "inherit_list",
     "description": "The label for the doc item 'inherit_list' in sidebar 'docs', linking to the doc efun/system/inherit_list"

--- a/docs/i18n/zh-CN/docusaurus-plugin-content-docs/current/efun/system/include_list.md
+++ b/docs/i18n/zh-CN/docusaurus-plugin-content-docs/current/efun/system/include_list.md
@@ -1,0 +1,26 @@
+---
+title: system / include_list
+---
+# include_list
+
+### 名称
+
+    include_list() - 获取对象编译时实际 #include 的文件列表
+
+### 语法
+
+    string *include_list( object obj );
+
+### 描述
+
+    返回对象编译时实际 `#include` 的文件名数组（含嵌套 include，按首次出现顺序，重复项只保留一次）。对象自身的源文件不在列表中。每个文件名带前导斜杠。
+
+    若编译器打开了配置中的全局头文件，也会列入。处于假 `#if` 分支中的 `#include` 不会出现：那个文件并未被打开。
+
+    这是 `inherit_list()` 对应的 include 侧接口。只重编译变更对象的 mudlib 可以遍历 `include_list(ob)`，判断哪些头文件变化会迫使 `ob` 重新编译。
+
+    若未提供对象，默认使用 this_object()。
+
+### 参考
+
+    inherit_list(3), deep_inherit_list(3), recompile_object(3)

--- a/docs/i18n/zh-CN/docusaurus-plugin-content-docs/current/efun/system/inherit_list.md
+++ b/docs/i18n/zh-CN/docusaurus-plugin-content-docs/current/efun/system/inherit_list.md
@@ -17,7 +17,7 @@ title: system / inherit_list
 
 ### 参考
 
-    deep_inherit_list(3), inherits(3)
+    deep_inherit_list(3), inherits(3), include_list(3)
 
 ### 翻译
 

--- a/docs/lpc/source-files.md
+++ b/docs/lpc/source-files.md
@@ -42,7 +42,8 @@ Consequently object identity is **extension-blind**:
 The **program name** (`prog->filename`) is different: it records the
 real file that was compiled, extension included. That is the name
 reported by `inherit_list()`, `deep_inherit_list()`, error tracebacks,
-and compiler diagnostics.
+and compiler diagnostics. `include_list()` reports the same style of
+path for every file the program `#include`d.
 
 ```c
 object ob = load_object("/std/room");      // loads /std/room.lpc

--- a/docs/sidebars.generated.json
+++ b/docs/sidebars.generated.json
@@ -2833,6 +2833,12 @@
           },
           {
             "type": "doc",
+            "id": "efun/system/include_list",
+            "key": "efun/system/include_list",
+            "label": "include_list"
+          },
+          {
+            "type": "doc",
             "id": "efun/system/inherit_list",
             "key": "efun/system/inherit_list",
             "label": "inherit_list"

--- a/src/compiler/internal/compiler.cc
+++ b/src/compiler/internal/compiler.cc
@@ -3450,6 +3450,11 @@ static program_t* epilog(void) {
     size += align(num_func * sizeof(unsigned short));
   }
 
+  /* A_INCLUDES is outside NUMPAREAS (compile-time only historically);
+   * persist it so include_list() can report the files this program
+   * actually opened (issue #1356). */
+  size += align(mem_block[A_INCLUDES].current_size);
+
   /* file_info header is two ints:
    *   [0] total bytes of the file_info+line_info allocation
    *       (dump_line_numbers / dump_prog_json use it as li_end)
@@ -3615,6 +3620,14 @@ static program_t* epilog(void) {
     copy_in(A_INHERITS, &p);
   } else {
     prog->inherit = nullptr;
+  }
+
+  prog->include_names_size = mem_block[A_INCLUDES].current_size;
+  if (prog->include_names_size) {
+    prog->include_names = p;
+    copy_in(A_INCLUDES, &p);
+  } else {
+    prog->include_names = nullptr;
   }
 
   prog->apply_lookup_table.reset(nullptr);

--- a/src/compiler/internal/compiler.h
+++ b/src/compiler/internal/compiler.h
@@ -35,8 +35,9 @@ struct mem_block_t {
 
 #define START_BLOCK_SIZE 4096
 
-/* NUMPAREAS ares are saved with the program code after compilation,
- * the rest are only temporary.
+/* NUMPAREAS areas are saved with the program code after compilation,
+ * the rest are only temporary. A_INCLUDES is outside NUMPAREAS but is
+ * copied into program_t::include_names for include_list().
  */
 #define A_PROGRAM 0 /* executable code */
 #define A_FUNCTIONS 1

--- a/src/packages/core/core.spec
+++ b/src/packages/core/core.spec
@@ -235,6 +235,7 @@ mapping unique_mapping(mixed *, string | function, ...);
 string *deep_inherit_list(object default:F__THIS_OBJECT);
 string *shallow_inherit_list(object default:F__THIS_OBJECT);
 string *inherit_list shallow_inherit_list(object default:F__THIS_OBJECT);
+string *include_list(object default:F__THIS_OBJECT);
 void printf(string, ...);
 string sprintf(string, ...);
 int mapp(mixed);

--- a/src/packages/core/efuns_main.cc
+++ b/src/packages/core/efuns_main.cc
@@ -796,6 +796,16 @@ void f_shallow_inherit_list() {
 }
 #endif
 
+#ifdef F_INCLUDE_LIST
+void f_include_list() {
+  array_t* vec;
+
+  vec = include_list(sp->u.ob);
+  free_object(&sp->u.ob, "f_include_list");
+  put_array(vec);
+}
+#endif
+
 #ifdef F_INPUT_TO
 void f_input_to() {
   svalue_t* arg;

--- a/src/vm/internal/base/array.cc
+++ b/src/vm/internal/base/array.cc
@@ -3,6 +3,8 @@
 #include "vm/internal/base/machine.h"
 
 #include <stdlib.h>  // for qsort
+#include <cstring>
+#include <vector>
 
 #include "vm/internal/apply.h"
 #include "vm/internal/simulate.h"
@@ -2025,6 +2027,47 @@ array_t* inherit_list(object_t* ob) {
     ret->item[il].type = T_STRING;
     ret->item[il].subtype = STRING_MALLOC;
     ret->item[il].u.string = add_slash(pr->filename);
+  }
+  return ret;
+}
+
+/*
+ * Files this program actually #included (nested includes included,
+ * duplicates dropped, first-seen order). The main source is omitted;
+ * the configured global include file is listed when it was opened.
+ */
+array_t* include_list(object_t* ob) {
+  program_t* prog = ob->prog;
+  if (!prog || !prog->include_names || prog->include_names_size <= 0) {
+    return &the_null_array;
+  }
+
+  std::vector<const char*> names;
+  const char* p = prog->include_names;
+  const char* end = p + prog->include_names_size;
+  while (p < end) {
+    if (*p == '\0') {
+      p++;
+      continue;
+    }
+    bool seen = false;
+    for (const char* existing : names) {
+      if (strcmp(existing, p) == 0) {
+        seen = true;
+        break;
+      }
+    }
+    if (!seen) {
+      names.push_back(p);
+    }
+    p += strlen(p) + 1;
+  }
+
+  array_t* ret = allocate_empty_array(static_cast<int>(names.size()));
+  for (size_t i = 0; i < names.size(); i++) {
+    ret->item[i].type = T_STRING;
+    ret->item[i].subtype = STRING_MALLOC;
+    ret->item[i].u.string = add_slash(names[i]);
   }
   return ret;
 }

--- a/src/vm/internal/base/array.h
+++ b/src/vm/internal/base/array.h
@@ -42,6 +42,7 @@ void filter_array(svalue_t*, int);
 void filter_string(svalue_t*, int);
 array_t* deep_inherit_list(struct object_t*);
 array_t* inherit_list(struct object_t*);
+array_t* include_list(struct object_t*);
 array_t* children(const char*);
 array_t* livings(void);
 array_t* objects(funptr_t*);

--- a/src/vm/internal/base/program.h
+++ b/src/vm/internal/base/program.h
@@ -236,6 +236,10 @@ struct program_t {
   char** variable_table;          /* variables defined by this program */
   lpc_type_t* variable_types;     /* variables defined by this program */
   inherit_t* inherit;             /* List of inherited prgms */
+  /* Packed nul-terminated include paths (not the main file), first-seen
+   * order. Copied from A_INCLUDES; include_list() walks this. */
+  char* include_names;
+  int include_names_size;
   int total_size;                 /* Sum of all data in this struct */
                                   /*
                                    * The types of function arguments are saved where 'argument_types'

--- a/testsuite/clone/include_list_a.h
+++ b/testsuite/clone/include_list_a.h
@@ -1,0 +1,3 @@
+// Direct include that pulls in a nested header.
+#include "include_list_nest.h"
+#define A 1

--- a/testsuite/clone/include_list_b.h
+++ b/testsuite/clone/include_list_b.h
@@ -1,0 +1,2 @@
+// Included twice by include_list_src.lpc; the efun lists it once.
+#define B 1

--- a/testsuite/clone/include_list_nest.h
+++ b/testsuite/clone/include_list_nest.h
@@ -1,0 +1,2 @@
+// Nested header opened by include_list_a.h.
+#define NEST 1

--- a/testsuite/clone/include_list_skipped.h
+++ b/testsuite/clone/include_list_skipped.h
@@ -1,0 +1,3 @@
+// Exists so a mistaken open would show up in include_list(). The
+// fixture only names this file inside #if 0.
+#define SKIPPED 1

--- a/testsuite/clone/include_list_src.lpc
+++ b/testsuite/clone/include_list_src.lpc
@@ -1,0 +1,10 @@
+// Fixture for include_list(): nested include, a duplicate include, and
+// an #include inside #if 0 that must not be opened.
+#include "include_list_a.h"
+#include "include_list_b.h"
+#include "include_list_b.h"
+#if 0
+#include "include_list_skipped.h"
+#endif
+
+int ok() { return A + B + NEST; }

--- a/testsuite/command/crasher.lpc
+++ b/testsuite/command/crasher.lpc
@@ -120,6 +120,7 @@ nosave mixed *_efuns = ({
   ({ "id_matrix", (: id_matrix :) }),
 #endif
   ({ "implode", (: implode :) }),
+  ({ "include_list", (: include_list :) }),
   ({ "in_edit", (: in_edit :) }),
   ({ "in_input", (: in_input :) }),
   ({ "inherit_list", (: inherit_list :) }),

--- a/testsuite/single/tests/efuns/include_list.lpc
+++ b/testsuite/single/tests/efuns/include_list.lpc
@@ -1,0 +1,84 @@
+// include_list() reports every file this program actually #included
+// (nested includes included, first-seen order, duplicates dropped).
+// The main source is omitted. The configured global include file is
+// listed when it was opened -- in the testsuite that is <globals.h>,
+// which pulls in tests.h.
+
+#include "/include/tests.h"
+
+#define GEN "/data/include_list_gen.c"
+#define HDR_A "/data/include_list_a.h"
+#define HDR_B "/data/include_list_b.h"
+#define HDR_NEST "/data/include_list_nest.h"
+#define HDR_SKIP "/data/include_list_skipped.h"
+
+private void cleanup() {
+  rm(GEN);
+  rm(HDR_A);
+  rm(HDR_B);
+  rm(HDR_NEST);
+  rm(HDR_SKIP);
+}
+
+void do_tests() {
+  object ob;
+  string *l, *mine;
+  int i, pos_a, pos_nest, pos_b;
+
+  mine = include_list();
+  ASSERT_EQ(mine, include_list(this_object()));
+  ASSERT(member_array("/include/globals.h", mine) != -1);
+  ASSERT(member_array("/include/tests.h", mine) != -1);
+
+  cleanup();
+  write_file(HDR_NEST, "#define NEST 1\n");
+  write_file(HDR_A, "#include \"include_list_nest.h\"\n#define A 1\n");
+  write_file(HDR_B, "#define B 1\n");
+  write_file(HDR_SKIP, "#define SKIPPED 1\n");
+  write_file(GEN,
+    "#include \"/data/include_list_a.h\"\n"
+    "#include \"/data/include_list_b.h\"\n"
+    "#include \"/data/include_list_b.h\"\n"
+    "#if 0\n"
+    "#include \"/data/include_list_skipped.h\"\n"
+    "#endif\n"
+    "int ok() { return A + B + NEST; }\n");
+
+  ob = load_object(GEN);
+  ASSERT2(ob, "generated file compiles");
+  if (!ob) {
+    cleanup();
+    return;
+  }
+  ASSERT_EQ(3, ob->ok());
+
+  l = include_list(ob);
+  ASSERT(member_array("/include/globals.h", l) != -1);
+  ASSERT(member_array("/include/tests.h", l) != -1);
+  ASSERT(member_array("/data/include_list_a.h", l) != -1);
+  ASSERT(member_array("/data/include_list_nest.h", l) != -1);
+  ASSERT(member_array("/data/include_list_b.h", l) != -1);
+  ASSERT(member_array("/data/include_list_skipped.h", l) == -1);
+  ASSERT(member_array(GEN, l) == -1);
+
+  // Duplicate #include of b.h is one entry.
+  ASSERT_EQ(1, sizeof(filter(l, (: $1 == "/data/include_list_b.h" :))));
+
+  // First-seen order: a, then the nested header it opened, then b.
+  pos_a = pos_nest = pos_b = -1;
+  for (i = 0; i < sizeof(l); i++) {
+    if (l[i] == "/data/include_list_a.h") {
+      pos_a = i;
+    }
+    if (l[i] == "/data/include_list_nest.h") {
+      pos_nest = i;
+    }
+    if (l[i] == "/data/include_list_b.h") {
+      pos_b = i;
+    }
+  }
+  ASSERT(pos_a >= 0 && pos_nest > pos_a && pos_b > pos_nest);
+
+  destruct(ob);
+  cleanup();
+}

--- a/testsuite/single/tests/efuns/include_list.lpc
+++ b/testsuite/single/tests/efuns/include_list.lpc
@@ -3,82 +3,23 @@
 // The main source is omitted. The configured global include file is
 // listed when it was opened -- in the testsuite that is <globals.h>,
 // which pulls in tests.h.
-
-#include "/include/tests.h"
-
-#define GEN "/data/include_list_gen.c"
-#define HDR_A "/data/include_list_a.h"
-#define HDR_B "/data/include_list_b.h"
-#define HDR_NEST "/data/include_list_nest.h"
-#define HDR_SKIP "/data/include_list_skipped.h"
-
-private void cleanup() {
-  rm(GEN);
-  rm(HDR_A);
-  rm(HDR_B);
-  rm(HDR_NEST);
-  rm(HDR_SKIP);
-}
+//
+// Fixture: /clone/include_list_src.lpc.
 
 void do_tests() {
   object ob;
   string *l, *mine;
-  int i, pos_a, pos_nest, pos_b;
 
   mine = include_list();
   ASSERT_EQ(mine, include_list(this_object()));
   ASSERT(member_array("/include/globals.h", mine) != -1);
   ASSERT(member_array("/include/tests.h", mine) != -1);
 
-  cleanup();
-  write_file(HDR_NEST, "#define NEST 1\n");
-  write_file(HDR_A, "#include \"include_list_nest.h\"\n#define A 1\n");
-  write_file(HDR_B, "#define B 1\n");
-  write_file(HDR_SKIP, "#define SKIPPED 1\n");
-  write_file(GEN,
-    "#include \"/data/include_list_a.h\"\n"
-    "#include \"/data/include_list_b.h\"\n"
-    "#include \"/data/include_list_b.h\"\n"
-    "#if 0\n"
-    "#include \"/data/include_list_skipped.h\"\n"
-    "#endif\n"
-    "int ok() { return A + B + NEST; }\n");
-
-  ob = load_object(GEN);
-  ASSERT2(ob, "generated file compiles");
-  if (!ob) {
-    cleanup();
-    return;
-  }
+  ob = load_object("/clone/include_list_src");
   ASSERT_EQ(3, ob->ok());
 
   l = include_list(ob);
-  ASSERT(member_array("/include/globals.h", l) != -1);
-  ASSERT(member_array("/include/tests.h", l) != -1);
-  ASSERT(member_array("/data/include_list_a.h", l) != -1);
-  ASSERT(member_array("/data/include_list_nest.h", l) != -1);
-  ASSERT(member_array("/data/include_list_b.h", l) != -1);
-  ASSERT(member_array("/data/include_list_skipped.h", l) == -1);
-  ASSERT(member_array(GEN, l) == -1);
-
-  // Duplicate #include of b.h is one entry.
-  ASSERT_EQ(1, sizeof(filter(l, (: $1 == "/data/include_list_b.h" :))));
-
-  // First-seen order: a, then the nested header it opened, then b.
-  pos_a = pos_nest = pos_b = -1;
-  for (i = 0; i < sizeof(l); i++) {
-    if (l[i] == "/data/include_list_a.h") {
-      pos_a = i;
-    }
-    if (l[i] == "/data/include_list_nest.h") {
-      pos_nest = i;
-    }
-    if (l[i] == "/data/include_list_b.h") {
-      pos_b = i;
-    }
-  }
-  ASSERT(pos_a >= 0 && pos_nest > pos_a && pos_b > pos_nest);
-
-  destruct(ob);
-  cleanup();
+  ASSERT_EQ(({ "/include/globals.h", "/include/tests.h",
+               "/clone/include_list_a.h", "/clone/include_list_nest.h",
+               "/clone/include_list_b.h" }), l);
 }

--- a/testsuite/single/tests/efuns/include_list.lpc
+++ b/testsuite/single/tests/efuns/include_list.lpc
@@ -20,6 +20,6 @@ void do_tests() {
 
   l = include_list(ob);
   ASSERT_EQ(({ "/include/globals.h", "/include/tests.h",
-               "/clone/include_list_a.h", "/clone/include_list_nest.h",
-               "/clone/include_list_b.h" }), l);
+    "/clone/include_list_a.h", "/clone/include_list_nest.h",
+    "/clone/include_list_b.h" }), l);
 }


### PR DESCRIPTION
Fixes #1356.

Mudlibs that rebuild only changed objects need the include graph: if a header changed, every file that included it must be updated. `recompile_object()` already reconsults `include_file` when it recompiles, but nothing exposed *which* headers a program opened.

The compiler already recorded those paths in `A_INCLUDES` and then discarded them. They are now stored on `program_t` (`include_names`). `include_list(ob)` returns them as `string *`:

- nested includes included
- first-seen order
- duplicates dropped
- the object's own source omitted
- leading slash, same style as `inherit_list()`
- the configured global include file is listed when it was opened
- `#include` inside a false `#if` is not listed (that file was not opened)

Pinned in `include_list.lpc`.