### PR TITLE
async: cancelled promises report promise_status() 3 (#1353)

### DIFF
--- a/docs/concepts/general/async.md
+++ b/docs/concepts/general/async.md
@@ -14,7 +14,9 @@ form of `catch`. This page is the execution-model specification.
 
 A promise is a first-class LPC value holding the eventual result of an
 asynchronous operation. It is created pending and settles exactly once —
-**fulfilled** with a value or **rejected** with a reason. See
+**fulfilled** with a value, **rejected** with a reason, or **cancelled**.
+Cancelled is reported by `promise_status()` as 3: a negative settlement
+that is not a fault. See
 `promise_create()`, `promise_resolve()`, `promise_reject()`,
 `promise_then()`, `promise_catch()`, `promise_status()`,
 `promise_result()`, and `async_info()`.

--- a/docs/efun/promises/promise_all_settled.md
+++ b/docs/efun/promises/promise_all_settled.md
@@ -19,11 +19,12 @@ title: promises / promise_all_settled
 
         ([ "status": 1, "value":  v ])   fulfilled
         ([ "status": 2, "reason": r ])   rejected
+        ([ "status": 3, "reason": r ])   cancelled
 
     The status codes are promise_status(3)'s, so one vocabulary covers both.
-    A fulfilled entry has no `"reason"` key and a rejected entry has no
-    `"value"` key, so `undefinedp()` distinguishes them as reliably as
-    `"status"` does.
+    A fulfilled entry has no `"reason"` key and a rejected or cancelled
+    entry has no `"value"` key, so `undefinedp()` distinguishes them as
+    reliably as `"status"` does.
 
     Use this instead of promise_all(3) when a partial failure is a result
     rather than an error -- fanning work out over many objects and reporting
@@ -45,7 +46,7 @@ async void reindex(object *rooms) {
     int i;
 
     foreach (mixed r in results) {
-        if (r["status"] == 2) {
+        if (r["status"] != 1) {
             write("room " + i + " failed: " + r["reason"] + "\n");
         }
         i++;

--- a/docs/efun/promises/promise_cancel.md
+++ b/docs/efun/promises/promise_cancel.md
@@ -24,7 +24,11 @@ title: promises / promise_cancel
 
     The raise behaves like any other rejection arriving at that `await`: it
     unwinds through enclosing `acatch` regions, runs `defer()` handlers in
-    order, and — if nothing catches it — rejects `p` with the same reason.
+    order, and — if nothing catches it — **cancels** `p` (promise_status(3)
+    returns 3) with the same reason. That is not a rejection: `acatch` still
+    yields the string, but `promise_status(p) == 3` is the test that cannot
+    be forged. Downstream `await` / `then` / `promise_all` / `promise_race`
+    links inherit the cancellation the same way.
 
     A body parked on a promise that will never settle is still cancelled
     promptly: it is detached from that promise and its rejection is

--- a/docs/efun/promises/promise_result.md
+++ b/docs/efun/promises/promise_result.md
@@ -10,12 +10,13 @@ title: promises / promise_result
     mixed promise_result(promise p);
 
 ### DESCRIPTION
-    Returns the fulfillment value or rejection reason of the settled
-    promise `p`. It is an error to call this on a pending promise (check
-    promise_status(3) first, or use promise_then(3) / `await` instead).
+    Returns the fulfillment value, rejection reason, or cancellation
+    reason of the settled promise `p`. It is an error to call this on a
+    pending promise (check promise_status(3) first, or use promise_then(3)
+    / `await` instead).
 
-    Reading a rejected promise's result counts as observing the rejection:
-    the unhandled-rejection report is suppressed for it.
+    Reading a rejected or cancelled promise's result counts as observing
+    it: the unhandled-rejection report is suppressed for it.
 
 ### SEE ALSO
     promise_status(3), promise_then(3)

--- a/docs/efun/promises/promise_status.md
+++ b/docs/efun/promises/promise_status.md
@@ -15,6 +15,14 @@ title: promises / promise_status
         0   pending
         1   fulfilled
         2   rejected
+        3   cancelled
+
+    Cancelled is a negative settlement -- `await`, `promise_then` /
+    `promise_catch`, and the fail-fast combinators treat it like a
+    rejection -- but it is not a fault. `acatch` still yields the reason
+    string (`"*async function cancelled"`); use this code, not that
+    string, to tell a cancellation from a rejection. A mudlib can forge
+    the string with `throw()`.
 
 ### SEE ALSO
-    promise_result(3), promise_create(3)
+    promise_result(3), promise_cancel(3), promise_create(3)

--- a/docs/lpc/types/promise.md
+++ b/docs/lpc/types/promise.md
@@ -4,8 +4,11 @@ title: types / promise
 # promise
 
 A `promise` is a first-class value standing for a result that is not
-available yet. It is in one of three states — **pending**, **fulfilled**
-with a value, or **rejected** with a reason — and it settles at most once.
+available yet. It is in one of four states — **pending**, **fulfilled**
+with a value, **rejected** with a reason, or **cancelled** — and it
+settles at most once. Cancelled is a negative settlement (await and
+`then` treat it like a rejection) that `promise_status()` reports as 3
+so a cancellation can be told from a fault.
 
 ```c
 promise p = promise_create();   // pending

--- a/src/include/promise.h
+++ b/src/include/promise.h
@@ -12,9 +12,8 @@
  * are values handed to a rejection handler, not messages printed by error().
  *
  * They are matched by CONTENT, which means a mudlib can forge one with
- * throw(). That is accepted: discriminating them authoritatively would need a
- * driver-reserved value kind, and promise_status() already answers the
- * question from outside.
+ * throw(). That is accepted: the authoritative test is promise_status() --
+ * PROMISE_CANCELLED is a real settlement, not a reserved string.
  */
 
 #ifndef _PROMISE_H_
@@ -25,10 +24,12 @@
 #define PROMISE_PENDING   0
 #define PROMISE_FULFILLED 1
 #define PROMISE_REJECTED  2
+#define PROMISE_CANCELLED 3
 
-/* What a cancelled body's next await raises, and what its promise rejects
- * with if nothing catches it. Identical on every delivery path -- body
- * running, queued, or parked -- so one comparison catches all three. */
+/* What a cancelled body's next await raises, and what its promise settles
+ * with as PROMISE_CANCELLED if nothing catches it. Identical on every
+ * delivery path -- body running, queued, or parked -- so one comparison
+ * catches all three. */
 #define PROMISE_REASON_CANCELLED "*async function cancelled"
 
 /* The suspended body's owner went away underneath it, so the body can never

--- a/src/packages/core/promises.cc
+++ b/src/packages/core/promises.cc
@@ -161,8 +161,8 @@ void f_promise_result() {
   if (p->state == PROMISE_PENDING) {
     error("promise_result: promise is still pending.\n");
   }
-  if (p->state == PROMISE_REJECTED) {
-    /* reading a rejection counts as observing it */
+  if (p->state == PROMISE_REJECTED || p->state == PROMISE_CANCELLED) {
+    /* reading a rejection or cancellation counts as observing it */
     p->handled = true;
   }
   svalue_t result;

--- a/src/packages/core/sprintf.cc
+++ b/src/packages/core/sprintf.cc
@@ -480,6 +480,11 @@ void svalue_to_string(svalue_t* obj, outbuffer_t* outbuf, int indent, int traili
           svalue_to_string(&obj->u.prom->result, outbuf, indent + 2, 0, 1);
           outbuf_add(outbuf, " )");
           break;
+        case PROMISE_CANCELLED:
+          outbuf_add(outbuf, "( cancelled: ");
+          svalue_to_string(&obj->u.prom->result, outbuf, indent + 2, 0, 1);
+          outbuf_add(outbuf, " )");
+          break;
         default:
           outbuf_add(outbuf, "( pending )");
           break;

--- a/src/vm/internal/base/promise.cc
+++ b/src/vm/internal/base/promise.cc
@@ -46,7 +46,8 @@ extern int stack_in_use_as_temporary;
  * namespace but CALLED from inside it, and declaring them in there would
  * name a different, never-defined symbol. */
 void free_combinator(promise_combinator_t* c);
-void deliver_combinator(promise_combinator_t* c, int index, svalue_t* value, bool rejected);
+void deliver_combinator(promise_combinator_t* c, int index, svalue_t* value, bool rejected,
+                       bool from_cancel = false);
 
 namespace {
 
@@ -553,7 +554,7 @@ void deliver_reaction(QueuedReaction* qr) {
   if (qr->comb) {
     /* Pure aggregation: runs no LPC, so it needs neither an eval budget nor
      * the command_giver dance below, and cannot re-enter the drain. */
-    deliver_combinator(qr->comb, qr->comb_index, &src->result, rejected);
+    deliver_combinator(qr->comb, qr->comb_index, &src->result, rejected, src->from_cancel);
     free_queued_reaction(qr);
     return;
   }
@@ -590,6 +591,9 @@ void deliver_reaction(QueuedReaction* qr) {
     /* pass-through: propagate the source's state to the chained promise */
     if (qr->next) {
       if (rejected) {
+        if (src->from_cancel) {
+          qr->next->from_cancel = true;
+        }
         promise_settle(qr->next, &src->result, 1);
       } else {
         promise_resolve_with(qr->next, &src->result);
@@ -1130,6 +1134,9 @@ void resume_coroutine(lpc_coroutine_t* coro, promise_t* source) {
     /* no acatch() region spans the await: the rejection propagates
      * straight to the coroutine's own promise, no need to rebuild the
      * frame at all (no catch may span an await by construction). */
+    if (source->from_cancel || reason == &cancel_reason) {
+      coro->result_promise->from_cancel = true;
+    }
     free_coroutine(coro, reason, true);
     return;
   }
@@ -1367,6 +1374,7 @@ promise_t* promise_alloc() {
   p->resolving = false;
   p->body_owned = false;
   p->cancelled = false;
+  p->from_cancel = false;
   p->value_type = 0;
   p->result = const0;
   p->reactions = nullptr;
@@ -1407,7 +1415,7 @@ void free_promise(promise_t* p) {
 }
 
 void dealloc_promise(promise_t* p) {
-  if (p->state == PROMISE_REJECTED && !p->handled) {
+  if (p->state == PROMISE_REJECTED && !p->handled && !p->from_cancel) {
     /* Where it was rejected. Without this the report is a bare reason with no
      * object, function or line -- and it is printed at DEALLOCATION, which
      * can be arbitrarily far from the rejection, so there is nothing else in
@@ -1511,7 +1519,7 @@ void dealloc_promise(promise_t* p) {
         err.type = T_STRING;
         err.subtype = STRING_CONSTANT;
         err.u.string = PROMISE_REASON_COLLECTED;
-        deliver_combinator(r.comb, r.comb_index, &err, true);
+        deliver_combinator(r.comb, r.comb_index, &err, true, p->from_cancel);
         free_combinator(r.comb);
       }
     }
@@ -1641,15 +1649,22 @@ svalue_t* promise_map_slot(mapping_t* m, const char* key) {
 
 /* One input settled (or was a plain value). Records it and settles the result
  * if this input decided the outcome. Runs no LPC. */
-void deliver_combinator(promise_combinator_t* c, int index, svalue_t* value, bool rejected) {
+void deliver_combinator(promise_combinator_t* c, int index, svalue_t* value, bool rejected,
+                       bool from_cancel) {
   switch (c->kind) {
     case PROMISE_COMB_RACE:
       /* first to settle decides, either way */
+      if (rejected && from_cancel) {
+        c->result->from_cancel = true;
+      }
       (void)promise_settle(c->result, value, rejected ? 1 : 0);
       break;
 
     case PROMISE_COMB_ALL:
       if (rejected) {
+        if (from_cancel) {
+          c->result->from_cancel = true;
+        }
         (void)promise_settle(c->result, value, 1); /* fail fast */
       } else {
         assign_svalue(&c->slots->item[index], value);
@@ -1809,8 +1824,10 @@ int promise_request_cancel(promise_t* p) {
   p->cancelled = true;
   /* The canceller has forced the outcome, so the rejection below is not
    * "unhandled" even if nobody attached a handler; without this a
-   * fire-and-forget cancel logs a rejection report when the promise dies. */
+   * fire-and-forget cancel logs a rejection report when the promise dies.
+   * from_cancel travels with the reason to every downstream link. */
   p->handled = true;
+  p->from_cancel = true;
 
   /* Find the parked frame, if there is one. A linear scan over at most
    * `max suspended async functions` entries, on a rare user-initiated efun.

--- a/src/vm/internal/base/promise.cc
+++ b/src/vm/internal/base/promise.cc
@@ -214,13 +214,17 @@ constexpr LPC_INT kDefaultDrainBudgetUs = 1000;
  * newline. No trailing newline: this is a value handed to a rejection
  * handler, not a message printed by error(). */
 constexpr const char* kDestructedRejection = PROMISE_REASON_DESTRUCTED;
-/* What a cancelled body's next await raises, and what its promise rejects
- * with if nothing catches it. Matched by CONTENT, like every other reason in
- * this family -- a plain string is forgeable by throw(), which is accepted:
- * discriminating cancellation authoritatively would need a driver-reserved
- * value kind, and promise_status() already answers the question from
- * outside. */
+/* What a cancelled body's next await raises, and what its promise settles
+ * with as PROMISE_CANCELLED if nothing catches it. Matched by CONTENT for
+ * the raise itself -- a plain string is forgeable by throw() -- but
+ * promise_status() is the authoritative test from outside. */
 constexpr const char* kCancelledRejection = PROMISE_REASON_CANCELLED;
+
+/* Cancelled is a negative settlement: await / then / combinators treat it
+ * like a rejection, but promise_status() reports PROMISE_CANCELLED. */
+bool promise_failed(const promise_t* p) {
+  return p->state == PROMISE_REJECTED || p->state == PROMISE_CANCELLED;
+}
 
 /* Consecutive slices that ended with work still queued. Routine under load;
  * a long run of them means the queue is not keeping up. Reset by any slice
@@ -549,7 +553,7 @@ void deliver_reaction(QueuedReaction* qr) {
     return;
   }
 
-  bool const rejected = (src->state == PROMISE_REJECTED);
+  bool const rejected = promise_failed(src);
 
   if (qr->comb) {
     /* Pure aggregation: runs no LPC, so it needs neither an eval budget nor
@@ -924,6 +928,14 @@ bool run_coroutine_body(char* entry_pc, promise_t* p, control_stack_t* async_fra
         } catch (const char*) {
         }
         if (unwound) {
+          /* The body caught the raise. If this was a cancellation, it was
+           * declined -- later settlement is ordinary fulfill or reject, not
+           * PROMISE_CANCELLED. Matched by the driver's constant pointer, not
+           * by string content: a mudlib throw of the same letters is a
+           * rejection. */
+          if (catch_value.type == T_STRING && catch_value.u.string == kCancelledRejection) {
+            p->from_cancel = false;
+          }
           continue;
         }
       }
@@ -1074,7 +1086,7 @@ void free_coroutine(lpc_coroutine_t* coro, svalue_t* reject_with, bool run_lpc) 
 }
 
 void resume_coroutine(lpc_coroutine_t* coro, promise_t* source) {
-  bool rejected = (source->state == PROMISE_REJECTED);
+  bool rejected = promise_failed(source);
   /* -1 = "no resumed frame to account for"; see the frame restore below */
   int resumed_temp_base = -1;
   /* what the resumed await yields, or rejects with -- the source's result
@@ -1282,7 +1294,14 @@ void resume_coroutine(lpc_coroutine_t* coro, promise_t* source) {
     assign_svalue_no_free(sp, reason);
     entry = coro->prog->program + coro->pc_offset;
   } else {
-    /* re-raise at the await point; the innermost acatch() catches it */
+    /* re-raise at the await point; the innermost acatch() catches it.
+     * Catching THIS body's own cancel (reason == &cancel_reason) declines
+     * it -- later settlement is ordinary. An inherited cancelled await is
+     * just a catchable rejection here; from_cancel was never set on this
+     * result. */
+    if (reason == &cancel_reason) {
+      coro->result_promise->from_cancel = false;
+    }
     assign_svalue(&catch_value, reason);
     entry = unwind_to_acatch_marker(csp);
   }
@@ -1536,7 +1555,13 @@ int promise_settle(promise_t* p, svalue_t* value, int rejected) {
   if (rejected && p->reject_origin == nullptr) {
     p->reject_origin = capture_reject_origin();
   }
-  p->state = rejected ? PROMISE_REJECTED : PROMISE_FULFILLED;
+  if (!rejected) {
+    p->state = PROMISE_FULFILLED;
+  } else if (p->from_cancel) {
+    p->state = PROMISE_CANCELLED;
+  } else {
+    p->state = PROMISE_REJECTED;
+  }
   assign_svalue(&p->result, value);
   if (p->reactions) {
     std::vector<promise_reaction_t>* reactions = p->reactions;
@@ -1680,13 +1705,14 @@ void deliver_combinator(promise_combinator_t* c, int index, svalue_t* value, boo
       break;
 
     case PROMISE_COMB_ALL_SETTLED: {
-      /* ([ "status": 1|2, "value"|"reason": v ]) -- the status codes are
+      /* ([ "status": 1|2|3, "value"|"reason": v ]) -- the status codes are
        * promise_status()'s, so one vocabulary covers both. */
       mapping_t* m = allocate_mapping(2);
       svalue_t* slot = promise_map_slot(m, "status");
       slot->type = T_NUMBER;
       slot->subtype = 0;
-      slot->u.number = rejected ? PROMISE_REJECTED : PROMISE_FULFILLED;
+      slot->u.number = rejected ? (from_cancel ? PROMISE_CANCELLED : PROMISE_REJECTED)
+                                : PROMISE_FULFILLED;
       slot = promise_map_slot(m, rejected ? "reason" : "value");
       assign_svalue_no_free(slot, value);
       free_svalue(&c->slots->item[index], "deliver_combinator");

--- a/src/vm/internal/base/promise.h
+++ b/src/vm/internal/base/promise.h
@@ -107,6 +107,14 @@ struct promise_t {
    * and a body running its first synchronous stretch has no coroutine at
    * all. */
   bool cancelled;
+  /* This rejection exists because a cancellation propagated here -- either
+   * this promise is the cancelled body, or it inherited that body's reason
+   * through await / then / adoption / a combinator. dealloc_promise() skips
+   * the unhandled-rejection report: cancel is a delivered outcome, not a
+   * fault, and stamping handled on the target alone left every downstream
+   * link to spam the driver log (PR #1353). Copied with the reason, not
+   * inferred from the string, which a mudlib can forge. */
+  bool from_cancel;
   /* the declared payload tag of an `async T f()`'s promise, as the runtime
    * T_* mask (0 = unannotated, e.g. promise_create()). The authoritative
    * copy lives in the svalue's subtype -- this is the record that survives

--- a/src/vm/internal/base/promise.h
+++ b/src/vm/internal/base/promise.h
@@ -107,13 +107,15 @@ struct promise_t {
    * and a body running its first synchronous stretch has no coroutine at
    * all. */
   bool cancelled;
-  /* This rejection exists because a cancellation propagated here -- either
-   * this promise is the cancelled body, or it inherited that body's reason
-   * through await / then / adoption / a combinator. dealloc_promise() skips
-   * the unhandled-rejection report: cancel is a delivered outcome, not a
-   * fault, and stamping handled on the target alone left every downstream
-   * link to spam the driver log (PR #1353). Copied with the reason, not
-   * inferred from the string, which a mudlib can forge. */
+  /* This settlement is a cancellation -- either this promise is the
+   * cancelled body, or it inherited that body's reason through await / then
+   * / adoption / a combinator. promise_settle() records PROMISE_CANCELLED
+   * rather than PROMISE_REJECTED when the bit is set, which is what
+   * promise_status() returns. dealloc_promise() also skips the unhandled-
+   * rejection report: cancel is a delivered outcome, not a fault, and
+   * stamping handled on the target alone left every downstream link to spam
+   * the driver log (PR #1353). Copied with the reason, not inferred from
+   * the string, which a mudlib can forge. */
   bool from_cancel;
   /* the declared payload tag of an `async T f()`'s promise, as the runtime
    * T_* mask (0 = unannotated, e.g. promise_create()). The authoritative

--- a/src/vm/internal/base/svalue.cc
+++ b/src/vm/internal/base/svalue.cc
@@ -271,6 +271,8 @@ json svalue_to_json_summary(const svalue_t* obj, int depth) {
           return "promise (fulfilled)";
         case PROMISE_REJECTED:
           return "promise (rejected)";
+        case PROMISE_CANCELLED:
+          return "promise (cancelled)";
         default:
           return "promise (pending)";
       }

--- a/testsuite/single/tests/efuns/promise_cancel.lpc
+++ b/testsuite/single/tests/efuns/promise_cancel.lpc
@@ -128,6 +128,118 @@ private async int cancel_in_nested_loop() {
   return total;
 }
 
+// Cancelling a body that another dropped awaiter is waiting on must not
+// print "Unhandled promise rejection" for the downstream link. The
+// canceller stamped handled on the TARGET only; the reason has to carry
+// from_cancel with it (PR #1353). Read the debug log, same channel as
+// unhandled_rejection_locus.lpc.
+
+#define DEBUG_LOG_FILE 10
+#define CANCEL_LOG_TRIES 12
+#define CANCEL_CHUNK_LINES 500
+#define CANCEL_MAX_CHUNKS 400
+
+nosave string cancel_log_marker;
+nosave string cancel_logfile;
+nosave int cancel_log_tries;
+nosave int cancel_log_finished;
+nosave promise inner_p;
+
+private async int cancel_leaf() {
+  await never;
+  return 1;
+}
+
+private async int cancel_waiter() {
+  return await inner_p;
+}
+
+private void cancel_log_done(mixed complaint) {
+  if (cancel_log_finished++) {
+    return;
+  }
+  if (complaint) {
+    ASSERT2(0, complaint);
+  }
+  RELEASE_LATCH("cancel-propagate");
+}
+
+private mixed cancel_scan_after_marker() {
+  int line = 1;
+  int i;
+  int seen_marker = 0;
+  int total = file_size(cancel_logfile);
+
+  if (total < 0) {
+    return 0;
+  }
+
+  for (i = 0; i < CANCEL_MAX_CHUNKS; i++) {
+    string chunk = read_file(cancel_logfile, line, CANCEL_CHUNK_LINES);
+    int at;
+
+    if (!chunk || chunk == "") {
+      break;
+    }
+    if (!seen_marker) {
+      at = strsrch(chunk, cancel_log_marker);
+      if (at == -1) {
+        line += CANCEL_CHUNK_LINES;
+        continue;
+      }
+      seen_marker = 1;
+      chunk = chunk[at..];
+    }
+    if (strsrch(chunk, "Unhandled promise rejection") != -1 &&
+      strsrch(chunk, "*async function cancelled") != -1) {
+      return chunk;
+    }
+    line += CANCEL_CHUNK_LINES;
+  }
+
+  return seen_marker ? "" : 0;
+}
+
+private void cancel_check_log() {
+  mixed hit = cancel_scan_after_marker();
+
+  if (hit == 0) {
+    if (++cancel_log_tries < CANCEL_LOG_TRIES) {
+      call_out((: cancel_check_log :), 1);
+      return;
+    }
+    // Marker never appeared: no debug log we can read. Not a failure.
+    cancel_log_done(0);
+    return;
+  }
+  if (stringp(hit) && hit != "") {
+    cancel_log_done("a cancelled downstream was reported unhandled: " + hit);
+    return;
+  }
+  cancel_log_done(0);
+}
+
+private void check_cancel_propagate() {
+  string configured = get_config(DEBUG_LOG_FILE);
+  promise all;
+
+  if (!stringp(configured) || configured == "") {
+    return;
+  }
+  cancel_logfile = LOG_DIR + "/" + configured;
+  cancel_log_marker = "cancel-propagate-probe-" + time() + "-" + random(1000000);
+  debug_message(cancel_log_marker + "\n");
+
+  EXPECT_LATCH("cancel-propagate");
+  inner_p = cancel_leaf();
+  // Drop the waiter and the combinator: both inherit the cancellation.
+  cancel_waiter();
+  all = promise_all(({ inner_p }));
+  all = 0;
+  ASSERT_EQ(1, promise_cancel(inner_p));
+  call_out((: cancel_check_log :), 1);
+}
+
 void do_tests() {
   never = promise_create();
   gate = promise_create();
@@ -152,4 +264,6 @@ void do_tests() {
     });
     ASSERT_EQ(1, promise_cancel(nested));
   }
+
+  check_cancel_propagate();
 }

--- a/testsuite/single/tests/efuns/promise_cancel.lpc
+++ b/testsuite/single/tests/efuns/promise_cancel.lpc
@@ -18,8 +18,10 @@
 
 nosave promise never, gate;
 nosave promise held, caught_body, defer_body;
+nosave promise status_leaf, status_all, status_race, status_settled;
+nosave promise catch_then_fail_p;
 nosave int body_ran_past_await, defer_ran, cleanup_awaited;
-nosave mixed caught;
+nosave mixed caught, declined_caught;
 
 // Parked on a promise nothing will ever settle.
 private async int stuck() {
@@ -49,6 +51,13 @@ private async int with_defer() {
 
 private async int quick() { return 3; }
 
+// Catches its own cancellation, then faults for a different reason.
+// from_cancel must not stick: the settlement is a rejection, not a cancel.
+private async int catch_then_fail() {
+  declined_caught = acatch(await never);
+  error("real fault");
+}
+
 private void check_stuck() {
   EXPECT_LATCH("stuck");
   held = stuck();
@@ -58,7 +67,10 @@ private void check_stuck() {
   promise_catch(held, function(mixed reason) {
     ASSERT_EQ("*async function cancelled", reason);
     ASSERT_EQ(0, body_ran_past_await);
-    ASSERT_EQ(2, promise_status(held));
+    // 3 == PROMISE_CANCELLED (src/include/promise.h). Not 2: cancel is
+    // a negative settlement, not a fault.
+    ASSERT_EQ(3, promise_status(held));
+    ASSERT_EQ("*async function cancelled", promise_result(held));
     RELEASE_LATCH("stuck");
   });
 }
@@ -240,6 +252,45 @@ private void check_cancel_propagate() {
   call_out((: cancel_check_log :), 1);
 }
 
+// PROMISE_CANCELLED == 3. Combinators inherit it: all / race fail-fast as
+// cancelled; all_settled reports status 3 with a reason and no value.
+private void check_cancel_status() {
+  EXPECT_LATCH("cancel-status");
+  status_leaf = cancel_leaf();
+  status_all = promise_all(({ status_leaf }));
+  status_race = promise_race(({ status_leaf }));
+  status_settled = promise_all_settled(({ status_leaf }));
+  ASSERT_EQ(1, promise_cancel(status_leaf));
+
+  promise_then(status_settled, function(mixed v) {
+    ASSERT_EQ(3, promise_status(status_leaf));
+    ASSERT_EQ("*async function cancelled", promise_result(status_leaf));
+    ASSERT_EQ(3, promise_status(status_all));
+    ASSERT_EQ("*async function cancelled", promise_result(status_all));
+    ASSERT_EQ(3, promise_status(status_race));
+    ASSERT_EQ(1, promise_status(status_settled));
+    ASSERT_EQ(3, v[0]["status"]);
+    ASSERT_EQ("*async function cancelled", v[0]["reason"]);
+    ASSERT2(undefinedp(v[0]["value"]), "a cancelled entry carries no value");
+    RELEASE_LATCH("cancel-status");
+  });
+}
+
+private void check_catch_then_fail() {
+  EXPECT_LATCH("catch-then-fail");
+  catch_then_fail_p = catch_then_fail();
+  ASSERT_EQ(1, promise_cancel(catch_then_fail_p));
+
+  promise_catch(catch_then_fail_p, function(mixed reason) {
+    // Declined the cancel, then faulted: rejected, not cancelled.
+    ASSERT_EQ(2, promise_status(catch_then_fail_p));
+    ASSERT2(stringp(reason) && strsrch(reason, "real fault") != -1,
+      "declined cancel then faulted: " + reason);
+    ASSERT_EQ("*async function cancelled", declined_caught);
+    RELEASE_LATCH("catch-then-fail");
+  });
+}
+
 void do_tests() {
   never = promise_create();
   gate = promise_create();
@@ -266,4 +317,6 @@ void do_tests() {
   }
 
   check_cancel_propagate();
+  check_cancel_status();
+  check_catch_then_fail();
 }


### PR DESCRIPTION
Addresses @gesslar's note on #1353.

`promise_cancel()` already avoids `error()` / `master::error_handler`. Two residuals from that review:

### (1) Unhandled-rejection spam on downstream links

`handled` was set on the cancel target only. A dropped `await` or `promise_all` of a cancelled body still hit `dealloc_promise()` with `Unhandled promise rejection (rejected by unknown location): *async function cancelled`.

A `from_cancel` bit is set by `promise_cancel()` and copied wherever a rejection reason is forwarded (await with no `acatch`, `then` pass-through, adoption, `promise_all` / `promise_race` fail-fast). `dealloc_promise()` skips the report when the bit is set. The string is not matched -- it is forgeable.

### (2) Fourth `promise_status()` state

`PROMISE_CANCELLED` is **3**. `promise_settle()` records that state when `from_cancel` is set, so the status is authoritative and the reason string is just the `await` / `acatch` value.

Cancelled is a **negative settlement**: `await`, `then` / `catch`, and the fail-fast combinators treat it like a rejection, but `promise_status()` returns 3 rather than 2.

Combinator rules:
- `promise_all` / `promise_race`: a cancelled input fail-fasts / first-settles as **cancelled** (status 3).
- `promise_any`: cancelled is not success; an all-fail still **rejects** with the array of reasons.
- `promise_all_settled`: a cancelled input is `([ "status": 3, "reason": r ])`.

A body that **catches** its cancellation and later fails settles as **rejected** (2): cancel was declined, the later fault is ordinary.

Pinned in `promise_cancel.lpc`: the debug-log probe from (1), status 3 on the target and on `all` / `race` / `all_settled`, and catch-then-fault stays 2.