### PR TITLE
efun: external handle API, promise start, and cancel-kill

### DIFF
--- a/docs/concepts/general/async.md
+++ b/docs/concepts/general/async.md
@@ -386,7 +386,7 @@ rejected with the failure value (e.g. `async_read`'s negative int) —
 `({ stdout, stderr, exit_code })` when the process exits (a non-zero
 exit still fulfills), or rejected with a socket error /
 `"*external process aborted"`. The child is started with
-`posix_spawn()`. The classic
+`posix_spawn()` (Win32: `CreateProcess`). The classic
 `external_start(index, args, read, write, close)` form is unchanged and
 still returns the socket fd.
 

--- a/docs/concepts/general/async.md
+++ b/docs/concepts/general/async.md
@@ -386,7 +386,8 @@ rejected with the failure value (e.g. `async_read`'s negative int) —
 `({ stdout, stderr, exit_code })` when the process exits (a non-zero
 exit still fulfills), or rejected with a socket error /
 `"*external process aborted"`. The child is started with
-`posix_spawn()` (Win32: `CreateProcess`). The classic
+`posix_spawn()` (Win32: `CreateProcess`). `promise_reject` of that
+promise, or of `external_run(handle)`'s promise, kills the child. The classic
 `external_start(index, args, read, write, close)` form is unchanged and
 still returns the socket fd.
 

--- a/docs/concepts/general/async.md
+++ b/docs/concepts/general/async.md
@@ -395,9 +395,7 @@ starts the process the same way and fulfills with the same
 `({ stdout, stderr, exit_code })` tuple. After it fulfills,
 `external_stdout()`, `external_stderr()` and `external_exit_code()`
 also read the results from the handle. `external_write()` /
-`external_close_stdin()` drive the child's stdin; the omit-callback
-form also accepts an optional stdin string,
-`await external_start(index, args, payload)`.
+`external_close_stdin()` drive the child's stdin.
 
 `async_yield()` returns a promise fulfilled with `0` on the event loop's
 next pass — `await async_yield();` is the cooperative preemption point for a

--- a/docs/concepts/general/async.md
+++ b/docs/concepts/general/async.md
@@ -381,14 +381,18 @@ promise fulfilled with the value the callback would have received, or
 rejected with the failure value (e.g. `async_read`'s negative int) —
 `string s = await async_read(path);`.
 
-`external_create(index, args)` allocates a handle. `external_start(handle)`
-starts the process and returns a promise fulfilled with `0` when it
-exits, or rejected with a socket error / `"*external process aborted"`.
-After it fulfills, `external_stdout()`, `external_stderr()` and
-`external_exit_code()` read the results from the handle (a non-zero
-exit still fulfills). The classic
+`external_start(index, args)` — the same efun with the socket callbacks
+**omitted** — returns a promise fulfilled with `({ output, exit_code })`
+when the process exits (a non-zero exit still fulfills), or rejected
+with a socket error / `"*external process aborted"`. The classic
 `external_start(index, args, read, write, close)` form is unchanged and
 still returns the socket fd.
+
+`external_create(index, args)` allocates a handle. `external_start(handle)`
+starts the process and returns a promise fulfilled with `0` when it
+exits (same reject reasons). After it fulfills, `external_stdout()`,
+`external_stderr()` and `external_exit_code()` read the results from
+the handle.
 
 `async_yield()` returns a promise fulfilled with `0` on the event loop's
 next pass — `await async_yield();` is the cooperative preemption point for a

--- a/docs/concepts/general/async.md
+++ b/docs/concepts/general/async.md
@@ -382,17 +382,19 @@ rejected with the failure value (e.g. `async_read`'s negative int) —
 `string s = await async_read(path);`.
 
 `external_start(index, args)` — the same efun with the socket callbacks
-**omitted** — returns a promise fulfilled with `({ output, exit_code })`
-when the process exits (a non-zero exit still fulfills), or rejected
-with a socket error / `"*external process aborted"`. The classic
+**omitted** — returns a promise fulfilled with
+`({ stdout, stderr, exit_code })` when the process exits (a non-zero
+exit still fulfills), or rejected with a socket error /
+`"*external process aborted"`. The child is started with
+`posix_spawn()`. The classic
 `external_start(index, args, read, write, close)` form is unchanged and
 still returns the socket fd.
 
 `external_create(index, args)` allocates a handle. `external_start(handle)`
-starts the process and returns a promise fulfilled with `0` when it
-exits (same reject reasons). After it fulfills, `external_stdout()`,
-`external_stderr()` and `external_exit_code()` read the results from
-the handle.
+starts the process the same way and fulfills with the same
+`({ stdout, stderr, exit_code })` tuple. After it fulfills,
+`external_stdout()`, `external_stderr()` and `external_exit_code()`
+also read the results from the handle.
 
 `async_yield()` returns a promise fulfilled with `0` on the event loop's
 next pass — `await async_yield();` is the cooperative preemption point for a

--- a/docs/concepts/general/async.md
+++ b/docs/concepts/general/async.md
@@ -168,7 +168,9 @@ differs from JS: there, settling an already-settled promise is a silent
 no-op, which is what lets `Promise.race` be written in userland. Here it is
 an **error**, so the unguarded version throws on whichever of the two paths
 finishes second — the common case, not a rare one. Note also that the
-underlying work is not stopped by either shape; only your wait ends.
+underlying work is not stopped by either shape; only your wait ends
+(exception: `promise_reject` of an `external_start` / `external_run`
+promise kills the child; `external_kill(handle)` is the handle form).
 
 `return value` fulfills the promise (a returned promise is adopted). An
 uncaught error inside the body rejects it — an async body behaves as if
@@ -387,7 +389,8 @@ rejected with the failure value (e.g. `async_read`'s negative int) —
 exit still fulfills), or rejected with a socket error /
 `"*external process aborted"`. The child is started with
 `posix_spawn()` (Win32: `CreateProcess`). `promise_reject` of that
-promise, or of `external_run(handle)`'s promise, kills the child. The classic
+promise kills the child. A handle is stopped with `external_kill(h)`
+(keep the result) or `external_close(h)` (discard). The classic
 `external_start(index, args, read, write, close)` form is unchanged and
 still returns the socket fd.
 

--- a/docs/concepts/general/async.md
+++ b/docs/concepts/general/async.md
@@ -394,7 +394,10 @@ still returns the socket fd.
 starts the process the same way and fulfills with the same
 `({ stdout, stderr, exit_code })` tuple. After it fulfills,
 `external_stdout()`, `external_stderr()` and `external_exit_code()`
-also read the results from the handle.
+also read the results from the handle. `external_write()` /
+`external_close_stdin()` drive the child's stdin; the omit-callback
+form also accepts an optional stdin string,
+`await external_start(index, args, payload)`.
 
 `async_yield()` returns a promise fulfilled with `0` on the event loop's
 next pass — `await async_yield();` is the cooperative preemption point for a

--- a/docs/concepts/general/async.md
+++ b/docs/concepts/general/async.md
@@ -390,7 +390,7 @@ exit still fulfills), or rejected with a socket error /
 `external_start(index, args, read, write, close)` form is unchanged and
 still returns the socket fd.
 
-`external_create(index, args)` allocates a handle. `external_start(handle)`
+`external_create(index, args)` allocates a handle. `external_run(handle)`
 starts the process the same way and fulfills with the same
 `({ stdout, stderr, exit_code })` tuple. After it fulfills,
 `external_stdout()`, `external_stderr()` and `external_exit_code()`

--- a/docs/concepts/general/async.md
+++ b/docs/concepts/general/async.md
@@ -382,12 +382,14 @@ rejected with the failure value (e.g. `async_read`'s negative int) —
 `string s = await async_read(path);`.
 
 `external_start(index, args)` — omit the socket callbacks — returns a
-promise fulfilled with the collected stdout/stderr when the process
+promise fulfilled with `({ output, exit_code })` when the process
 exits, or rejected with the negative socket error the classic form
 would have returned (`EESECURITY`, `EESOCKET`, ...) or
 `"*external process aborted"` if the calling object is destructed
-first. The classic `external_start(index, args, read, write, close)`
-form is unchanged and still returns the socket fd.
+first. `exit_code` is the child's wait status (0 on success; on POSIX a
+signal death is `128 + signo`). The classic
+`external_start(index, args, read, write, close)` form is unchanged and
+still returns the socket fd.
 
 `async_yield()` returns a promise fulfilled with `0` on the event loop's
 next pass — `await async_yield();` is the cooperative preemption point for a

--- a/docs/concepts/general/async.md
+++ b/docs/concepts/general/async.md
@@ -381,13 +381,12 @@ promise fulfilled with the value the callback would have received, or
 rejected with the failure value (e.g. `async_read`'s negative int) —
 `string s = await async_read(path);`.
 
-`external_start(index, args)` — omit the socket callbacks — returns a
-promise fulfilled with `({ output, exit_code })` when the process
-exits, or rejected with the negative socket error the classic form
-would have returned (`EESECURITY`, `EESOCKET`, ...) or
-`"*external process aborted"` if the calling object is destructed
-first. `exit_code` is the child's wait status (0 on success; on POSIX a
-signal death is `128 + signo`). The classic
+`external_create(index, args)` allocates a handle. `external_start(handle)`
+starts the process and returns a promise fulfilled with `0` when it
+exits, or rejected with a socket error / `"*external process aborted"`.
+After it fulfills, `external_stdout()`, `external_stderr()` and
+`external_exit_code()` read the results from the handle (a non-zero
+exit still fulfills). The classic
 `external_start(index, args, read, write, close)` form is unchanged and
 still returns the socket fd.
 

--- a/docs/concepts/general/async.md
+++ b/docs/concepts/general/async.md
@@ -381,6 +381,14 @@ promise fulfilled with the value the callback would have received, or
 rejected with the failure value (e.g. `async_read`'s negative int) —
 `string s = await async_read(path);`.
 
+`external_start(index, args)` — omit the socket callbacks — returns a
+promise fulfilled with the collected stdout/stderr when the process
+exits, or rejected with the negative socket error the classic form
+would have returned (`EESECURITY`, `EESOCKET`, ...) or
+`"*external process aborted"` if the calling object is destructed
+first. The classic `external_start(index, args, read, write, close)`
+form is unchanged and still returns the socket fd.
+
 `async_yield()` returns a promise fulfilled with `0` on the event loop's
 next pass — `await async_yield();` is the cooperative preemption point for a
 long computation, letting the driver serve players between chunks. It is the

--- a/docs/efun/external/external_close.md
+++ b/docs/efun/external/external_close.md
@@ -1,0 +1,23 @@
+---
+title: external / external_close
+---
+# external_close
+
+### NAME
+
+    external_close() - release an external_create() handle
+
+### SYNOPSIS
+
+    void external_close(int handle);
+
+### DESCRIPTION
+
+    Free the handle. If the process is still running it is aborted (the
+    start promise is rejected with `"*external process aborted"`) and
+    the child is sent `SIGTERM` (or `TerminateProcess` on Windows).
+    Destructing the owning object closes every handle it still holds.
+
+### SEE ALSO
+
+    external_create(3), external_start(3)

--- a/docs/efun/external/external_close.md
+++ b/docs/efun/external/external_close.md
@@ -20,4 +20,4 @@ title: external / external_close
 
 ### SEE ALSO
 
-    external_create(3), external_start(3)
+    external_create(3), external_run(3)

--- a/docs/efun/external/external_close.md
+++ b/docs/efun/external/external_close.md
@@ -20,4 +20,4 @@ title: external / external_close
 
 ### SEE ALSO
 
-    external_create(3), external_run(3)
+    external_create(3), external_run(3), external_kill(3)

--- a/docs/efun/external/external_close_stdin.md
+++ b/docs/efun/external/external_close_stdin.md
@@ -1,0 +1,25 @@
+---
+title: external / external_close_stdin
+---
+# external_close_stdin
+
+### NAME
+
+    external_close_stdin() - close an external command's stdin
+
+### SYNOPSIS
+
+    void external_close_stdin(int handle);
+
+### DESCRIPTION
+
+    Close the write end of a handle's stdin after any buffered data is
+    flushed. The child then sees EOF. Does not kill the process or
+    release the handle; use `external_close()` for that.
+
+    Safe to call before start: stdin is closed as soon as the process
+    is spawned and the pending buffer has been written.
+
+### SEE ALSO
+
+    external_write(3), external_start(3), external_close(3)

--- a/docs/efun/external/external_close_stdin.md
+++ b/docs/efun/external/external_close_stdin.md
@@ -22,4 +22,4 @@ title: external / external_close_stdin
 
 ### SEE ALSO
 
-    external_write(3), external_start(3), external_close(3)
+    external_write(3), external_run(3), external_close(3)

--- a/docs/efun/external/external_create.md
+++ b/docs/efun/external/external_create.md
@@ -14,12 +14,12 @@ title: external / external_create
 ### DESCRIPTION
 
     Allocate a handle for a command configured as `external_cmd_N`. The
-    process is not started. Pass the handle to `external_start()` to run
+    process is not started. Pass the handle to `external_run()` to run
     it (awaitable), then read `external_stdout()`, `external_stderr()`
     and `external_exit_code()` from the same handle.
 
         int h = external_create(CURL_CMD, ({ "-s", url }));
-        mixed *r = await external_start(h);
+        mixed *r = await external_run(h);
         string body = r[0];       /* also external_stdout(h) */
         string err = r[1];
         int code = r[2];
@@ -37,6 +37,7 @@ title: external / external_create
 
 ### SEE ALSO
 
-    external_start(3), external_write(3), external_close_stdin(3),
+    external_run(3), external_start(3), external_write(3),
+    external_close_stdin(3),
     external_stdout(3), external_stderr(3),
     external_exit_code(3), external_close(3)

--- a/docs/efun/external/external_create.md
+++ b/docs/efun/external/external_create.md
@@ -25,13 +25,18 @@ title: external / external_create
         int code = r[2];
         external_close(h);
 
+    Write to the child's stdin with `external_write()` (buffered until
+    start, then flushed). `external_close_stdin()` closes the write end
+    so the child sees EOF.
+
     `args` is an array of arguments, or a space-separated string.
 
     The handle is owned by the calling object: another object cannot
-    start, read, or close it. Destructing the owner aborts a running
+    start, read, write, or close it. Destructing the owner aborts a running
     process and frees the handle.
 
 ### SEE ALSO
 
-    external_start(3), external_stdout(3), external_stderr(3),
+    external_start(3), external_write(3), external_close_stdin(3),
+    external_stdout(3), external_stderr(3),
     external_exit_code(3), external_close(3)

--- a/docs/efun/external/external_create.md
+++ b/docs/efun/external/external_create.md
@@ -1,0 +1,36 @@
+---
+title: external / external_create
+---
+# external_create
+
+### NAME
+
+    external_create() - allocate a handle for an external command
+
+### SYNOPSIS
+
+    int external_create(int external_index, string | string * args);
+
+### DESCRIPTION
+
+    Allocate a handle for a command configured as `external_cmd_N`. The
+    process is not started. Pass the handle to `external_start()` to run
+    it (awaitable), then read `external_stdout()`, `external_stderr()`
+    and `external_exit_code()` from the same handle.
+
+        int h = external_create(CURL_CMD, ({ "-s", url }));
+        await external_start(h);
+        string body = external_stdout(h);
+        int code = external_exit_code(h);
+        external_close(h);
+
+    `args` is an array of arguments, or a space-separated string.
+
+    The handle is owned by the calling object: another object cannot
+    start, read, or close it. Destructing the owner aborts a running
+    process and frees the handle.
+
+### SEE ALSO
+
+    external_start(3), external_stdout(3), external_stderr(3),
+    external_exit_code(3), external_close(3)

--- a/docs/efun/external/external_create.md
+++ b/docs/efun/external/external_create.md
@@ -37,7 +37,8 @@ title: external / external_create
 
 ### SEE ALSO
 
-    external_run(3), external_start(3), external_write(3),
+    external_run(3), external_kill(3), external_start(3),
+    external_write(3),
     external_close_stdin(3),
     external_stdout(3), external_stderr(3),
     external_exit_code(3), external_close(3)

--- a/docs/efun/external/external_create.md
+++ b/docs/efun/external/external_create.md
@@ -19,9 +19,10 @@ title: external / external_create
     and `external_exit_code()` from the same handle.
 
         int h = external_create(CURL_CMD, ({ "-s", url }));
-        await external_start(h);
-        string body = external_stdout(h);
-        int code = external_exit_code(h);
+        mixed *r = await external_start(h);
+        string body = r[0];       /* also external_stdout(h) */
+        string err = r[1];
+        int code = r[2];
         external_close(h);
 
     `args` is an array of arguments, or a space-separated string.

--- a/docs/efun/external/external_exit_code.md
+++ b/docs/efun/external/external_exit_code.md
@@ -14,9 +14,10 @@ title: external / external_exit_code
 ### DESCRIPTION
 
     `-1` if the process has not exited yet. After `await external_start(h)`
-    fulfills, the child's wait status: `0` on success, the exit code on a
-    normal exit, and `128 + signo` on POSIX if the child died from a
-    signal. A non-zero code does not reject the start promise.
+    fulfills, the child's wait status (same as `r[2]` of the fulfillment
+    tuple): `0` on success, the exit code on a normal exit, and
+    `128 + signo` on POSIX if the child died from a signal. A non-zero
+    code does not reject the start promise.
 
 ### SEE ALSO
 

--- a/docs/efun/external/external_exit_code.md
+++ b/docs/efun/external/external_exit_code.md
@@ -13,7 +13,7 @@ title: external / external_exit_code
 
 ### DESCRIPTION
 
-    `-1` if the process has not exited yet. After `await external_start(h)`
+    `-1` if the process has not exited yet. After `await external_run(h)`
     fulfills, the child's wait status (same as `r[2]` of the fulfillment
     tuple): `0` on success, the exit code on a normal exit, and
     `128 + signo` on POSIX if the child died from a signal. A non-zero
@@ -21,4 +21,4 @@ title: external / external_exit_code
 
 ### SEE ALSO
 
-    external_create(3), external_start(3)
+    external_create(3), external_run(3)

--- a/docs/efun/external/external_exit_code.md
+++ b/docs/efun/external/external_exit_code.md
@@ -1,0 +1,23 @@
+---
+title: external / external_exit_code
+---
+# external_exit_code
+
+### NAME
+
+    external_exit_code() - wait status of an external_create() handle
+
+### SYNOPSIS
+
+    int external_exit_code(int handle);
+
+### DESCRIPTION
+
+    `-1` if the process has not exited yet. After `await external_start(h)`
+    fulfills, the child's wait status: `0` on success, the exit code on a
+    normal exit, and `128 + signo` on POSIX if the child died from a
+    signal. A non-zero code does not reject the start promise.
+
+### SEE ALSO
+
+    external_create(3), external_start(3)

--- a/docs/efun/external/external_kill.md
+++ b/docs/efun/external/external_kill.md
@@ -1,0 +1,43 @@
+---
+title: external / external_kill
+---
+# external_kill
+
+### NAME
+
+    external_kill() - stop an external command, keep the handle
+
+### SYNOPSIS
+
+    int external_kill(int handle);
+
+### DESCRIPTION
+
+    Send `SIGTERM` to a running child (`TerminateProcess` with status
+    `143` on Win32, the same as `128 + SIGTERM`). Returns `1` if a
+    signal was sent, `0` if the handle is not running (Created or
+    already exited). Errors only if the handle is invalid or not owned
+    by this object.
+
+    The run promise is not rejected. It fulfills when the child
+    actually exits, with `({ stdout, stderr, exit_code })` — typically
+    `r[2] == 143`. Partial output stays on the handle.
+
+        int h = external_create(SLEEP_CMD, ({ "20" }));
+        mixed p = external_run(h);
+        call_out((: external_kill, h :), 10);
+        mixed *r = await p;
+        external_close(h);
+
+    `external_close(h)` also kills a running child, but frees the
+    handle and rejects the run promise with `"*external process
+    aborted"`. Use `external_kill` when you still want the result.
+
+    The omit-callback form has no handle: `promise_reject(p, reason)`
+    of that start promise kills the child. `with_timeout()` rejects a
+    gate and does **not** kill the child.
+
+### SEE ALSO
+
+    external_run(3), external_close(3), external_start(3),
+    promise_reject(3)

--- a/docs/efun/external/external_run.md
+++ b/docs/efun/external/external_run.md
@@ -37,6 +37,12 @@ title: external / external_run
     A handle can be run only once. Use `external_start(index, args)`
     when there is no handle.
 
+    Cancelling the run promise with `promise_reject(p)` (first settle
+    wins) kills the child (`SIGTERM` / `TerminateProcess`).
+    `external_close(h)` and destructing the owner do the same. A
+    non-zero exit from the kill (`128 + SIGTERM` on POSIX) is not
+    reported on a cancelled promise -- the promise is already rejected.
+
 ### SEE ALSO
 
     external_create(3), external_start(3), external_write(3),

--- a/docs/efun/external/external_run.md
+++ b/docs/efun/external/external_run.md
@@ -1,0 +1,44 @@
+---
+title: external / external_run
+---
+# external_run
+
+### NAME
+
+    external_run() - start a handle from external_create()
+
+### SYNOPSIS
+
+    promise external_run(int handle);
+
+### DESCRIPTION
+
+    Start the process for a handle from `external_create()` and return a
+    promise fulfilled with `({ stdout, stderr, exit_code })` when the
+    process exits (a non-zero exit still fulfills -- read `r[2]`), or
+    rejected with a socket error (`EESECURITY`, `EESOCKET`, ...) if
+    spawn fails -- or with `"*external process aborted"` if the owner
+    is destructed first. The child is started with `posix_spawn()`
+    (vfork fast path on glibc; Win32 uses `CreateProcess`).
+
+        int h = external_create(CURL_CMD, ({ "-s", url }));
+        mixed *r = await external_run(h);
+        string body = external_stdout(h);  /* same as r[0] */
+        int code = external_exit_code(h);  /* same as r[2] */
+
+    Drive stdin with `external_write()` (before or after start) and
+    `external_close_stdin()` when the child should see EOF:
+
+        int h = external_create(CAT_CMD, ({}));
+        external_write(h, payload);
+        external_close_stdin(h);
+        mixed *r = await external_run(h);
+
+    A handle can be run only once. Use `external_start(index, args)`
+    when there is no handle.
+
+### SEE ALSO
+
+    external_create(3), external_start(3), external_write(3),
+    external_close_stdin(3), external_stdout(3), external_stderr(3),
+    external_exit_code(3), external_close(3)

--- a/docs/efun/external/external_run.md
+++ b/docs/efun/external/external_run.md
@@ -37,14 +37,18 @@ title: external / external_run
     A handle can be run only once. Use `external_start(index, args)`
     when there is no handle.
 
-    Cancelling the run promise with `promise_reject(p)` (first settle
-    wins) kills the child (`SIGTERM` / `TerminateProcess`).
-    `external_close(h)` and destructing the owner do the same. A
-    non-zero exit from the kill (`128 + SIGTERM` on POSIX) is not
-    reported on a cancelled promise -- the promise is already rejected.
+### CANCELLING
+
+    `external_kill(h)` stops the child and keeps the handle: the run
+    promise still fulfills with `({ stdout, stderr, 143 })`.
+    `external_close(h)` stops the child, frees the handle, and rejects
+    the run promise with `"*external process aborted"`. Destructing
+    the owner does the same as `external_close`.
+    `promise_reject(p)` of the run promise also kills the child; the
+    promise stays rejected with the given reason.
 
 ### SEE ALSO
 
-    external_create(3), external_start(3), external_write(3),
-    external_close_stdin(3), external_stdout(3), external_stderr(3),
-    external_exit_code(3), external_close(3)
+    external_create(3), external_start(3), external_kill(3),
+    external_write(3), external_close_stdin(3), external_stdout(3),
+    external_stderr(3), external_exit_code(3), external_close(3)

--- a/docs/efun/external/external_start.md
+++ b/docs/efun/external/external_start.md
@@ -39,25 +39,28 @@ title: external / external_start
 
     Omit the callbacks (issue #1319, same pattern as `async_read(path)`
     and `call_out(delay)`) and `external_start(index, args)` returns a
-    promise fulfilled with `({ output, exit_code })` when the process
-    exits (a non-zero exit still fulfills -- read `r[1]`), or rejected
-    with a socket error (`EESECURITY`, `EESOCKET`, ...) if spawn fails
-    -- or with `"*external process aborted"` if the owner is destructed
-    first:
+    promise fulfilled with `({ stdout, stderr, exit_code })` when the
+    process exits (a non-zero exit still fulfills -- read `r[2]`), or
+    rejected with a socket error (`EESECURITY`, `EESOCKET`, ...) if
+    spawn fails -- or with `"*external process aborted"` if the owner
+    is destructed first. The child is started with `posix_spawn()`
+    (vfork fast path on glibc):
 
         mixed *r = await external_start(CURL_CMD, ({ "-s", url }));
         string body = r[0];
-        int code = r[1];
+        string err = r[1];
+        int code = r[2];
 
-    With a handle from `external_create()`: starts the process and
-    returns a promise fulfilled with `0` when it exits (same reject
-    reasons as the omit-callback form). After it fulfills, read stdout,
-    stderr and the wait status from the handle:
+    With a handle from `external_create()`: starts the process the same
+    way and returns a promise fulfilled with the same
+    `({ stdout, stderr, exit_code })` tuple (same reject reasons).
+    After it fulfills, the streams and wait status are also on the
+    handle:
 
         int h = external_create(CURL_CMD, ({ "-s", url }));
-        await external_start(h);
-        string body = external_stdout(h);
-        int code = external_exit_code(h);
+        mixed *r = await external_start(h);
+        string body = external_stdout(h);  /* same as r[0] */
+        int code = external_exit_code(h);  /* same as r[2] */
 
 ### RUNTIME CONFIGURATION
 

--- a/docs/efun/external/external_start.md
+++ b/docs/efun/external/external_start.md
@@ -55,6 +55,12 @@ title: external / external_start
     A handle from `external_create()` is started with `external_run()`,
     not this efun. See [external_run](/efun/external/external_run).
 
+    Cancelling the start promise with `promise_reject(p)` (first settle
+    wins) kills the child (`SIGTERM` / `TerminateProcess`).
+    `external_close(h)` and destructing the owner do the same. A
+    non-zero exit from the kill (`128 + SIGTERM` on POSIX) is not
+    reported on a cancelled promise -- the promise is already rejected.
+
 ### RUNTIME CONFIGURATION
 
     You can configure your runtime configuration to know about various external

--- a/docs/efun/external/external_start.md
+++ b/docs/efun/external/external_start.md
@@ -28,6 +28,8 @@ title: external / external_start
     This function returns the socket number which you should record for later
     processing of the results from the external command. The classic
     callback form is unchanged: it still returns that socket fd (`int`).
+    The child is started with `posix_spawn()` on POSIX and `CreateProcess`
+    on Win32 (no `posix_spawn` there).
 
     `args` - An array of the arguments passed to the external command,
     or a space-separated string of arguments.
@@ -44,7 +46,7 @@ title: external / external_start
     rejected with a socket error (`EESECURITY`, `EESOCKET`, ...) if
     spawn fails -- or with `"*external process aborted"` if the owner
     is destructed first. The child is started with `posix_spawn()`
-    (vfork fast path on glibc):
+    (vfork fast path on glibc; Win32 uses `CreateProcess`):
 
         mixed *r = await external_start(CURL_CMD, ({ "-s", url }));
         string body = r[0];

--- a/docs/efun/external/external_start.md
+++ b/docs/efun/external/external_start.md
@@ -10,10 +10,11 @@ title: external / external_start
 ### SYNOPSIS
 
     int external_start(int external_index,
-                       string *args,
+                       string | string * args,
                        string|function read_call_back,
                        string|function write_call_back,
-                       string|function close_call_back)
+                       void | string|function close_call_back);
+    promise external_start(int external_index, string | string * args);
 
 ### DESCRIPTION
 
@@ -26,12 +27,23 @@ title: external / external_start
     This function returns the socket number which you should record for later
     processing of the results from the external command.
 
-    `args` - An array of the arguments passed to the external command.
+    `args` - An array of the arguments passed to the external command,
+    or a space-separated string of arguments.
     `read_call_back` - As data becomes available, this function will be called
     with a string containing that data.
     `write_call_back` - I am not 100% sure what would be written to the external
     command, but, this is a required parameter.
     `close_call_back` - When the socket closes, this function is called.
+
+    With the callbacks OMITTED, returns a promise instead (issue #1319):
+    fulfilled with the collected stdout/stderr (the concatenation of every
+    string the read callback would have received) when the process exits,
+    or rejected with the negative socket error the classic form would have
+    returned (`EESECURITY`, `EESOCKET`, ...) -- or with
+    `"*external process aborted"` if the calling object is destructed
+    first. Inside an async function:
+
+        string body = await external_start(CURL_CMD, ({ "-s", url }));
 
 ### RUNTIME CONFIGURATION
 
@@ -119,3 +131,7 @@ void close_call_back(int fd) {
 ### ADDITIONAL INFORMATION
 
     This efun requires that PACKAGE_EXTERNAL be compiled into the driver.
+
+### SEE ALSO
+
+    socket_write(3), socket_close(3), async_read(3), call_out(3)

--- a/docs/efun/external/external_start.md
+++ b/docs/efun/external/external_start.md
@@ -14,7 +14,7 @@ title: external / external_start
                        string|function read_call_back,
                        string|function write_call_back,
                        void | string|function close_call_back);
-    promise external_start(int external_index, string | string * args);
+    promise external_start(int handle);
 
 ### DESCRIPTION
 
@@ -35,19 +35,17 @@ title: external / external_start
     command, but, this is a required parameter.
     `close_call_back` - When the socket closes, this function is called.
 
-    With the callbacks OMITTED, returns a promise instead (issue #1319):
-    fulfilled with `({ output, exit_code })` when the process exits --
-    `output` is the concatenation of every string the read callback would
-    have received, `exit_code` is the child's wait status (0 on success;
-    on POSIX a signal death is `128 + signo`, matching the shell).
-    Rejected with the negative socket error the classic form would have
-    returned (`EESECURITY`, `EESOCKET`, ...) -- or with
-    `"*external process aborted"` if the calling object is destructed
-    first. Inside an async function:
+    With a handle from `external_create()` (issue #1319): starts the
+    process and returns a promise fulfilled with `0` when it exits, or
+    rejected with a socket error (`EESECURITY`, `EESOCKET`, ...) if spawn
+    fails -- or with `"*external process aborted"` if the owner is
+    destructed / the handle is closed first. After it fulfills, read
+    stdout, stderr and the wait status from the handle:
 
-        mixed *r = await external_start(CURL_CMD, ({ "-s", url }));
-        string body = r[0];
-        int code = r[1];
+        int h = external_create(CURL_CMD, ({ "-s", url }));
+        await external_start(h);
+        string body = external_stdout(h);
+        int code = external_exit_code(h);
 
 ### RUNTIME CONFIGURATION
 
@@ -138,4 +136,6 @@ void close_call_back(int fd) {
 
 ### SEE ALSO
 
-    socket_write(3), socket_close(3), async_read(3), call_out(3)
+    external_create(3), external_stdout(3), external_stderr(3),
+    external_exit_code(3), external_close(3), socket_write(3),
+    socket_close(3), async_read(3), call_out(3)

--- a/docs/efun/external/external_start.md
+++ b/docs/efun/external/external_start.md
@@ -15,7 +15,6 @@ title: external / external_start
                        string|function write_call_back,
                        void | string|function close_call_back);
     promise external_start(int external_index, string | string * args);
-    promise external_start(int handle);
 
 ### DESCRIPTION
 
@@ -53,24 +52,8 @@ title: external / external_start
         string err = r[1];
         int code = r[2];
 
-    With a handle from `external_create()`: starts the process the same
-    way and returns a promise fulfilled with the same
-    `({ stdout, stderr, exit_code })` tuple (same reject reasons).
-    After it fulfills, the streams and wait status are also on the
-    handle:
-
-        int h = external_create(CURL_CMD, ({ "-s", url }));
-        mixed *r = await external_start(h);
-        string body = external_stdout(h);  /* same as r[0] */
-        int code = external_exit_code(h);  /* same as r[2] */
-
-    Drive stdin on a handle with `external_write()` (before or after
-    start) and `external_close_stdin()` when the child should see EOF:
-
-        int h = external_create(CAT_CMD, ({}));
-        external_write(h, payload);
-        external_close_stdin(h);
-        mixed *r = await external_start(h);
+    A handle from `external_create()` is started with `external_run()`,
+    not this efun. See [external_run](/efun/external/external_run).
 
 ### RUNTIME CONFIGURATION
 
@@ -161,7 +144,8 @@ void close_call_back(int fd) {
 
 ### SEE ALSO
 
-    external_create(3), external_write(3), external_close_stdin(3),
+    external_create(3), external_run(3), external_write(3),
+    external_close_stdin(3),
     external_stdout(3), external_stderr(3),
     external_exit_code(3), external_close(3), socket_write(3),
     socket_close(3), async_read(3), call_out(3)

--- a/docs/efun/external/external_start.md
+++ b/docs/efun/external/external_start.md
@@ -36,14 +36,18 @@ title: external / external_start
     `close_call_back` - When the socket closes, this function is called.
 
     With the callbacks OMITTED, returns a promise instead (issue #1319):
-    fulfilled with the collected stdout/stderr (the concatenation of every
-    string the read callback would have received) when the process exits,
-    or rejected with the negative socket error the classic form would have
+    fulfilled with `({ output, exit_code })` when the process exits --
+    `output` is the concatenation of every string the read callback would
+    have received, `exit_code` is the child's wait status (0 on success;
+    on POSIX a signal death is `128 + signo`, matching the shell).
+    Rejected with the negative socket error the classic form would have
     returned (`EESECURITY`, `EESOCKET`, ...) -- or with
     `"*external process aborted"` if the calling object is destructed
     first. Inside an async function:
 
-        string body = await external_start(CURL_CMD, ({ "-s", url }));
+        mixed *r = await external_start(CURL_CMD, ({ "-s", url }));
+        string body = r[0];
+        int code = r[1];
 
 ### RUNTIME CONFIGURATION
 

--- a/docs/efun/external/external_start.md
+++ b/docs/efun/external/external_start.md
@@ -15,6 +15,7 @@ title: external / external_start
                        string|function write_call_back,
                        void | string|function close_call_back);
     promise external_start(int external_index, string | string * args);
+    promise external_start(int external_index, string | string * args, string stdin);
     promise external_start(int handle);
 
 ### DESCRIPTION
@@ -53,6 +54,12 @@ title: external / external_start
         string err = r[1];
         int code = r[2];
 
+    An optional third string is written to the child's stdin and then
+    the write end is closed (EOF), so tools that read until end-of-file
+    (`cat`, `curl --data-binary @-`) finish:
+
+        mixed *r = await external_start(CAT_CMD, ({}), payload);
+
     With a handle from `external_create()`: starts the process the same
     way and returns a promise fulfilled with the same
     `({ stdout, stderr, exit_code })` tuple (same reject reasons).
@@ -63,6 +70,14 @@ title: external / external_start
         mixed *r = await external_start(h);
         string body = external_stdout(h);  /* same as r[0] */
         int code = external_exit_code(h);  /* same as r[2] */
+
+    Drive stdin on a handle with `external_write()` (before or after
+    start) and `external_close_stdin()` when the child should see EOF:
+
+        int h = external_create(CAT_CMD, ({}));
+        external_write(h, payload);
+        external_close_stdin(h);
+        mixed *r = await external_start(h);
 
 ### RUNTIME CONFIGURATION
 
@@ -153,6 +168,7 @@ void close_call_back(int fd) {
 
 ### SEE ALSO
 
-    external_create(3), external_stdout(3), external_stderr(3),
+    external_create(3), external_write(3), external_close_stdin(3),
+    external_stdout(3), external_stderr(3),
     external_exit_code(3), external_close(3), socket_write(3),
     socket_close(3), async_read(3), call_out(3)

--- a/docs/efun/external/external_start.md
+++ b/docs/efun/external/external_start.md
@@ -55,11 +55,16 @@ title: external / external_start
     A handle from `external_create()` is started with `external_run()`,
     not this efun. See [external_run](/efun/external/external_run).
 
-    Cancelling the start promise with `promise_reject(p)` (first settle
-    wins) kills the child (`SIGTERM` / `TerminateProcess`).
-    `external_close(h)` and destructing the owner do the same. A
-    non-zero exit from the kill (`128 + SIGTERM` on POSIX) is not
-    reported on a cancelled promise -- the promise is already rejected.
+### CANCELLING
+
+    This form has no handle. `promise_reject(p, reason)` of the start
+    promise kills the child; `p` stays rejected with `reason`. That is
+    the one driver promise where rejecting also stops the work.
+    `with_timeout()` rejects a gate and does **not** kill the child.
+
+    For a handle, use `external_kill(h)` (stop, keep the result) or
+    `external_close(h)` (stop, discard). See
+    [external_kill](/efun/external/external_kill).
 
 ### RUNTIME CONFIGURATION
 
@@ -150,7 +155,8 @@ void close_call_back(int fd) {
 
 ### SEE ALSO
 
-    external_create(3), external_run(3), external_write(3),
+    external_create(3), external_run(3), external_kill(3),
+    external_write(3),
     external_close_stdin(3),
     external_stdout(3), external_stderr(3),
     external_exit_code(3), external_close(3), socket_write(3),

--- a/docs/efun/external/external_start.md
+++ b/docs/efun/external/external_start.md
@@ -15,7 +15,6 @@ title: external / external_start
                        string|function write_call_back,
                        void | string|function close_call_back);
     promise external_start(int external_index, string | string * args);
-    promise external_start(int external_index, string | string * args, string stdin);
     promise external_start(int handle);
 
 ### DESCRIPTION
@@ -53,12 +52,6 @@ title: external / external_start
         string body = r[0];
         string err = r[1];
         int code = r[2];
-
-    An optional third string is written to the child's stdin and then
-    the write end is closed (EOF), so tools that read until end-of-file
-    (`cat`, `curl --data-binary @-`) finish:
-
-        mixed *r = await external_start(CAT_CMD, ({}), payload);
 
     With a handle from `external_create()`: starts the process the same
     way and returns a promise fulfilled with the same

--- a/docs/efun/external/external_start.md
+++ b/docs/efun/external/external_start.md
@@ -14,6 +14,7 @@ title: external / external_start
                        string|function read_call_back,
                        string|function write_call_back,
                        void | string|function close_call_back);
+    promise external_start(int external_index, string | string * args);
     promise external_start(int handle);
 
 ### DESCRIPTION
@@ -25,7 +26,8 @@ title: external / external_start
     argument to external_start `external_index`. 
 
     This function returns the socket number which you should record for later
-    processing of the results from the external command.
+    processing of the results from the external command. The classic
+    callback form is unchanged: it still returns that socket fd (`int`).
 
     `args` - An array of the arguments passed to the external command,
     or a space-separated string of arguments.
@@ -35,12 +37,22 @@ title: external / external_start
     command, but, this is a required parameter.
     `close_call_back` - When the socket closes, this function is called.
 
-    With a handle from `external_create()` (issue #1319): starts the
-    process and returns a promise fulfilled with `0` when it exits, or
-    rejected with a socket error (`EESECURITY`, `EESOCKET`, ...) if spawn
-    fails -- or with `"*external process aborted"` if the owner is
-    destructed / the handle is closed first. After it fulfills, read
-    stdout, stderr and the wait status from the handle:
+    Omit the callbacks (issue #1319, same pattern as `async_read(path)`
+    and `call_out(delay)`) and `external_start(index, args)` returns a
+    promise fulfilled with `({ output, exit_code })` when the process
+    exits (a non-zero exit still fulfills -- read `r[1]`), or rejected
+    with a socket error (`EESECURITY`, `EESOCKET`, ...) if spawn fails
+    -- or with `"*external process aborted"` if the owner is destructed
+    first:
+
+        mixed *r = await external_start(CURL_CMD, ({ "-s", url }));
+        string body = r[0];
+        int code = r[1];
+
+    With a handle from `external_create()`: starts the process and
+    returns a promise fulfilled with `0` when it exits (same reject
+    reasons as the omit-callback form). After it fulfills, read stdout,
+    stderr and the wait status from the handle:
 
         int h = external_create(CURL_CMD, ({ "-s", url }));
         await external_start(h);

--- a/docs/efun/external/external_stderr.md
+++ b/docs/efun/external/external_stderr.md
@@ -1,0 +1,21 @@
+---
+title: external / external_stderr
+---
+# external_stderr
+
+### NAME
+
+    external_stderr() - collected stderr of an external_create() handle
+
+### SYNOPSIS
+
+    string external_stderr(int handle);
+
+### DESCRIPTION
+
+    Return the stderr collected so far for `handle`. Same rules as
+    `external_stdout()`.
+
+### SEE ALSO
+
+    external_create(3), external_start(3), external_stdout(3)

--- a/docs/efun/external/external_stderr.md
+++ b/docs/efun/external/external_stderr.md
@@ -18,4 +18,4 @@ title: external / external_stderr
 
 ### SEE ALSO
 
-    external_create(3), external_start(3), external_stdout(3)
+    external_create(3), external_run(3), external_stdout(3)

--- a/docs/efun/external/external_stdout.md
+++ b/docs/efun/external/external_stdout.md
@@ -15,11 +15,11 @@ title: external / external_stdout
 
     Return the stdout collected so far for `handle`. Safe to call while
     the process is still running (partial output) or after
-    `external_start(handle)` has fulfilled. After fulfillment this is
+    `external_run(handle)` has fulfilled. After fulfillment this is
     the same string as `r[0]` of `({ stdout, stderr, exit_code })`
     (complete output, UTF-8 sanitized, capped at
     `__MAX_STRING_LENGTH__`).
 
 ### SEE ALSO
 
-    external_create(3), external_start(3), external_stderr(3)
+    external_create(3), external_run(3), external_stderr(3)

--- a/docs/efun/external/external_stdout.md
+++ b/docs/efun/external/external_stdout.md
@@ -15,8 +15,10 @@ title: external / external_stdout
 
     Return the stdout collected so far for `handle`. Safe to call while
     the process is still running (partial output) or after
-    `external_start(handle)` has fulfilled (complete output, UTF-8
-    sanitized, capped at `__MAX_STRING_LENGTH__`).
+    `external_start(handle)` has fulfilled. After fulfillment this is
+    the same string as `r[0]` of `({ stdout, stderr, exit_code })`
+    (complete output, UTF-8 sanitized, capped at
+    `__MAX_STRING_LENGTH__`).
 
 ### SEE ALSO
 

--- a/docs/efun/external/external_stdout.md
+++ b/docs/efun/external/external_stdout.md
@@ -1,0 +1,23 @@
+---
+title: external / external_stdout
+---
+# external_stdout
+
+### NAME
+
+    external_stdout() - collected stdout of an external_create() handle
+
+### SYNOPSIS
+
+    string external_stdout(int handle);
+
+### DESCRIPTION
+
+    Return the stdout collected so far for `handle`. Safe to call while
+    the process is still running (partial output) or after
+    `external_start(handle)` has fulfilled (complete output, UTF-8
+    sanitized, capped at `__MAX_STRING_LENGTH__`).
+
+### SEE ALSO
+
+    external_create(3), external_start(3), external_stderr(3)

--- a/docs/efun/external/external_write.md
+++ b/docs/efun/external/external_write.md
@@ -15,8 +15,10 @@ title: external / external_write
 
     Append `data` to the stdin of a handle from `external_create()`.
     Writes before `external_run()` are buffered and flushed when the
-    process starts. Writes after start go to the pipe (or the shared
-    stdio socket on Win32).
+    process starts. Writes after start go to the stdin pipe (POSIX and
+    Win32). On Win32, stdout/stderr still share one socketpair; stdin
+    is a separate anonymous pipe so the child can ReadFile and WriteFile
+    without deadlocking.
 
     The write end stays open until `external_close_stdin()` or
     `external_close()`. Commands that read until EOF need the explicit

--- a/docs/efun/external/external_write.md
+++ b/docs/efun/external/external_write.md
@@ -1,0 +1,38 @@
+---
+title: external / external_write
+---
+# external_write
+
+### NAME
+
+    external_write() - write to an external command's stdin
+
+### SYNOPSIS
+
+    void external_write(int handle, string data);
+
+### DESCRIPTION
+
+    Append `data` to the stdin of a handle from `external_create()`.
+    Writes before `external_start()` are buffered and flushed when the
+    process starts. Writes after start go to the pipe (or the shared
+    stdio socket on Win32).
+
+    The write end stays open until `external_close_stdin()` or
+    `external_close()`. Commands that read until EOF need the explicit
+    close.
+
+        int h = external_create(CAT_CMD, ({}));
+        external_write(h, "one\n");
+        mixed p = external_start(h);
+        external_write(h, "two\n");
+        external_close_stdin(h);
+        mixed *r = await p;
+
+    Errors if the handle is not owned by this object, stdin was already
+    closed, or the process has exited.
+
+### SEE ALSO
+
+    external_create(3), external_start(3), external_close_stdin(3),
+    external_close(3)

--- a/docs/efun/external/external_write.md
+++ b/docs/efun/external/external_write.md
@@ -9,7 +9,7 @@ title: external / external_write
 
 ### SYNOPSIS
 
-    void external_write(int handle, string data);
+    int external_write(int handle, string data);
 
 ### DESCRIPTION
 
@@ -29,8 +29,9 @@ title: external / external_write
         external_close_stdin(h);
         mixed *r = await p;
 
-    Errors if the handle is not owned by this object, stdin was already
-    closed, or the process has exited.
+    Returns `1` if the data was queued or written, `0` if stdin is
+    already closed or the process has exited (the data is dropped).
+    Errors only if the handle is invalid or not owned by this object.
 
 ### SEE ALSO
 

--- a/docs/efun/external/external_write.md
+++ b/docs/efun/external/external_write.md
@@ -14,7 +14,7 @@ title: external / external_write
 ### DESCRIPTION
 
     Append `data` to the stdin of a handle from `external_create()`.
-    Writes before `external_start()` are buffered and flushed when the
+    Writes before `external_run()` are buffered and flushed when the
     process starts. Writes after start go to the pipe (or the shared
     stdio socket on Win32).
 
@@ -24,7 +24,7 @@ title: external / external_write
 
         int h = external_create(CAT_CMD, ({}));
         external_write(h, "one\n");
-        mixed p = external_start(h);
+        mixed p = external_run(h);
         external_write(h, "two\n");
         external_close_stdin(h);
         mixed *r = await p;
@@ -34,5 +34,5 @@ title: external / external_write
 
 ### SEE ALSO
 
-    external_create(3), external_start(3), external_close_stdin(3),
+    external_create(3), external_run(3), external_close_stdin(3),
     external_close(3)

--- a/docs/efun/promises/promise_reject.md
+++ b/docs/efun/promises/promise_reject.md
@@ -38,7 +38,9 @@ title: promises / promise_reject
     a pre-settled async_read(3) promise discards the file contents, and a
     pre-resolved one turns a read failure into an apparent success. Settle a
     promise you did not create only when you mean to stop caring about its
-    result.
+    result. Exception: rejecting an `external_start` / `external_run`
+    promise also kills the child process. To stop a handle and still
+    read the result, use `external_kill(handle)` instead.
 
     A rejected promise whose rejection is never observed (no handler
     attached, result never read) is reported to the debug log when it is

--- a/docs/lpc/types/promise.md
+++ b/docs/lpc/types/promise.md
@@ -17,7 +17,7 @@ promise_result(p);              // 42
 Promises are produced by [`async` functions](../constructs/async), by the
 promise efuns, and by the promise forms of the callback efuns
 (`call_out(delay)`, `async_read(path)`, `external_start(index, args)`,
-`external_start(handle)`, ...). They are consumed with
+`external_run(handle)`, ...). They are consumed with
 `await`, or with `promise_then()` / `promise_catch()` handlers.
 
 ## Value semantics

--- a/docs/lpc/types/promise.md
+++ b/docs/lpc/types/promise.md
@@ -16,8 +16,8 @@ promise_result(p);              // 42
 
 Promises are produced by [`async` functions](../constructs/async), by the
 promise efuns, and by the promise forms of the callback efuns
-(`call_out(delay)`, `async_read(path)`, `external_start(handle)`,
-...). They are consumed with
+(`call_out(delay)`, `async_read(path)`, `external_start(index, args)`,
+`external_start(handle)`, ...). They are consumed with
 `await`, or with `promise_then()` / `promise_catch()` handlers.
 
 ## Value semantics

--- a/docs/lpc/types/promise.md
+++ b/docs/lpc/types/promise.md
@@ -16,7 +16,8 @@ promise_result(p);              // 42
 
 Promises are produced by [`async` functions](../constructs/async), by the
 promise efuns, and by the promise forms of the callback efuns
-(`call_out(delay)`, `async_read(path)`, ...). They are consumed with
+(`call_out(delay)`, `async_read(path)`, `external_start(index, args)`,
+...). They are consumed with
 `await`, or with `promise_then()` / `promise_catch()` handlers.
 
 ## Value semantics

--- a/docs/lpc/types/promise.md
+++ b/docs/lpc/types/promise.md
@@ -16,7 +16,7 @@ promise_result(p);              // 42
 
 Promises are produced by [`async` functions](../constructs/async), by the
 promise efuns, and by the promise forms of the callback efuns
-(`call_out(delay)`, `async_read(path)`, `external_start(index, args)`,
+(`call_out(delay)`, `async_read(path)`, `external_start(handle)`,
 ...). They are consumed with
 `await`, or with `promise_then()` / `promise_catch()` handlers.
 

--- a/docs/sidebars.generated.json
+++ b/docs/sidebars.generated.json
@@ -775,9 +775,39 @@
         "items": [
           {
             "type": "doc",
+            "id": "efun/external/external_close",
+            "key": "efun/external/external_close",
+            "label": "external_close"
+          },
+          {
+            "type": "doc",
+            "id": "efun/external/external_create",
+            "key": "efun/external/external_create",
+            "label": "external_create"
+          },
+          {
+            "type": "doc",
+            "id": "efun/external/external_exit_code",
+            "key": "efun/external/external_exit_code",
+            "label": "external_exit_code"
+          },
+          {
+            "type": "doc",
             "id": "efun/external/external_start",
             "key": "efun/external/external_start",
             "label": "external_start"
+          },
+          {
+            "type": "doc",
+            "id": "efun/external/external_stderr",
+            "key": "efun/external/external_stderr",
+            "label": "external_stderr"
+          },
+          {
+            "type": "doc",
+            "id": "efun/external/external_stdout",
+            "key": "efun/external/external_stdout",
+            "label": "external_stdout"
           }
         ]
       },

--- a/docs/sidebars.generated.json
+++ b/docs/sidebars.generated.json
@@ -799,6 +799,12 @@
           },
           {
             "type": "doc",
+            "id": "efun/external/external_run",
+            "key": "efun/external/external_run",
+            "label": "external_run"
+          },
+          {
+            "type": "doc",
             "id": "efun/external/external_start",
             "key": "efun/external/external_start",
             "label": "external_start"

--- a/docs/sidebars.generated.json
+++ b/docs/sidebars.generated.json
@@ -781,6 +781,12 @@
           },
           {
             "type": "doc",
+            "id": "efun/external/external_close_stdin",
+            "key": "efun/external/external_close_stdin",
+            "label": "external_close_stdin"
+          },
+          {
+            "type": "doc",
             "id": "efun/external/external_create",
             "key": "efun/external/external_create",
             "label": "external_create"
@@ -808,6 +814,12 @@
             "id": "efun/external/external_stdout",
             "key": "efun/external/external_stdout",
             "label": "external_stdout"
+          },
+          {
+            "type": "doc",
+            "id": "efun/external/external_write",
+            "key": "efun/external/external_write",
+            "label": "external_write"
           }
         ]
       },

--- a/docs/sidebars.generated.json
+++ b/docs/sidebars.generated.json
@@ -799,6 +799,12 @@
           },
           {
             "type": "doc",
+            "id": "efun/external/external_kill",
+            "key": "efun/external/external_kill",
+            "label": "external_kill"
+          },
+          {
+            "type": "doc",
             "id": "efun/external/external_run",
             "key": "efun/external/external_run",
             "label": "external_run"

--- a/src/packages/develop/checkmemory.cc
+++ b/src/packages/develop/checkmemory.cc
@@ -37,6 +37,9 @@
 #ifdef PACKAGE_JSBRIDGE
 #include "packages/jsbridge/jsbridge.h"
 #endif
+#ifdef PACKAGE_EXTERNAL
+#include "packages/external/external.h"
+#endif
 
 #include <functional>
 #include <unordered_map>
@@ -751,6 +754,9 @@ void check_all_blocks(int flag) {
 #endif
 #ifdef PACKAGE_ASYNC
     async_mark_request();
+#endif
+#ifdef PACKAGE_EXTERNAL
+    mark_external();
 #endif
     free_svalue(&apply_ret_value, "checkmemory");
     apply_ret_value = const0u;

--- a/src/packages/external/CMakeLists.txt
+++ b/src/packages/external/CMakeLists.txt
@@ -1,6 +1,7 @@
 if(${PACKAGE_EXTERNAL})
   add_library(package_external STATIC
           "external.cc"
+          "external.h"
           "socketpair.cc"
           )
 endif()

--- a/src/packages/external/external.cc
+++ b/src/packages/external/external.cc
@@ -360,8 +360,10 @@ void arm_pipe_reader(ExternalHandle* h, int id, int stream, evutil_socket_t fd) 
 }
 
 #ifndef _WIN32
-/* posix_spawn + POSIX_SPAWN_USEVFORK (glibc) is the fast path: vfork/clone
- * instead of a full fork of the driver address space. */
+/* Shared by the classic callback form and the handle/promise form.
+ * POSIX_SPAWN_USEVFORK (glibc) is the fast path: vfork/clone instead of
+ * a full fork of the driver address space. Win32 has no posix_spawn;
+ * see win32_create_process(). */
 int posix_spawn_fast(pid_t* pid, const char* path,
                      const posix_spawn_file_actions_t* file_actions, char** argv, char** envp) {
   posix_spawnattr_t attr;
@@ -481,6 +483,20 @@ int spawn_handle_posix(ExternalHandle* h, int id) {
 #endif
 
 #ifdef _WIN32
+/* Win32 special case: no posix_spawn. CreateProcess is used by both the
+ * classic callback form and the handle/promise form. Returns 1 on
+ * success. The caller decides whether to error() or reject. */
+int win32_create_process(std::string* cmdline, HANDLE h_in, HANDLE h_out, HANDLE h_err,
+                         PROCESS_INFORMATION* pi) {
+  STARTUPINFOA si = {sizeof(si)};
+  si.dwFlags = STARTF_USESHOWWINDOW | STARTF_USESTDHANDLES;
+  si.wShowWindow = SW_HIDE;
+  si.hStdInput = h_in;
+  si.hStdOutput = h_out;
+  si.hStdError = h_err;
+  return CreateProcessA(NULL, cmdline->data(), NULL, NULL, TRUE, 0, NULL, NULL, &si, pi) ? 1 : 0;
+}
+
 std::string quote_argument(const std::string& arg) {
   if (arg.empty()) {
     return "\"\"";
@@ -541,15 +557,9 @@ int spawn_handle_win32(ExternalHandle* h, int id) {
   HANDLE nul = CreateFileA("NUL", GENERIC_READ, FILE_SHARE_READ | FILE_SHARE_WRITE, &sa,
                            OPEN_EXISTING, 0, nullptr);
 
-  STARTUPINFOA si = {sizeof(si)};
-  si.dwFlags = STARTF_USESHOWWINDOW | STARTF_USESTDHANDLES;
-  si.wShowWindow = SW_HIDE;
-  si.hStdInput = nul;
-  si.hStdOutput = reinterpret_cast<HANDLE>(out_sv[0]);
-  si.hStdError = reinterpret_cast<HANDLE>(err_sv[0]);
   PROCESS_INFORMATION processInfo{};
-
-  if (!CreateProcessA(NULL, cmdline.data(), NULL, NULL, TRUE, 0, NULL, NULL, &si, &processInfo)) {
+  if (!win32_create_process(&cmdline, nul, reinterpret_cast<HANDLE>(out_sv[0]),
+                            reinterpret_cast<HANDLE>(err_sv[0]), &processInfo)) {
     if (nul != INVALID_HANDLE_VALUE) {
       CloseHandle(nul);
     }
@@ -620,6 +630,8 @@ void split(const std::string& s, char delim, Out result) {
 }  // namespace
 
 #ifndef _WIN32
+/* Classic callback form: same posix_spawn_fast() as the handle path.
+ * Stdio still shares one socketpair so the LPC socket callbacks work. */
 int external_start(int which, svalue_t* args, svalue_t* arg1, svalue_t* arg2, svalue_t* arg3) {
   std::vector<std::string> newargs_data = {std::string(external_cmd[which])};
   if (args->type == T_ARRAY) {
@@ -707,18 +719,7 @@ int external_start(int which, svalue_t* args, svalue_t* arg1, svalue_t* arg2, sv
 
   pid_t pid;
   char* newenviron[] = {nullptr};
-  posix_spawnattr_t spawn_attr;
-  int const attr_ok = posix_spawnattr_init(&spawn_attr) == 0;
-#ifdef POSIX_SPAWN_USEVFORK
-  if (attr_ok) {
-    posix_spawnattr_setflags(&spawn_attr, POSIX_SPAWN_USEVFORK);
-  }
-#endif
-  ret = posix_spawn(&pid, newargs[0], &file_actions, attr_ok ? &spawn_attr : nullptr,
-                    newargs.data(), newenviron);
-  if (attr_ok) {
-    posix_spawnattr_destroy(&spawn_attr);
-  }
+  ret = posix_spawn_fast(&pid, newargs[0], &file_actions, newargs.data(), newenviron);
   if (ret) {
     debug(external_start, "external_start: posix_spawn() error: %s\n", strerror(ret));
     socket_close(fd, SC_FORCE | SC_FINAL_CLOSE);
@@ -748,6 +749,7 @@ int external_start(int which, svalue_t* args, svalue_t* arg1, svalue_t* arg2, sv
 #endif
 
 #ifdef _WIN32
+/* Classic callback form, Win32 special case: CreateProcess (no posix_spawn). */
 int external_start(int which, svalue_t* args, svalue_t* arg1, svalue_t* arg2, svalue_t* arg3) {
   int fd;
 
@@ -808,15 +810,10 @@ int external_start(int which, svalue_t* args, svalue_t* arg1, svalue_t* arg2, sv
   event_add(sock->ev_write, NULL);
   event_add(sock->ev_read, NULL);
 
-  STARTUPINFOA si = {sizeof(si)};
-  si.dwFlags = STARTF_USESHOWWINDOW | STARTF_USESTDHANDLES;
-  si.wShowWindow = SW_HIDE;
-  si.hStdInput = reinterpret_cast<HANDLE>(sv[0]);
-  si.hStdError = reinterpret_cast<HANDLE>(sv[0]);
-  si.hStdOutput = reinterpret_cast<HANDLE>(sv[0]);
   PROCESS_INFORMATION processInfo{};
-
-  if (!CreateProcessA(NULL, cmdline.data(), NULL, NULL, TRUE, 0, NULL, NULL, &si, &processInfo)) {
+  if (!win32_create_process(&cmdline, reinterpret_cast<HANDLE>(sv[0]),
+                            reinterpret_cast<HANDLE>(sv[0]), reinterpret_cast<HANDLE>(sv[0]),
+                            &processInfo)) {
     error("CreateProcess() in external_start() failed: %s\n", strerror(errno));
     return EESOCKET;
   }

--- a/src/packages/external/external.cc
+++ b/src/packages/external/external.cc
@@ -462,17 +462,15 @@ void flush_stdin(ExternalHandle* h, int id) {
   }
 }
 
-void queue_stdin(ExternalHandle* h, int id, const char* data, size_t len) {
-  if (h->in_closed) {
-    error("external_write: stdin is closed.\n");
-  }
-  if (h->state == HandleState::Done) {
-    error("external_write: process has already exited.\n");
+int queue_stdin(ExternalHandle* h, int id, const char* data, size_t len) {
+  if (h->in_closed || h->close_stdin_after_flush || h->state == HandleState::Done) {
+    return 0;
   }
   append_capped(h->in_buf, data, len);
   if (h->state == HandleState::Running) {
     flush_stdin(h, id);
   }
+  return 1;
 }
 
 #ifndef _WIN32
@@ -995,12 +993,7 @@ void f_external_create() {
   int const num_arg = st_num_arg;
   svalue_t* arg = sp - num_arg + 1;
 
-  if (!check_valid_socket("external", -1, current_object, "N/A", -1)) {
-    st_num_arg = num_arg;
-    error("external_create: permission denied.\n");
-  }
-  st_num_arg = num_arg;
-
+  /* Allocation is not privileged; valid_socket is checked at run. */
   int const cmd = validate_cmd_index(arg[0].u.number);
   std::vector<std::string> extra;
   parse_cmd_args(arg + 1, &extra);
@@ -1162,8 +1155,9 @@ void f_external_write() {
   svalue_t* arg = sp - num_arg + 1;
   int const id = static_cast<int>(arg[0].u.number);
   ExternalHandle* h = lookup_handle(id, /*require_owner=*/1);
-  queue_stdin(h, id, arg[1].u.string, SVALUE_STRLEN(arg + 1));
+  int const ok = queue_stdin(h, id, arg[1].u.string, SVALUE_STRLEN(arg + 1));
   pop_n_elems(num_arg);
+  push_number(ok);
 }
 #endif
 

--- a/src/packages/external/external.cc
+++ b/src/packages/external/external.cc
@@ -57,7 +57,7 @@ struct ExternalHandle {
   HandleState state = HandleState::Created;
   promise_t* prom = nullptr;
   /* Omit-callback form: not visible to LPC. Fulfill with
-   * ({ stdout+stderr, exit_code }) and free the slot. */
+   * ({ stdout, stderr, exit_code }) and free the slot. */
   bool ephemeral = false;
   std::string out;
   std::string err;
@@ -192,6 +192,18 @@ void free_pipe_events(ExternalHandle* h) {
   close_pipe_fd(&h->err_fd);
 }
 
+void push_external_result(const std::string& out, const std::string& err, LPC_INT code) {
+  array_t* arr = allocate_array(3);
+  arr->item[0].type = T_STRING;
+  arr->item[0].subtype = STRING_MALLOC;
+  arr->item[0].u.string = string_copy(out.c_str(), "external_stdout");
+  arr->item[1].type = T_STRING;
+  arr->item[1].subtype = STRING_MALLOC;
+  arr->item[1].u.string = string_copy(err.c_str(), "external_stderr");
+  arr->item[2].u.number = code;
+  push_refed_array(arr);
+}
+
 void fulfill_handle_promise(int id) {
   ExternalHandle* h = g_handles[id - 1];
   if (!h->prom) {
@@ -203,28 +215,14 @@ void fulfill_handle_promise(int id) {
   }
   promise_t* p = h->prom;
   h->prom = nullptr;
-  if (h->ephemeral) {
-    std::string output = h->out;
-    if (!h->err.empty()) {
-      output += h->err;
-    }
-    array_t* arr = allocate_array(2);
-    arr->item[0].type = T_STRING;
-    arr->item[0].subtype = STRING_MALLOC;
-    arr->item[0].u.string = string_copy(output.c_str(), "external_promise");
-    arr->item[1].u.number = h->exit_code;
-    push_refed_array(arr);
-    promise_settle(p, sp, 0);
-    pop_stack();
-    free_promise(p);
-    delete h;
-    g_handles[id - 1] = nullptr;
-    return;
-  }
-  push_number(0);
+  push_external_result(h->out, h->err, h->exit_code);
   promise_settle(p, sp, 0);
   pop_stack();
   free_promise(p);
+  if (h->ephemeral) {
+    delete h;
+    g_handles[id - 1] = nullptr;
+  }
 }
 
 void try_finish_handle(int id) {
@@ -362,6 +360,53 @@ void arm_pipe_reader(ExternalHandle* h, int id, int stream, evutil_socket_t fd) 
 }
 
 #ifndef _WIN32
+/* posix_spawn + POSIX_SPAWN_USEVFORK (glibc) is the fast path: vfork/clone
+ * instead of a full fork of the driver address space. */
+int posix_spawn_fast(pid_t* pid, const char* path,
+                     const posix_spawn_file_actions_t* file_actions, char** argv, char** envp) {
+  posix_spawnattr_t attr;
+  if (posix_spawnattr_init(&attr) != 0) {
+    return posix_spawn(pid, path, file_actions, nullptr, argv, envp);
+  }
+  short flags = 0;
+#ifdef POSIX_SPAWN_USEVFORK
+  flags |= POSIX_SPAWN_USEVFORK;
+#endif
+  if (flags != 0) {
+    posix_spawnattr_setflags(&attr, flags);
+  }
+  int const ret = posix_spawn(pid, path, file_actions, &attr, argv, envp);
+  posix_spawnattr_destroy(&attr);
+  return ret;
+}
+
+void close_pipe_pair(int p[2]) {
+  if (p[0] >= 0) {
+    close(p[0]);
+  }
+  if (p[1] >= 0) {
+    close(p[1]);
+  }
+  p[0] = p[1] = -1;
+}
+
+/* Parent read end is nonblocking; write end stays blocking so the child
+ * does not see EAGAIN. CLOEXEC so the child's unused ends vanish at exec
+ * without extra file_actions_addclose. */
+int open_spawn_pipe(int p[2]) {
+  p[0] = p[1] = -1;
+  if (pipe(p) != 0) {
+    return -1;
+  }
+  fcntl(p[0], F_SETFD, FD_CLOEXEC);
+  fcntl(p[1], F_SETFD, FD_CLOEXEC);
+  if (evutil_make_socket_nonblocking(p[0]) == -1) {
+    close_pipe_pair(p);
+    return -1;
+  }
+  return 0;
+}
+
 int spawn_handle_posix(ExternalHandle* h, int id) {
   std::vector<std::string> argv_data = {std::string(external_cmd[h->cmd_index])};
   argv_data.insert(argv_data.end(), h->args.begin(), h->args.end());
@@ -373,63 +418,38 @@ int spawn_handle_posix(ExternalHandle* h, int id) {
 
   int outp[2] = {-1, -1};
   int errp[2] = {-1, -1};
-  if (pipe(outp) != 0 || pipe(errp) != 0) {
-    if (outp[0] >= 0) {
-      close(outp[0]);
-    }
-    if (outp[1] >= 0) {
-      close(outp[1]);
-    }
-    if (errp[0] >= 0) {
-      close(errp[0]);
-    }
-    if (errp[1] >= 0) {
-      close(errp[1]);
-    }
-    return EESOCKET;
-  }
-  if (evutil_make_socket_nonblocking(outp[0]) == -1 ||
-      evutil_make_socket_nonblocking(errp[0]) == -1) {
-    close(outp[0]);
-    close(outp[1]);
-    close(errp[0]);
-    close(errp[1]);
+  if (open_spawn_pipe(outp) != 0 || open_spawn_pipe(errp) != 0) {
+    close_pipe_pair(outp);
+    close_pipe_pair(errp);
     return EESOCKET;
   }
 
   posix_spawn_file_actions_t file_actions;
   int ret = posix_spawn_file_actions_init(&file_actions);
   if (ret != 0) {
-    close(outp[0]);
-    close(outp[1]);
-    close(errp[0]);
-    close(errp[1]);
+    close_pipe_pair(outp);
+    close_pipe_pair(errp);
     return EESOCKET;
   }
   DEFER { posix_spawn_file_actions_destroy(&file_actions); };
 
+  /* CLOEXEC drops the parent read ends at exec; only dup2 + stdin null. */
   ret = posix_spawn_file_actions_adddup2(&file_actions, outp[1], 1) ||
         posix_spawn_file_actions_adddup2(&file_actions, errp[1], 2) ||
-        posix_spawn_file_actions_addopen(&file_actions, 0, "/dev/null", O_RDONLY, 0) ||
-        posix_spawn_file_actions_addclose(&file_actions, outp[0]) ||
-        posix_spawn_file_actions_addclose(&file_actions, errp[0]);
+        posix_spawn_file_actions_addopen(&file_actions, 0, "/dev/null", O_RDONLY, 0);
   if (ret != 0) {
-    close(outp[0]);
-    close(outp[1]);
-    close(errp[0]);
-    close(errp[1]);
+    close_pipe_pair(outp);
+    close_pipe_pair(errp);
     return EESOCKET;
   }
 
   pid_t pid;
   char* newenviron[] = {nullptr};
-  ret = posix_spawn(&pid, argv[0], &file_actions, nullptr, argv.data(), newenviron);
+  ret = posix_spawn_fast(&pid, argv[0], &file_actions, argv.data(), newenviron);
   if (ret != 0) {
     debug(external_start, "external_start: posix_spawn() error: %s\n", strerror(ret));
-    close(outp[0]);
-    close(outp[1]);
-    close(errp[0]);
-    close(errp[1]);
+    close_pipe_pair(outp);
+    close_pipe_pair(errp);
     return EESOCKET;
   }
   close(outp[1]);
@@ -687,7 +707,18 @@ int external_start(int which, svalue_t* args, svalue_t* arg1, svalue_t* arg2, sv
 
   pid_t pid;
   char* newenviron[] = {nullptr};
-  ret = posix_spawn(&pid, newargs[0], &file_actions, nullptr, newargs.data(), newenviron);
+  posix_spawnattr_t spawn_attr;
+  int const attr_ok = posix_spawnattr_init(&spawn_attr) == 0;
+#ifdef POSIX_SPAWN_USEVFORK
+  if (attr_ok) {
+    posix_spawnattr_setflags(&spawn_attr, POSIX_SPAWN_USEVFORK);
+  }
+#endif
+  ret = posix_spawn(&pid, newargs[0], &file_actions, attr_ok ? &spawn_attr : nullptr,
+                    newargs.data(), newenviron);
+  if (attr_ok) {
+    posix_spawnattr_destroy(&spawn_attr);
+  }
   if (ret) {
     debug(external_start, "external_start: posix_spawn() error: %s\n", strerror(ret));
     socket_close(fd, SC_FORCE | SC_FINAL_CLOSE);
@@ -902,7 +933,7 @@ void f_external_start() {
 
   if (num_arg == 2) {
     /* Issue #1319 omit-callback form: same efun, no callbacks, promise of
-     * ({ output, exit_code }). Classic 4/5-arg path below is unchanged. */
+     * ({ stdout, stderr, exit_code }). Classic 4/5-arg path below is unchanged. */
     if (!check_valid_socket("external", -1, current_object, "N/A", -1)) {
       st_num_arg = num_arg;
       promise_t* p = promise_alloc();

--- a/src/packages/external/external.cc
+++ b/src/packages/external/external.cc
@@ -1056,10 +1056,10 @@ void f_external_start() {
     return;
   }
 
-  if (num_arg == 2 || (num_arg == 3 && arg[2].type == T_STRING)) {
+  if (num_arg == 2) {
     /* Issue #1319 omit-callback form: same efun, no callbacks, promise of
-     * ({ stdout, stderr, exit_code }). Optional third string is stdin
-     * (written then closed). Classic 4/5-arg path below is unchanged. */
+     * ({ stdout, stderr, exit_code }). Classic 4/5-arg path below is
+     * unchanged. Drive stdin on a handle with external_write(). */
     if (!check_valid_socket("external", -1, current_object, "N/A", -1)) {
       st_num_arg = num_arg;
       promise_t* p = promise_alloc();
@@ -1084,10 +1084,6 @@ void f_external_start() {
     h->cmd_index = static_cast<int>(which);
     h->args = std::move(extra);
     h->ephemeral = true;
-    if (num_arg == 3) {
-      append_capped(h->in_buf, arg[2].u.string, SVALUE_STRLEN(arg + 2));
-      h->close_stdin_after_flush = true;
-    }
     g_handles[id - 1] = h;
 
     promise_t* p = start_created_handle(h, id);
@@ -1099,8 +1095,8 @@ void f_external_start() {
   if (num_arg != 4 && num_arg != 5) {
     error(
         "external_start: omit the callbacks for the promise form, pass a "
-        "handle from external_create(), pass stdin as a third string, or "
-        "pass the classic read/write callbacks.\n");
+        "handle from external_create(), or pass the classic read/write "
+        "callbacks.\n");
   }
 
   if (!check_valid_socket("external", -1, current_object, "N/A", -1)) {

--- a/src/packages/external/external.cc
+++ b/src/packages/external/external.cc
@@ -257,7 +257,8 @@ void kill_handle_child(ExternalHandle* h) {
   }
 #else
   if (h->pi.hProcess) {
-    TerminateProcess(h->pi.hProcess, 1);
+    /* 143 == 128 + SIGTERM so Win32 reports the same wait status as POSIX. */
+    TerminateProcess(h->pi.hProcess, 143);
   }
 #endif
 }
@@ -1255,6 +1256,19 @@ void f_external_stderr() {
 void f_external_exit_code() {
   ExternalHandle* h = lookup_handle(static_cast<int>(sp->u.number), /*require_owner=*/1);
   sp->u.number = h->exit_code;
+}
+#endif
+
+#ifdef F_EXTERNAL_KILL
+void f_external_kill() {
+  int const id = static_cast<int>(sp->u.number);
+  ExternalHandle* h = lookup_handle(id, /*require_owner=*/1);
+  if (h->state != HandleState::Running) {
+    sp->u.number = 0;
+    return;
+  }
+  kill_handle_child(h);
+  sp->u.number = 1;
 }
 #endif
 

--- a/src/packages/external/external.cc
+++ b/src/packages/external/external.cc
@@ -81,6 +81,10 @@ struct ExternalHandle {
   pid_t pid = -1;
 #else
   PROCESS_INFORMATION pi{};
+  /* Separate from the stdout socketpair: console programs ReadFile
+   * stdin and WriteFile stdout. One TCP socket for both deadlocks
+   * (findstr) and closesocket() can RST unread stdout. */
+  HANDLE in_handle = nullptr;
 #endif
 };
 
@@ -181,6 +185,27 @@ void close_pipe_fd(evutil_socket_t* fd) {
   *fd = -1;
 }
 
+bool stdin_writable(const ExternalHandle* h) {
+  if (h->in_closed) {
+    return false;
+  }
+#ifdef _WIN32
+  if (h->in_handle) {
+    return true;
+  }
+#endif
+  return h->in_fd >= 0;
+}
+
+#ifdef _WIN32
+void close_win32_stdin(ExternalHandle* h) {
+  if (h->in_handle) {
+    CloseHandle(h->in_handle);
+    h->in_handle = nullptr;
+  }
+}
+#endif
+
 void free_pipe_events(ExternalHandle* h) {
   if (h->ev_out) {
     event_free(h->ev_out);
@@ -198,6 +223,9 @@ void free_pipe_events(ExternalHandle* h) {
   h->out_watch = nullptr;
   delete h->err_watch;
   h->err_watch = nullptr;
+#ifdef _WIN32
+  close_win32_stdin(h);
+#endif
   if (h->in_fd >= 0 && h->in_fd != h->out_fd) {
     close_pipe_fd(&h->in_fd);
   } else {
@@ -327,35 +355,40 @@ void on_handle_pipe_read(evutil_socket_t fd, short /*what*/, void* arg) {
   }
   ExternalHandle* h = g_handles[id - 1];
   char buf[kPipeBuf];
+  for (;;) {
 #ifdef _WIN32
-  int cc = recv(fd, buf, sizeof(buf) - 1, 0);
+    int cc = recv(fd, buf, sizeof(buf) - 1, 0);
 #else
-  int cc = static_cast<int>(read(fd, buf, sizeof(buf) - 1));
+    int cc = static_cast<int>(read(fd, buf, sizeof(buf) - 1));
 #endif
-  if (cc > 0) {
-    buf[cc] = '\0';
-    auto res = u8_sanitize(buf);
-    append_capped(watch->stream == 0 ? h->out : h->err, res.c_str(), res.size());
+    if (cc > 0) {
+      buf[cc] = '\0';
+      auto res = u8_sanitize(buf);
+      append_capped(watch->stream == 0 ? h->out : h->err, res.c_str(), res.size());
+      continue;
+    }
+    if (cc < 0) {
+#ifdef _WIN32
+      if (evutil_socket_geterror(fd) == WSAEWOULDBLOCK) {
+        return;
+      }
+#else
+      if (errno == EINTR) {
+        continue;
+      }
+      if (errno == EAGAIN || errno == EWOULDBLOCK) {
+        return;
+      }
+#endif
+    }
+    if (watch->stream == 0) {
+      h->out_eof = true;
+    } else {
+      h->err_eof = true;
+    }
+    try_finish_handle(id);
     return;
   }
-  if (cc < 0) {
-#ifdef _WIN32
-    int err = evutil_socket_geterror(fd);
-    if (err == WSAEWOULDBLOCK) {
-      return;
-    }
-#else
-    if (errno == EINTR || errno == EAGAIN || errno == EWOULDBLOCK) {
-      return;
-    }
-#endif
-  }
-  if (watch->stream == 0) {
-    h->out_eof = true;
-  } else {
-    h->err_eof = true;
-  }
-  try_finish_handle(id);
 }
 
 void arm_pipe_reader(ExternalHandle* h, int id, int stream, evutil_socket_t fd) {
@@ -382,6 +415,9 @@ void close_stdin_write(ExternalHandle* h) {
     event_free(h->ev_in);
     h->ev_in = nullptr;
   }
+#ifdef _WIN32
+  close_win32_stdin(h);
+#endif
   if (h->in_fd >= 0) {
     if (h->in_fd == h->out_fd) {
 #ifdef _WIN32
@@ -410,7 +446,7 @@ void on_handle_stdin_writable(evutil_socket_t /*fd*/, short /*what*/, void* arg)
 }
 
 void arm_stdin_writer(ExternalHandle* h, int id) {
-  if (h->in_fd < 0 || h->in_closed) {
+  if (!stdin_writable(h) || h->in_fd < 0) {
     return;
   }
   if (!h->ev_in) {
@@ -421,9 +457,27 @@ void arm_stdin_writer(ExternalHandle* h, int id) {
 }
 
 void flush_stdin(ExternalHandle* h, int id) {
-  if (h->in_closed || h->in_fd < 0) {
+  if (!stdin_writable(h)) {
     return;
   }
+#ifdef _WIN32
+  if (h->in_handle) {
+    while (!h->in_buf.empty()) {
+      DWORD written = 0;
+      size_t chunk = std::min(h->in_buf.size(), static_cast<size_t>(kPipeBuf));
+      if (!WriteFile(h->in_handle, h->in_buf.data(), static_cast<DWORD>(chunk), &written, nullptr) ||
+          written == 0) {
+        close_stdin_write(h);
+        return;
+      }
+      h->in_buf.erase(0, static_cast<size_t>(written));
+    }
+    if (h->close_stdin_after_flush) {
+      close_stdin_write(h);
+    }
+    return;
+  }
+#endif
   while (!h->in_buf.empty()) {
     size_t chunk = std::min(h->in_buf.size(), static_cast<size_t>(kPipeBuf));
 #ifdef _WIN32
@@ -676,10 +730,11 @@ int spawn_handle_win32(ExternalHandle* h, int id) {
   }
   cmdline += fmt::to_string(fmt::join(quoted.begin(), quoted.end(), " "));
 
-  /* Same stdio as the classic form: one socketpair, socks[0] for all three
-   * child handles. Separate stdout/stderr socketpairs do not deliver data
-   * through CreateProcess on Win32 (classic latch passed; handle latches
-   * never released). stderr is reported empty. */
+  /* stdout/stderr still share one socketpair (separate output pairs do
+   * not deliver data through CreateProcess). stdin is a real anonymous
+   * pipe: console tools ReadFile stdin and WriteFile stdout, so one TCP
+   * socket for both deadlocks, and cmd.exe treats `^` as an escape.
+   * stderr is reported empty. */
   SOCKET sv[2];
   if (socketpair_win32(sv, 0) != 0) {
     return EESOCKET;
@@ -690,18 +745,39 @@ int spawn_handle_win32(ExternalHandle* h, int id) {
     return EESOCKET;
   }
 
-  PROCESS_INFORMATION processInfo{};
-  if (!win32_create_process(&cmdline, reinterpret_cast<HANDLE>(sv[0]),
-                            reinterpret_cast<HANDLE>(sv[0]),
-                            reinterpret_cast<HANDLE>(sv[0]), &processInfo)) {
+  SECURITY_ATTRIBUTES sa{};
+  sa.nLength = sizeof(sa);
+  sa.bInheritHandle = TRUE;
+  HANDLE stdin_rd = nullptr;
+  HANDLE stdin_wr = nullptr;
+  if (!CreatePipe(&stdin_rd, &stdin_wr, &sa, 65536)) {
     evutil_closesocket(sv[0]);
     evutil_closesocket(sv[1]);
     return EESOCKET;
   }
+  /* Child must not inherit the write end, or CloseHandle never delivers EOF. */
+  if (!SetHandleInformation(stdin_wr, HANDLE_FLAG_INHERIT, 0)) {
+    CloseHandle(stdin_rd);
+    CloseHandle(stdin_wr);
+    evutil_closesocket(sv[0]);
+    evutil_closesocket(sv[1]);
+    return EESOCKET;
+  }
+
+  PROCESS_INFORMATION processInfo{};
+  if (!win32_create_process(&cmdline, stdin_rd, reinterpret_cast<HANDLE>(sv[0]),
+                            reinterpret_cast<HANDLE>(sv[0]), &processInfo)) {
+    CloseHandle(stdin_rd);
+    CloseHandle(stdin_wr);
+    evutil_closesocket(sv[0]);
+    evutil_closesocket(sv[1]);
+    return EESOCKET;
+  }
+  CloseHandle(stdin_rd);
   h->pi = processInfo;
   h->err_eof = true;
   arm_pipe_reader(h, id, 0, sv[1]);
-  h->in_fd = sv[1];
+  h->in_handle = stdin_wr;
   flush_stdin(h, id);
 
   std::thread([id, processInfo, child_fd = sv[0]]() {
@@ -710,6 +786,7 @@ int spawn_handle_win32(ExternalHandle* h, int id) {
     GetExitCodeProcess(processInfo.hProcess, &exitCode);
     CloseHandle(processInfo.hProcess);
     CloseHandle(processInfo.hThread);
+    shutdown(child_fd, SD_SEND);
     evutil_closesocket(child_fd);
     note_child_exit(id, static_cast<LPC_INT>(exitCode));
   }).detach();

--- a/src/packages/external/external.cc
+++ b/src/packages/external/external.cc
@@ -2,26 +2,246 @@
 
 #include <algorithm>
 #include <cerrno>
+#include <chrono>
+#include <cinttypes>
 #include <cstring>
 #include <cstdlib>  // for exit
-#include <thread>
+#include <mutex>
 #include <string>
+#include <thread>
 #include <unordered_map>
+#include <vector>
 #include <fmt/format.h>
 #include <fmt/ranges.h>
 
 #include <event2/event.h>
 
+#include "backend.h"
 #include "include/socket_err.h"
 #include "packages/external/external.h"
 #include "packages/sockets/socket_efuns.h"
 
+#ifdef _WIN32
+#include <windows.h>
+#include <fcntl.h>
+extern int socketpair_win32(SOCKET socks[2], int make_overlapped);  // in socketpair.cc
+#endif
+
 #ifndef _WIN32
 #include <sstream>
-#include <vector>
 #include <spawn.h>
 #include <sys/wait.h>
+#endif
 
+namespace {
+
+/* Promise-form jobs (issue #1319): collect stdout/stderr, then settle when
+ * BOTH the child socket has closed and waitpid/GetExitCode has reported
+ * the return code. Keyed by LPC socket index. */
+struct ExternalPromiseJob {
+  promise_t* prom = nullptr;
+  std::string output;
+  LPC_INT exit_code = 0;
+  bool io_done = false;
+  bool status_done = false;
+  bool aborted = false;
+};
+
+struct ChildWatch {
+#ifdef _WIN32
+  PROCESS_INFORMATION pi{};
+  SOCKET child_sock = static_cast<SOCKET>(INVALID_SOCKET);
+#else
+  pid_t pid = -1;
+#endif
+};
+
+std::unordered_map<int, ExternalPromiseJob*> g_external_jobs;
+std::unordered_map<int, ChildWatch> g_child_watches;
+
+std::mutex g_exit_mu;
+struct ChildExitNote {
+  int fd;
+  LPC_INT code;
+};
+std::vector<ChildExitNote> g_exit_notes;
+
+void reject_with_number(promise_t* p, LPC_INT n) {
+  push_number(n);
+  promise_settle(p, sp, 1);
+  pop_stack();
+}
+
+void settle_and_drop_job(int fd) {
+  auto it = g_external_jobs.find(fd);
+  if (it == g_external_jobs.end()) {
+    return;
+  }
+  ExternalPromiseJob* job = it->second;
+  g_external_jobs.erase(it);
+
+  if (job->aborted) {
+    push_constant_string("*external process aborted");
+    promise_settle(job->prom, sp, 1);
+    pop_stack();
+  } else {
+    array_t* arr = allocate_array(2);
+    arr->item[0].type = T_STRING;
+    arr->item[0].subtype = STRING_MALLOC;
+    arr->item[0].u.string = string_copy(job->output.c_str(), "external_promise");
+    arr->item[1].u.number = job->exit_code;
+    push_refed_array(arr);
+    promise_settle(job->prom, sp, 0);
+    pop_stack();
+  }
+  free_promise(job->prom);
+  delete job;
+}
+
+void try_finish_job(int fd) {
+  auto it = g_external_jobs.find(fd);
+  if (it == g_external_jobs.end()) {
+    return;
+  }
+  ExternalPromiseJob* job = it->second;
+  if (job->aborted || (job->io_done && job->status_done)) {
+    settle_and_drop_job(fd);
+  }
+}
+
+void attach_external_job(int fd, promise_t* p) {
+  auto* job = new ExternalPromiseJob{};
+  job->prom = p;
+  g_external_jobs[fd] = job;
+}
+
+void drain_child_exits() {
+  std::vector<ChildExitNote> notes;
+  {
+    std::lock_guard<std::mutex> const lock(g_exit_mu);
+    notes.swap(g_exit_notes);
+  }
+  for (auto& note : notes) {
+    auto it = g_external_jobs.find(note.fd);
+    if (it == g_external_jobs.end()) {
+      continue;
+    }
+    it->second->exit_code = note.code;
+    it->second->status_done = true;
+    try_finish_job(note.fd);
+  }
+}
+
+/* Called from the waitpid / WaitForSingleObject thread. Must not touch
+ * LPC; the wall-time event runs drain_child_exits() on the main loop. */
+void note_child_exit(int fd, LPC_INT code) {
+  {
+    std::lock_guard<std::mutex> const lock(g_exit_mu);
+    g_exit_notes.push_back(ChildExitNote{fd, code});
+  }
+  add_walltime_event(std::chrono::milliseconds(0), TickEvent::callback_type([] { drain_child_exits(); }));
+}
+
+#ifndef _WIN32
+void stash_posix_child(int fd, pid_t pid) { g_child_watches[fd] = ChildWatch{pid}; }
+#else
+void stash_win32_child(int fd, PROCESS_INFORMATION pi, SOCKET child_sock) {
+  ChildWatch w;
+  w.pi = pi;
+  w.child_sock = child_sock;
+  g_child_watches[fd] = w;
+}
+#endif
+
+void watch_child(int fd) {
+  auto it = g_child_watches.find(fd);
+  if (it == g_child_watches.end()) {
+    return;
+  }
+  ChildWatch w = it->second;
+  g_child_watches.erase(it);
+
+#ifndef _WIN32
+  pid_t const pid = w.pid;
+  std::thread([=]() {
+    int status = 0;
+    LPC_INT code = -1;
+    do {
+      const int s = waitpid(pid, &status, WUNTRACED | WCONTINUED);
+      if (s == -1) {
+        debug(external_start, "external_start: waitpid() error: %s (%d).\n", strerror(errno),
+              errno);
+        note_child_exit(fd, -1);
+        return;
+      }
+      if (WIFEXITED(status)) {
+        code = WEXITSTATUS(status);
+        debug(external_start, "external_start: child %jd exited, status=%d\n", (intmax_t)pid,
+              WEXITSTATUS(status));
+      } else if (WIFSIGNALED(status)) {
+        code = 128 + WTERMSIG(status);
+        debug(external_start, "external_start: child %jd killed by signal %d\n", (intmax_t)pid,
+              WTERMSIG(status));
+      } else if (WIFSTOPPED(status)) {
+        debug(external_start, "external_start: child %jd stopped by signal %d\n", (intmax_t)pid,
+              WSTOPSIG(status));
+      } else if (WIFCONTINUED(status)) {
+        debug(external_start, "external_start: child %jd continued\n", (intmax_t)pid);
+      }
+    } while (!WIFEXITED(status) && !WIFSIGNALED(status));
+    note_child_exit(fd, code);
+  }).detach();
+#else
+  PROCESS_INFORMATION const processInfo = w.pi;
+  SOCKET const child_sock = w.child_sock;
+  std::thread([=]() {
+    WaitForSingleObject(processInfo.hProcess, INFINITE);
+    DWORD exitCode = static_cast<DWORD>(-1);
+    GetExitCodeProcess(processInfo.hProcess, &exitCode);
+    debug(external_start, "external_start: pid: %d exited with %d.\n", processInfo.dwProcessId,
+          exitCode);
+    CloseHandle(processInfo.hProcess);
+    CloseHandle(processInfo.hThread);
+    evutil_closesocket(child_sock);
+    note_child_exit(fd, static_cast<LPC_INT>(exitCode));
+  }).detach();
+#endif
+}
+
+std::string quote_argument(const std::string& arg) {
+  if (arg.empty()) {
+    return "\"\"";
+  }
+  if (arg.find_first_of(" \t\n\v\"") == std::string::npos) {
+    return arg;
+  }
+  std::string res = "\"";
+  // from
+  // https://learn.microsoft.com/en-us/archive/blogs/twistylittlepassagesallalike/everyone-quotes-command-line-arguments-the-wrong-way
+  for (auto It = arg.begin();; ++It) {
+    unsigned NumberBackslashes = 0;
+
+    while (It != arg.end() && *It == '\\') {
+      ++It;
+      ++NumberBackslashes;
+    }
+
+    if (It == arg.end()) {
+      res.append(NumberBackslashes * 2, '\\');
+      break;
+    } else if (*It == '"') {
+      res.append(NumberBackslashes * 2 + 1, '\\');
+      res.push_back(*It);
+    } else {
+      res.append(NumberBackslashes, '\\');
+      res.push_back(*It);
+    }
+  }
+  res.push_back('"');
+  return res;
+}
+
+#ifndef _WIN32
 template <typename Out>
 void split(const std::string& s, char delim, Out result) {
   std::istringstream iss(s);
@@ -30,14 +250,11 @@ void split(const std::string& s, char delim, Out result) {
     *result++ = item;
   }
 }
+#endif
 
-// Added because debug() macro won't take a struct tm as an argument.
-std::string format_time(const struct tm& timeinfo) {
-  char buffer[64];
-  strftime(buffer, sizeof(buffer), "%Y-%m-%d %H:%M:%S", &timeinfo);
-  return std::string(buffer);
-}
+}  // namespace
 
+#ifndef _WIN32
 int external_start(int which, svalue_t* args, svalue_t* arg1, svalue_t* arg2, svalue_t* arg3) {
   std::vector<std::string> newargs_data = {std::string(external_cmd[which])};
   if (args->type == T_ARRAY) {
@@ -140,96 +357,21 @@ int external_start(int which, svalue_t* args, svalue_t* arg1, svalue_t* arg2, sv
 
   evutil_closesocket(sv[1]);
   sv[1] = -1;
-
-  evutil_socket_t childfd = sv[0];
   sv[0] = -1;
 
   debug(external_start, "external_start: Launching external command '%s %s', pid: %jd.\n",
         external_cmd[which], args->type == T_STRING ? args->u.string : "<ARRAY>", (intmax_t)pid);
 
-  std::thread([=]() {
-    int status;
-    do {
-      const int s = waitpid(pid, &status, WUNTRACED | WCONTINUED);
-      if (s == -1) {
-        debug(external_start, "external_start: waitpid() error: %s (%d).\n", strerror(errno),
-              errno);
-        return;
-      }
-      std::string res = fmt::format(FMT_STRING("external_start(): child {} status: "), pid);
-      if (WIFEXITED(status)) {
-        res += fmt::format(FMT_STRING("exited, status={}\n"), WEXITSTATUS(status));
-      } else if (WIFSIGNALED(status)) {
-        res += fmt::format(FMT_STRING("killed by signal {}\n"), WTERMSIG(status));
-      } else if (WIFSTOPPED(status)) {
-        res += fmt::format(FMT_STRING("stopped by signal {}\n"), WSTOPSIG(status));
-      } else if (WIFCONTINUED(status)) {
-        res += "continued\n";
-      }
-
-      debug(external_start, "external_start: %s\n", format_time(res).c_str());
-    } while (!WIFEXITED(status) && !WIFSIGNALED(status));
-  }).detach();
-
+  /* Reaper starts after the caller attaches a promise job (if any), so a
+   * fast child cannot post its exit code before the job exists. */
+  stash_posix_child(fd, pid);
   return fd;
 }
 #endif
 
-namespace {
-std::string quote_argument(const std::string& arg) {
-  if (arg.empty()) {
-    return "\"\"";
-  }
-  if (arg.find_first_of(" \t\n\v\"") == std::string::npos) {
-    return arg;
-  }
-  std::string res = "\"";
-  // from
-  // https://learn.microsoft.com/en-us/archive/blogs/twistylittlepassagesallalike/everyone-quotes-command-line-arguments-the-wrong-way
-  for (auto It = arg.begin();; ++It) {
-    unsigned NumberBackslashes = 0;
-
-    while (It != arg.end() && *It == '\\') {
-      ++It;
-      ++NumberBackslashes;
-    }
-
-    if (It == arg.end()) {
-      //
-      // Escape all backslashes, but let the terminating
-      // double quotation mark we add below be interpreted
-      // as a metacharacter.
-      //
-      res.append(NumberBackslashes * 2, '\\');
-      break;
-    } else if (*It == '"') {
-      //
-      // Escape all backslashes and the following
-      // double quotation mark.
-      //
-      res.append(NumberBackslashes * 2 + 1, '\\');
-      res.push_back(*It);
-    } else {
-      //
-      // Backslashes aren't special here.
-      //
-      res.append(NumberBackslashes, '\\');
-      res.push_back(*It);
-    }
-  }
-  res.push_back('"');
-  return res;
-}
-}  // namespace
-
 #ifdef _WIN32
-#include <windows.h>
-#include <fcntl.h>
-extern int socketpair_win32(SOCKET socks[2], int make_overlapped);  // in socketpair.cc
-
 int external_start(int which, svalue_t* args, svalue_t* arg1, svalue_t* arg2, svalue_t* arg3) {
   int fd;
-  pid_t ret;
 
   std::string cmd = external_cmd[which];
   // guard against long path with spaces.
@@ -315,67 +457,10 @@ int external_start(int which, svalue_t* args, svalue_t* arg1, svalue_t* arg2, sv
   debug(external_start, "external_start: Launching external command '%s', pid: %d.\n",
         cmdline.c_str(), processInfo.dwProcessId);
 
-  std::thread([=]() {
-    WaitForSingleObject(processInfo.hProcess, INFINITE);
-    DWORD exitCode = -1;
-    // Get the exit code.
-    GetExitCodeProcess(processInfo.hProcess, &exitCode);
-    debug(external_start, "external_start: pid: %d exited with %d.\n", processInfo.dwProcessId,
-          exitCode);
-    CloseHandle(processInfo.hProcess);
-    CloseHandle(processInfo.hThread);
-    evutil_closesocket(sv[0]);
-  }).detach();
-
+  stash_win32_child(fd, processInfo, sv[0]);
   return fd;
 }
 #endif
-
-namespace {
-
-/* Promise-form jobs (issue #1319): collect stdout/stderr, settle when the
- * child socket closes. Keyed by LPC socket index. */
-struct ExternalPromiseJob {
-  promise_t* prom;
-  std::string output;
-};
-
-std::unordered_map<int, ExternalPromiseJob*> g_external_jobs;
-
-void reject_with_number(promise_t* p, LPC_INT n) {
-  push_number(n);
-  promise_settle(p, sp, 1);
-  pop_stack();
-}
-
-void attach_external_job(int fd, promise_t* p) {
-  auto* job = new ExternalPromiseJob{};
-  job->prom = p;
-  g_external_jobs[fd] = job;
-}
-
-void finish_external_job(int fd, int aborted) {
-  auto it = g_external_jobs.find(fd);
-  if (it == g_external_jobs.end()) {
-    return;
-  }
-  ExternalPromiseJob* job = it->second;
-  g_external_jobs.erase(it);
-
-  if (aborted) {
-    push_constant_string("*external process aborted");
-    promise_settle(job->prom, sp, 1);
-    pop_stack();
-  } else {
-    copy_and_push_string(job->output.c_str());
-    promise_settle(job->prom, sp, 0);
-    pop_stack();
-  }
-  free_promise(job->prom);
-  delete job;
-}
-
-}  // namespace
 
 int external_promise_take_read(int fd, const char* data, int len) {
   auto it = g_external_jobs.find(fd);
@@ -395,12 +480,28 @@ int external_promise_take_read(int fd, const char* data, int len) {
   return 1;
 }
 
-void external_promise_closed(int fd, int aborted) { finish_external_job(fd, aborted); }
+void external_promise_closed(int fd, int aborted) {
+  auto it = g_external_jobs.find(fd);
+  if (it == g_external_jobs.end()) {
+    return;
+  }
+  if (aborted) {
+    it->second->aborted = true;
+  } else {
+    it->second->io_done = true;
+  }
+  try_finish_job(fd);
+}
 
 void external_cleanup() {
   while (!g_external_jobs.empty()) {
-    finish_external_job(g_external_jobs.begin()->first, /*aborted=*/1);
+    auto fd = g_external_jobs.begin()->first;
+    g_external_jobs.begin()->second->aborted = true;
+    settle_and_drop_job(fd);
   }
+  g_child_watches.clear();
+  std::lock_guard<std::mutex> const lock(g_exit_mu);
+  g_exit_notes.clear();
 }
 
 #ifdef DEBUGMALLOC_EXTENSIONS
@@ -450,7 +551,8 @@ void f_external_start() {
   int fd;
   if (promise_form) {
     /* Spawn first: Windows CreateProcess error()s, so no promise is live
-     * across that unwind. Attach the job only after we have an fd. */
+     * across that unwind. Attach the job, then start the reaper so a
+     * fast child cannot post its exit code before the job exists. */
     fd = external_start(which, arg + 1, nullptr, nullptr, nullptr);
     if (fd < 0) {
       promise_t* p = promise_alloc();
@@ -462,12 +564,16 @@ void f_external_start() {
     promise_t* p = promise_alloc();
     p->ref++; /* the job's ref; push_refed_promise takes the other */
     attach_external_job(fd, p);
+    watch_child(fd);
     pop_n_elems(num_arg);
     push_refed_promise(p);
     return;
   }
 
   fd = external_start(which, arg + 1, arg + 2, arg + 3, (num_arg == 5 ? arg + 4 : nullptr));
+  if (fd >= 0) {
+    watch_child(fd);
+  }
   pop_n_elems(num_arg - 1);
   sp->u.number = fd;
 }

--- a/src/packages/external/external.cc
+++ b/src/packages/external/external.cc
@@ -539,54 +539,39 @@ int spawn_handle_win32(ExternalHandle* h, int id) {
   }
   cmdline += fmt::to_string(fmt::join(quoted.begin(), quoted.end(), " "));
 
-  /* socks[0] is the ReadFile-capable end (see socketpair_win32). All three
-   * std handles must be sockets -- mixing a real NUL HANDLE with sockets
-   * makes CreateProcess fail. Classic uses one socket for all three. */
-  SOCKET out_sv[2];
-  SOCKET err_sv[2];
-  SOCKET in_sv[2];
-  if (socketpair_win32(out_sv, 0) != 0 || socketpair_win32(err_sv, 0) != 0 ||
-      socketpair_win32(in_sv, 0) != 0) {
+  /* Same stdio as the classic form: one socketpair, socks[0] for all three
+   * child handles. Separate stdout/stderr socketpairs do not deliver data
+   * through CreateProcess on Win32 (classic latch passed; handle latches
+   * never released). stderr is reported empty. */
+  SOCKET sv[2];
+  if (socketpair_win32(sv, 0) != 0) {
     return EESOCKET;
   }
-  if (evutil_make_socket_nonblocking(out_sv[1]) == -1 ||
-      evutil_make_socket_nonblocking(err_sv[1]) == -1) {
-    evutil_closesocket(out_sv[0]);
-    evutil_closesocket(out_sv[1]);
-    evutil_closesocket(err_sv[0]);
-    evutil_closesocket(err_sv[1]);
-    evutil_closesocket(in_sv[0]);
-    evutil_closesocket(in_sv[1]);
+  if (evutil_make_socket_nonblocking(sv[1]) == -1) {
+    evutil_closesocket(sv[0]);
+    evutil_closesocket(sv[1]);
     return EESOCKET;
   }
 
   PROCESS_INFORMATION processInfo{};
-  if (!win32_create_process(&cmdline, reinterpret_cast<HANDLE>(in_sv[0]),
-                            reinterpret_cast<HANDLE>(out_sv[0]),
-                            reinterpret_cast<HANDLE>(err_sv[0]), &processInfo)) {
-    evutil_closesocket(out_sv[0]);
-    evutil_closesocket(out_sv[1]);
-    evutil_closesocket(err_sv[0]);
-    evutil_closesocket(err_sv[1]);
-    evutil_closesocket(in_sv[0]);
-    evutil_closesocket(in_sv[1]);
+  if (!win32_create_process(&cmdline, reinterpret_cast<HANDLE>(sv[0]),
+                            reinterpret_cast<HANDLE>(sv[0]),
+                            reinterpret_cast<HANDLE>(sv[0]), &processInfo)) {
+    evutil_closesocket(sv[0]);
+    evutil_closesocket(sv[1]);
     return EESOCKET;
   }
-  evutil_closesocket(in_sv[0]);
-  evutil_closesocket(in_sv[1]);
-  evutil_closesocket(out_sv[0]);
-  evutil_closesocket(err_sv[0]);
   h->pi = processInfo;
+  h->err_eof = true;
+  arm_pipe_reader(h, id, 0, sv[1]);
 
-  arm_pipe_reader(h, id, 0, out_sv[1]);
-  arm_pipe_reader(h, id, 1, err_sv[1]);
-
-  std::thread([id, processInfo]() {
+  std::thread([id, processInfo, child_fd = sv[0]]() {
     WaitForSingleObject(processInfo.hProcess, INFINITE);
     DWORD exitCode = static_cast<DWORD>(-1);
     GetExitCodeProcess(processInfo.hProcess, &exitCode);
     CloseHandle(processInfo.hProcess);
     CloseHandle(processInfo.hThread);
+    evutil_closesocket(child_fd);
     note_child_exit(id, static_cast<LPC_INT>(exitCode));
   }).detach();
   return 0;

--- a/src/packages/external/external.cc
+++ b/src/packages/external/external.cc
@@ -1017,44 +1017,48 @@ void f_external_create() {
 }
 #endif
 
+#ifdef F_EXTERNAL_RUN
+void f_external_run() {
+  /* Latch arity first: check_valid_socket() runs a master apply that
+   * overwrites st_num_arg (same trap as f_async_read). */
+  int const num_arg = st_num_arg;
+  int const id = static_cast<int>(sp->u.number);
+  ExternalHandle* h = lookup_handle(id, /*require_owner=*/1);
+  if (h->state != HandleState::Created) {
+    error("external_run: handle has already been started.\n");
+  }
+  if (!check_valid_socket("external", -1, current_object, "N/A", -1)) {
+    st_num_arg = num_arg;
+    promise_t* p = promise_alloc();
+    reject_with_number(p, EESECURITY);
+    pop_n_elems(num_arg);
+    push_refed_promise(p);
+    return;
+  }
+  st_num_arg = num_arg;
+
+  int const rc = spawn_handle(h, id);
+  promise_t* p = promise_alloc();
+  if (rc < 0) {
+    reject_with_number(p, rc);
+    pop_n_elems(num_arg);
+    push_refed_promise(p);
+    return;
+  }
+  h->state = HandleState::Running;
+  h->prom = p;
+  p->ref++;
+  pop_n_elems(num_arg);
+  push_refed_promise(p);
+}
+#endif
+
 #ifdef F_EXTERNAL_START
 void f_external_start() {
   /* Latch arity first: check_valid_socket() runs a master apply that
    * overwrites st_num_arg (same trap as f_async_read). */
   int const num_arg = st_num_arg;
   svalue_t* arg = sp - num_arg + 1;
-
-  if (num_arg == 1) {
-    ExternalHandle* h = lookup_handle(static_cast<int>(arg[0].u.number), /*require_owner=*/1);
-    int const id = static_cast<int>(arg[0].u.number);
-    if (h->state != HandleState::Created) {
-      error("external_start: handle has already been started.\n");
-    }
-    if (!check_valid_socket("external", -1, current_object, "N/A", -1)) {
-      st_num_arg = num_arg;
-      promise_t* p = promise_alloc();
-      reject_with_number(p, EESECURITY);
-      pop_n_elems(num_arg);
-      push_refed_promise(p);
-      return;
-    }
-    st_num_arg = num_arg;
-
-    int const rc = spawn_handle(h, id);
-    promise_t* p = promise_alloc();
-    if (rc < 0) {
-      reject_with_number(p, rc);
-      pop_n_elems(num_arg);
-      push_refed_promise(p);
-      return;
-    }
-    h->state = HandleState::Running;
-    h->prom = p;
-    p->ref++;
-    pop_n_elems(num_arg);
-    push_refed_promise(p);
-    return;
-  }
 
   if (num_arg == 2) {
     /* Issue #1319 omit-callback form: same efun, no callbacks, promise of
@@ -1094,9 +1098,9 @@ void f_external_start() {
 
   if (num_arg != 4 && num_arg != 5) {
     error(
-        "external_start: omit the callbacks for the promise form, pass a "
-        "handle from external_create(), or pass the classic read/write "
-        "callbacks.\n");
+        "external_start: omit the callbacks for the promise form, or pass "
+        "the classic read/write callbacks. Use external_run() for a handle "
+        "from external_create().\n");
   }
 
   if (!check_valid_socket("external", -1, current_object, "N/A", -1)) {

--- a/src/packages/external/external.cc
+++ b/src/packages/external/external.cc
@@ -56,6 +56,9 @@ struct ExternalHandle {
   std::vector<std::string> args;
   HandleState state = HandleState::Created;
   promise_t* prom = nullptr;
+  /* Omit-callback form: not visible to LPC. Fulfill with
+   * ({ stdout+stderr, exit_code }) and free the slot. */
+  bool ephemeral = false;
   std::string out;
   std::string err;
   LPC_INT exit_code = -1;
@@ -189,6 +192,41 @@ void free_pipe_events(ExternalHandle* h) {
   close_pipe_fd(&h->err_fd);
 }
 
+void fulfill_handle_promise(int id) {
+  ExternalHandle* h = g_handles[id - 1];
+  if (!h->prom) {
+    if (h->ephemeral) {
+      delete h;
+      g_handles[id - 1] = nullptr;
+    }
+    return;
+  }
+  promise_t* p = h->prom;
+  h->prom = nullptr;
+  if (h->ephemeral) {
+    std::string output = h->out;
+    if (!h->err.empty()) {
+      output += h->err;
+    }
+    array_t* arr = allocate_array(2);
+    arr->item[0].type = T_STRING;
+    arr->item[0].subtype = STRING_MALLOC;
+    arr->item[0].u.string = string_copy(output.c_str(), "external_promise");
+    arr->item[1].u.number = h->exit_code;
+    push_refed_array(arr);
+    promise_settle(p, sp, 0);
+    pop_stack();
+    free_promise(p);
+    delete h;
+    g_handles[id - 1] = nullptr;
+    return;
+  }
+  push_number(0);
+  promise_settle(p, sp, 0);
+  pop_stack();
+  free_promise(p);
+}
+
 void try_finish_handle(int id) {
   if (id < 1 || id > static_cast<int>(g_handles.size()) || !g_handles[id - 1]) {
     return;
@@ -202,13 +240,7 @@ void try_finish_handle(int id) {
   }
   h->state = HandleState::Done;
   free_pipe_events(h);
-  if (h->prom) {
-    push_number(0);
-    promise_settle(h->prom, sp, 0);
-    pop_stack();
-    free_promise(h->prom);
-    h->prom = nullptr;
-  }
+  fulfill_handle_promise(id);
 }
 
 void abort_handle(int id, int kill_child) {
@@ -537,6 +569,23 @@ int spawn_handle(ExternalHandle* h, int id) {
 #endif
 }
 
+/* Spawn a Created handle. On failure the handle is deleted and the
+ * returned promise is already rejected (caller just pushes it). */
+promise_t* start_created_handle(ExternalHandle* h, int id) {
+  promise_t* p = promise_alloc();
+  int const rc = spawn_handle(h, id);
+  if (rc < 0) {
+    g_handles[id - 1] = nullptr;
+    delete h;
+    reject_with_number(p, rc);
+    return p;
+  }
+  h->state = HandleState::Running;
+  h->prom = p;
+  p->ref++;
+  return p;
+}
+
 #ifndef _WIN32
 template <typename Out>
 void split(const std::string& s, char delim, Out result) {
@@ -814,6 +863,8 @@ void f_external_create() {
 
 #ifdef F_EXTERNAL_START
 void f_external_start() {
+  /* Latch arity first: check_valid_socket() runs a master apply that
+   * overwrites st_num_arg (same trap as f_async_read). */
   int const num_arg = st_num_arg;
   svalue_t* arg = sp - num_arg + 1;
 
@@ -849,10 +900,46 @@ void f_external_start() {
     return;
   }
 
+  if (num_arg == 2) {
+    /* Issue #1319 omit-callback form: same efun, no callbacks, promise of
+     * ({ output, exit_code }). Classic 4/5-arg path below is unchanged. */
+    if (!check_valid_socket("external", -1, current_object, "N/A", -1)) {
+      st_num_arg = num_arg;
+      promise_t* p = promise_alloc();
+      reject_with_number(p, EESECURITY);
+      pop_n_elems(num_arg);
+      push_refed_promise(p);
+      return;
+    }
+    st_num_arg = num_arg;
+
+    auto which = arg[0].u.number;
+    if (--which < 0 || which > (g_num_external_cmds - 1) || !external_cmd[which]) {
+      error("Bad argument 1 to external_start()\n");
+    }
+
+    std::vector<std::string> extra;
+    parse_cmd_args(arg + 1, &extra);
+
+    int const id = alloc_handle_id();
+    auto* h = new ExternalHandle{};
+    h->owner = current_object;
+    h->cmd_index = static_cast<int>(which);
+    h->args = std::move(extra);
+    h->ephemeral = true;
+    g_handles[id - 1] = h;
+
+    promise_t* p = start_created_handle(h, id);
+    pop_n_elems(num_arg);
+    push_refed_promise(p);
+    return;
+  }
+
   if (num_arg != 4 && num_arg != 5) {
     error(
-        "external_start: pass a handle from external_create(), or the classic "
-        "read/write callbacks.\n");
+        "external_start: omit the callbacks for the promise form, pass a "
+        "handle from external_create(), or pass the classic read/write "
+        "callbacks.\n");
   }
 
   if (!check_valid_socket("external", -1, current_object, "N/A", -1)) {

--- a/src/packages/external/external.cc
+++ b/src/packages/external/external.cc
@@ -34,6 +34,7 @@ extern int socketpair_win32(SOCKET socks[2], int make_overlapped);  // in socket
 #include <fcntl.h>
 #include <sstream>
 #include <spawn.h>
+#include <sys/socket.h>
 #include <sys/wait.h>
 #include <unistd.h>
 #endif
@@ -67,10 +68,15 @@ struct ExternalHandle {
   bool status_done = false;
   evutil_socket_t out_fd = -1;
   evutil_socket_t err_fd = -1;
+  evutil_socket_t in_fd = -1;
   struct event* ev_out = nullptr;
   struct event* ev_err = nullptr;
+  struct event* ev_in = nullptr;
   PipeWatch* out_watch = nullptr;
   PipeWatch* err_watch = nullptr;
+  std::string in_buf;
+  bool in_closed = false;
+  bool close_stdin_after_flush = false;
 #ifndef _WIN32
   pid_t pid = -1;
 #else
@@ -184,10 +190,19 @@ void free_pipe_events(ExternalHandle* h) {
     event_free(h->ev_err);
     h->ev_err = nullptr;
   }
+  if (h->ev_in) {
+    event_free(h->ev_in);
+    h->ev_in = nullptr;
+  }
   delete h->out_watch;
   h->out_watch = nullptr;
   delete h->err_watch;
   h->err_watch = nullptr;
+  if (h->in_fd >= 0 && h->in_fd != h->out_fd) {
+    close_pipe_fd(&h->in_fd);
+  } else {
+    h->in_fd = -1;
+  }
   close_pipe_fd(&h->out_fd);
   close_pipe_fd(&h->err_fd);
 }
@@ -359,6 +374,107 @@ void arm_pipe_reader(ExternalHandle* h, int id, int stream, evutil_socket_t fd) 
   event_add(ev, nullptr);
 }
 
+void close_stdin_write(ExternalHandle* h) {
+  if (h->in_closed) {
+    return;
+  }
+  if (h->ev_in) {
+    event_free(h->ev_in);
+    h->ev_in = nullptr;
+  }
+  if (h->in_fd >= 0) {
+    if (h->in_fd == h->out_fd) {
+#ifdef _WIN32
+      shutdown(h->in_fd, SD_SEND);
+#else
+      shutdown(h->in_fd, SHUT_WR);
+#endif
+      h->in_fd = -1;
+    } else {
+      close_pipe_fd(&h->in_fd);
+    }
+  }
+  h->in_closed = true;
+  h->in_buf.clear();
+}
+
+void arm_stdin_writer(ExternalHandle* h, int id);
+void flush_stdin(ExternalHandle* h, int id);
+
+void on_handle_stdin_writable(evutil_socket_t /*fd*/, short /*what*/, void* arg) {
+  int const id = static_cast<int>(reinterpret_cast<intptr_t>(arg));
+  if (id < 1 || id > static_cast<int>(g_handles.size()) || !g_handles[id - 1]) {
+    return;
+  }
+  flush_stdin(g_handles[id - 1], id);
+}
+
+void arm_stdin_writer(ExternalHandle* h, int id) {
+  if (h->in_fd < 0 || h->in_closed) {
+    return;
+  }
+  if (!h->ev_in) {
+    h->ev_in = event_new(g_event_base, h->in_fd, EV_WRITE | EV_PERSIST, on_handle_stdin_writable,
+                         reinterpret_cast<void*>(static_cast<intptr_t>(id)));
+  }
+  event_add(h->ev_in, nullptr);
+}
+
+void flush_stdin(ExternalHandle* h, int id) {
+  if (h->in_closed || h->in_fd < 0) {
+    return;
+  }
+  while (!h->in_buf.empty()) {
+    size_t chunk = std::min(h->in_buf.size(), static_cast<size_t>(kPipeBuf));
+#ifdef _WIN32
+    int n = send(h->in_fd, h->in_buf.data(), static_cast<int>(chunk), 0);
+#else
+    int n = static_cast<int>(write(h->in_fd, h->in_buf.data(), chunk));
+#endif
+    if (n > 0) {
+      h->in_buf.erase(0, static_cast<size_t>(n));
+      continue;
+    }
+    if (n < 0) {
+#ifdef _WIN32
+      if (evutil_socket_geterror(h->in_fd) == WSAEWOULDBLOCK) {
+        arm_stdin_writer(h, id);
+        return;
+      }
+#else
+      if (errno == EINTR) {
+        continue;
+      }
+      if (errno == EAGAIN || errno == EWOULDBLOCK) {
+        arm_stdin_writer(h, id);
+        return;
+      }
+#endif
+    }
+    close_stdin_write(h);
+    return;
+  }
+  if (h->ev_in) {
+    event_del(h->ev_in);
+  }
+  if (h->close_stdin_after_flush) {
+    close_stdin_write(h);
+  }
+}
+
+void queue_stdin(ExternalHandle* h, int id, const char* data, size_t len) {
+  if (h->in_closed) {
+    error("external_write: stdin is closed.\n");
+  }
+  if (h->state == HandleState::Done) {
+    error("external_write: process has already exited.\n");
+  }
+  append_capped(h->in_buf, data, len);
+  if (h->state == HandleState::Running) {
+    flush_stdin(h, id);
+  }
+}
+
 #ifndef _WIN32
 /* Shared by the classic callback form and the handle/promise form.
  * POSIX_SPAWN_USEVFORK (glibc) is the fast path: vfork/clone instead of
@@ -409,6 +525,21 @@ int open_spawn_pipe(int p[2]) {
   return 0;
 }
 
+/* Parent write end is nonblocking (EV_WRITE). Child read end stays blocking. */
+int open_stdin_pipe(int p[2]) {
+  p[0] = p[1] = -1;
+  if (pipe(p) != 0) {
+    return -1;
+  }
+  fcntl(p[0], F_SETFD, FD_CLOEXEC);
+  fcntl(p[1], F_SETFD, FD_CLOEXEC);
+  if (evutil_make_socket_nonblocking(p[1]) == -1) {
+    close_pipe_pair(p);
+    return -1;
+  }
+  return 0;
+}
+
 int spawn_handle_posix(ExternalHandle* h, int id) {
   std::vector<std::string> argv_data = {std::string(external_cmd[h->cmd_index])};
   argv_data.insert(argv_data.end(), h->args.begin(), h->args.end());
@@ -420,9 +551,11 @@ int spawn_handle_posix(ExternalHandle* h, int id) {
 
   int outp[2] = {-1, -1};
   int errp[2] = {-1, -1};
-  if (open_spawn_pipe(outp) != 0 || open_spawn_pipe(errp) != 0) {
+  int inp[2] = {-1, -1};
+  if (open_spawn_pipe(outp) != 0 || open_spawn_pipe(errp) != 0 || open_stdin_pipe(inp) != 0) {
     close_pipe_pair(outp);
     close_pipe_pair(errp);
+    close_pipe_pair(inp);
     return EESOCKET;
   }
 
@@ -431,17 +564,19 @@ int spawn_handle_posix(ExternalHandle* h, int id) {
   if (ret != 0) {
     close_pipe_pair(outp);
     close_pipe_pair(errp);
+    close_pipe_pair(inp);
     return EESOCKET;
   }
   DEFER { posix_spawn_file_actions_destroy(&file_actions); };
 
-  /* CLOEXEC drops the parent read ends at exec; only dup2 + stdin null. */
+  /* CLOEXEC drops the parent ends at exec; dup2 stdin/stdout/stderr. */
   ret = posix_spawn_file_actions_adddup2(&file_actions, outp[1], 1) ||
         posix_spawn_file_actions_adddup2(&file_actions, errp[1], 2) ||
-        posix_spawn_file_actions_addopen(&file_actions, 0, "/dev/null", O_RDONLY, 0);
+        posix_spawn_file_actions_adddup2(&file_actions, inp[0], 0);
   if (ret != 0) {
     close_pipe_pair(outp);
     close_pipe_pair(errp);
+    close_pipe_pair(inp);
     return EESOCKET;
   }
 
@@ -452,14 +587,18 @@ int spawn_handle_posix(ExternalHandle* h, int id) {
     debug(external_start, "external_start: posix_spawn() error: %s\n", strerror(ret));
     close_pipe_pair(outp);
     close_pipe_pair(errp);
+    close_pipe_pair(inp);
     return EESOCKET;
   }
   close(outp[1]);
   close(errp[1]);
+  close(inp[0]);
   h->pid = pid;
+  h->in_fd = inp[1];
 
   arm_pipe_reader(h, id, 0, outp[0]);
   arm_pipe_reader(h, id, 1, errp[0]);
+  flush_stdin(h, id);
 
   std::thread([id, pid]() {
     int status = 0;
@@ -564,6 +703,8 @@ int spawn_handle_win32(ExternalHandle* h, int id) {
   h->pi = processInfo;
   h->err_eof = true;
   arm_pipe_reader(h, id, 0, sv[1]);
+  h->in_fd = sv[1];
+  flush_stdin(h, id);
 
   std::thread([id, processInfo, child_fd = sv[0]]() {
     WaitForSingleObject(processInfo.hProcess, INFINITE);
@@ -915,9 +1056,10 @@ void f_external_start() {
     return;
   }
 
-  if (num_arg == 2) {
+  if (num_arg == 2 || (num_arg == 3 && arg[2].type == T_STRING)) {
     /* Issue #1319 omit-callback form: same efun, no callbacks, promise of
-     * ({ stdout, stderr, exit_code }). Classic 4/5-arg path below is unchanged. */
+     * ({ stdout, stderr, exit_code }). Optional third string is stdin
+     * (written then closed). Classic 4/5-arg path below is unchanged. */
     if (!check_valid_socket("external", -1, current_object, "N/A", -1)) {
       st_num_arg = num_arg;
       promise_t* p = promise_alloc();
@@ -942,6 +1084,10 @@ void f_external_start() {
     h->cmd_index = static_cast<int>(which);
     h->args = std::move(extra);
     h->ephemeral = true;
+    if (num_arg == 3) {
+      append_capped(h->in_buf, arg[2].u.string, SVALUE_STRLEN(arg + 2));
+      h->close_stdin_after_flush = true;
+    }
     g_handles[id - 1] = h;
 
     promise_t* p = start_created_handle(h, id);
@@ -953,8 +1099,8 @@ void f_external_start() {
   if (num_arg != 4 && num_arg != 5) {
     error(
         "external_start: omit the callbacks for the promise form, pass a "
-        "handle from external_create(), or pass the classic read/write "
-        "callbacks.\n");
+        "handle from external_create(), pass stdin as a third string, or "
+        "pass the classic read/write callbacks.\n");
   }
 
   if (!check_valid_socket("external", -1, current_object, "N/A", -1)) {
@@ -1006,6 +1152,29 @@ void f_external_close() {
   int const id = static_cast<int>(sp->u.number);
   lookup_handle(id, /*require_owner=*/1);
   destroy_handle(id, /*kill_child=*/1);
+  pop_stack();
+}
+#endif
+
+#ifdef F_EXTERNAL_WRITE
+void f_external_write() {
+  int const num_arg = st_num_arg;
+  svalue_t* arg = sp - num_arg + 1;
+  int const id = static_cast<int>(arg[0].u.number);
+  ExternalHandle* h = lookup_handle(id, /*require_owner=*/1);
+  queue_stdin(h, id, arg[1].u.string, SVALUE_STRLEN(arg + 1));
+  pop_n_elems(num_arg);
+}
+#endif
+
+#ifdef F_EXTERNAL_CLOSE_STDIN
+void f_external_close_stdin() {
+  int const id = static_cast<int>(sp->u.number);
+  ExternalHandle* h = lookup_handle(id, /*require_owner=*/1);
+  h->close_stdin_after_flush = true;
+  if (h->state == HandleState::Running) {
+    flush_stdin(h, id);
+  }
   pop_stack();
 }
 #endif

--- a/src/packages/external/external.cc
+++ b/src/packages/external/external.cc
@@ -1,16 +1,19 @@
 #include "base/package_api.h"
 
+#include <algorithm>
 #include <cerrno>
 #include <cstring>
 #include <cstdlib>  // for exit
 #include <thread>
 #include <string>
+#include <unordered_map>
 #include <fmt/format.h>
 #include <fmt/ranges.h>
 
 #include <event2/event.h>
 
 #include "include/socket_err.h"
+#include "packages/external/external.h"
 #include "packages/sockets/socket_efuns.h"
 
 #ifndef _WIN32
@@ -328,20 +331,140 @@ int external_start(int which, svalue_t* args, svalue_t* arg1, svalue_t* arg2, sv
 }
 #endif
 
+namespace {
+
+/* Promise-form jobs (issue #1319): collect stdout/stderr, settle when the
+ * child socket closes. Keyed by LPC socket index. */
+struct ExternalPromiseJob {
+  promise_t* prom;
+  std::string output;
+};
+
+std::unordered_map<int, ExternalPromiseJob*> g_external_jobs;
+
+void reject_with_number(promise_t* p, LPC_INT n) {
+  push_number(n);
+  promise_settle(p, sp, 1);
+  pop_stack();
+}
+
+void attach_external_job(int fd, promise_t* p) {
+  auto* job = new ExternalPromiseJob{};
+  job->prom = p;
+  g_external_jobs[fd] = job;
+}
+
+void finish_external_job(int fd, int aborted) {
+  auto it = g_external_jobs.find(fd);
+  if (it == g_external_jobs.end()) {
+    return;
+  }
+  ExternalPromiseJob* job = it->second;
+  g_external_jobs.erase(it);
+
+  if (aborted) {
+    push_constant_string("*external process aborted");
+    promise_settle(job->prom, sp, 1);
+    pop_stack();
+  } else {
+    copy_and_push_string(job->output.c_str());
+    promise_settle(job->prom, sp, 0);
+    pop_stack();
+  }
+  free_promise(job->prom);
+  delete job;
+}
+
+}  // namespace
+
+int external_promise_take_read(int fd, const char* data, int len) {
+  auto it = g_external_jobs.find(fd);
+  if (it == g_external_jobs.end()) {
+    return 0;
+  }
+  if (data && len > 0) {
+    auto max_string_length = CONFIG_INT(__MAX_STRING_LENGTH__);
+    auto& out = it->second->output;
+    size_t room = (max_string_length > 0 && static_cast<size_t>(max_string_length) > out.size())
+                      ? static_cast<size_t>(max_string_length) - out.size()
+                      : 0;
+    if (room > 0) {
+      out.append(data, std::min(static_cast<size_t>(len), room));
+    }
+  }
+  return 1;
+}
+
+void external_promise_closed(int fd, int aborted) { finish_external_job(fd, aborted); }
+
+void external_cleanup() {
+  while (!g_external_jobs.empty()) {
+    finish_external_job(g_external_jobs.begin()->first, /*aborted=*/1);
+  }
+}
+
+#ifdef DEBUGMALLOC_EXTENSIONS
+void mark_external() {
+  for (auto& entry : g_external_jobs) {
+    if (entry.second->prom) {
+      entry.second->prom->extra_ref++;
+    }
+  }
+}
+#endif
+
 #ifdef F_EXTERNAL_START
 void f_external_start() {
-  int fd, num_arg = st_num_arg;
+  /* Latch arity first: check_valid_socket() runs a master apply that
+   * overwrites st_num_arg (same trap as f_async_read / f_async_db_exec). */
+  int const num_arg = st_num_arg;
   svalue_t* arg = sp - num_arg + 1;
+  int const promise_form = (num_arg == 2);
+
+  if (num_arg != 2 && num_arg < 4) {
+    error(
+        "external_start: promise form takes two arguments; classic form needs "
+        "read and write callbacks.\n");
+  }
 
   if (!check_valid_socket("external", -1, current_object, "N/A", -1)) {
+    st_num_arg = num_arg;
+    if (promise_form) {
+      promise_t* p = promise_alloc();
+      reject_with_number(p, EESECURITY);
+      pop_n_elems(num_arg);
+      push_refed_promise(p);
+      return;
+    }
     pop_n_elems(num_arg - 1);
     sp->u.number = EESECURITY;
     return;
   }
+  st_num_arg = num_arg;
 
   auto which = arg[0].u.number;
   if (--which < 0 || which > (g_num_external_cmds - 1) || !external_cmd[which]) {
     error("Bad argument 1 to external_start()\n");
+  }
+
+  int fd;
+  if (promise_form) {
+    /* Spawn first: Windows CreateProcess error()s, so no promise is live
+     * across that unwind. Attach the job only after we have an fd. */
+    fd = external_start(which, arg + 1, nullptr, nullptr, nullptr);
+    if (fd < 0) {
+      promise_t* p = promise_alloc();
+      reject_with_number(p, fd);
+      pop_n_elems(num_arg);
+      push_refed_promise(p);
+      return;
+    }
+    promise_t* p = promise_alloc();
+    p->ref++; /* the job's ref; push_refed_promise takes the other */
+    attach_external_job(fd, p);
+    pop_n_elems(num_arg);
+    push_refed_promise(p);
+    return;
   }
 
   fd = external_start(which, arg + 1, arg + 2, arg + 3, (num_arg == 5 ? arg + 4 : nullptr));

--- a/src/packages/external/external.cc
+++ b/src/packages/external/external.cc
@@ -4,12 +4,12 @@
 #include <cerrno>
 #include <chrono>
 #include <cinttypes>
+#include <cstdint>
 #include <cstring>
 #include <cstdlib>  // for exit
 #include <mutex>
 #include <string>
 #include <thread>
-#include <unordered_map>
 #include <vector>
 #include <fmt/format.h>
 #include <fmt/ranges.h>
@@ -17,51 +17,69 @@
 #include <event2/event.h>
 
 #include "backend.h"
+#include "base/internal/strutils.h"
 #include "include/socket_err.h"
 #include "packages/external/external.h"
 #include "packages/sockets/socket_efuns.h"
 
 #ifdef _WIN32
+#define WIN32_LEAN_AND_MEAN
 #include <windows.h>
 #include <fcntl.h>
 extern int socketpair_win32(SOCKET socks[2], int make_overlapped);  // in socketpair.cc
 #endif
 
 #ifndef _WIN32
+#include <csignal>
+#include <fcntl.h>
 #include <sstream>
 #include <spawn.h>
 #include <sys/wait.h>
+#include <unistd.h>
 #endif
 
 namespace {
 
-/* Promise-form jobs (issue #1319): collect stdout/stderr, then settle when
- * BOTH the child socket has closed and waitpid/GetExitCode has reported
- * the return code. Keyed by LPC socket index. */
-struct ExternalPromiseJob {
-  promise_t* prom = nullptr;
-  std::string output;
-  LPC_INT exit_code = 0;
-  bool io_done = false;
-  bool status_done = false;
-  bool aborted = false;
+constexpr int kMaxHandles = 1024;
+constexpr int kPipeBuf = 4096;
+
+enum class HandleState : uint8_t { Created, Running, Done };
+
+struct PipeWatch {
+  int handle;
+  int stream; /* 0 = stdout, 1 = stderr */
 };
 
-struct ChildWatch {
-#ifdef _WIN32
-  PROCESS_INFORMATION pi{};
-  SOCKET child_sock = static_cast<SOCKET>(INVALID_SOCKET);
-#else
+struct ExternalHandle {
+  object_t* owner = nullptr;
+  int cmd_index = -1; /* 0-based */
+  std::vector<std::string> args;
+  HandleState state = HandleState::Created;
+  promise_t* prom = nullptr;
+  std::string out;
+  std::string err;
+  LPC_INT exit_code = -1;
+  bool out_eof = false;
+  bool err_eof = false;
+  bool status_done = false;
+  evutil_socket_t out_fd = -1;
+  evutil_socket_t err_fd = -1;
+  struct event* ev_out = nullptr;
+  struct event* ev_err = nullptr;
+  PipeWatch* out_watch = nullptr;
+  PipeWatch* err_watch = nullptr;
+#ifndef _WIN32
   pid_t pid = -1;
+#else
+  PROCESS_INFORMATION pi{};
 #endif
 };
 
-std::unordered_map<int, ExternalPromiseJob*> g_external_jobs;
-std::unordered_map<int, ChildWatch> g_child_watches;
+std::vector<ExternalHandle*> g_handles; /* handle id = index + 1 */
 
 std::mutex g_exit_mu;
 struct ChildExitNote {
-  int fd;
+  int handle;
   LPC_INT code;
 };
 std::vector<ChildExitNote> g_exit_notes;
@@ -72,47 +90,161 @@ void reject_with_number(promise_t* p, LPC_INT n) {
   pop_stack();
 }
 
-void settle_and_drop_job(int fd) {
-  auto it = g_external_jobs.find(fd);
-  if (it == g_external_jobs.end()) {
+void append_capped(std::string& dest, const char* data, size_t len) {
+  if (!data || len == 0) {
     return;
   }
-  ExternalPromiseJob* job = it->second;
-  g_external_jobs.erase(it);
+  auto max_string_length = CONFIG_INT(__MAX_STRING_LENGTH__);
+  size_t room = (max_string_length > 0 && static_cast<size_t>(max_string_length) > dest.size())
+                    ? static_cast<size_t>(max_string_length) - dest.size()
+                    : 0;
+  if (room > 0) {
+    dest.append(data, std::min(len, room));
+  }
+}
 
-  if (job->aborted) {
-    push_constant_string("*external process aborted");
-    promise_settle(job->prom, sp, 1);
-    pop_stack();
+ExternalHandle* lookup_handle(int id, int require_owner) {
+  if (id < 1 || id > static_cast<int>(g_handles.size()) || !g_handles[id - 1]) {
+    error("Bad argument 1 to external efun: invalid handle.\n");
+  }
+  ExternalHandle* h = g_handles[id - 1];
+  if (require_owner && h->owner != current_object) {
+    error("Bad argument 1 to external efun: handle is not owned by this object.\n");
+  }
+  return h;
+}
+
+int alloc_handle_id() {
+  for (size_t i = 0; i < g_handles.size(); i++) {
+    if (!g_handles[i]) {
+      return static_cast<int>(i + 1);
+    }
+  }
+  if (static_cast<int>(g_handles.size()) >= kMaxHandles) {
+    error("external_create: too many handles.\n");
+  }
+  g_handles.push_back(nullptr);
+  return static_cast<int>(g_handles.size());
+}
+
+void parse_cmd_args(svalue_t* args, std::vector<std::string>* extra) {
+  extra->clear();
+  if (args->type == T_ARRAY) {
+    for (int i = 0; i < args->u.arr->size; i++) {
+      auto item = args->u.arr->item[i];
+      if (item.type != T_STRING) {
+        error("Bad argument list item %d to external efun\n", i);
+      }
+      extra->emplace_back(item.u.string);
+    }
   } else {
-    array_t* arr = allocate_array(2);
-    arr->item[0].type = T_STRING;
-    arr->item[0].subtype = STRING_MALLOC;
-    arr->item[0].u.string = string_copy(job->output.c_str(), "external_promise");
-    arr->item[1].u.number = job->exit_code;
-    push_refed_array(arr);
-    promise_settle(job->prom, sp, 0);
-    pop_stack();
+#ifndef _WIN32
+    std::istringstream iss(args->u.string);
+    std::string item;
+    while (std::getline(iss, item, ' ')) {
+      if (!item.empty()) {
+        extra->push_back(item);
+      }
+    }
+#else
+    extra->emplace_back(args->u.string);
+#endif
   }
-  free_promise(job->prom);
-  delete job;
 }
 
-void try_finish_job(int fd) {
-  auto it = g_external_jobs.find(fd);
-  if (it == g_external_jobs.end()) {
+int validate_cmd_index(LPC_INT which) {
+  int idx = static_cast<int>(which) - 1;
+  if (idx < 0 || idx > (g_num_external_cmds - 1) || !external_cmd[idx]) {
+    error("Bad argument 1 to external efun: unconfigured command.\n");
+  }
+  return idx;
+}
+
+void close_pipe_fd(evutil_socket_t* fd) {
+  if (*fd < 0) {
     return;
   }
-  ExternalPromiseJob* job = it->second;
-  if (job->aborted || (job->io_done && job->status_done)) {
-    settle_and_drop_job(fd);
+#ifdef _WIN32
+  evutil_closesocket(*fd);
+#else
+  close(*fd);
+#endif
+  *fd = -1;
+}
+
+void free_pipe_events(ExternalHandle* h) {
+  if (h->ev_out) {
+    event_free(h->ev_out);
+    h->ev_out = nullptr;
+  }
+  if (h->ev_err) {
+    event_free(h->ev_err);
+    h->ev_err = nullptr;
+  }
+  delete h->out_watch;
+  h->out_watch = nullptr;
+  delete h->err_watch;
+  h->err_watch = nullptr;
+  close_pipe_fd(&h->out_fd);
+  close_pipe_fd(&h->err_fd);
+}
+
+void try_finish_handle(int id) {
+  if (id < 1 || id > static_cast<int>(g_handles.size()) || !g_handles[id - 1]) {
+    return;
+  }
+  ExternalHandle* h = g_handles[id - 1];
+  if (h->state != HandleState::Running) {
+    return;
+  }
+  if (!h->out_eof || !h->err_eof || !h->status_done) {
+    return;
+  }
+  h->state = HandleState::Done;
+  free_pipe_events(h);
+  if (h->prom) {
+    push_number(0);
+    promise_settle(h->prom, sp, 0);
+    pop_stack();
+    free_promise(h->prom);
+    h->prom = nullptr;
   }
 }
 
-void attach_external_job(int fd, promise_t* p) {
-  auto* job = new ExternalPromiseJob{};
-  job->prom = p;
-  g_external_jobs[fd] = job;
+void abort_handle(int id, int kill_child) {
+  if (id < 1 || id > static_cast<int>(g_handles.size()) || !g_handles[id - 1]) {
+    return;
+  }
+  ExternalHandle* h = g_handles[id - 1];
+  if (h->state == HandleState::Running && kill_child) {
+#ifndef _WIN32
+    if (h->pid > 0) {
+      kill(h->pid, SIGTERM);
+    }
+#else
+    if (h->pi.hProcess) {
+      TerminateProcess(h->pi.hProcess, 1);
+    }
+#endif
+  }
+  free_pipe_events(h);
+  if (h->prom) {
+    push_constant_string("*external process aborted");
+    promise_settle(h->prom, sp, 1);
+    pop_stack();
+    free_promise(h->prom);
+    h->prom = nullptr;
+  }
+  h->state = HandleState::Done;
+}
+
+void destroy_handle(int id, int kill_child) {
+  if (id < 1 || id > static_cast<int>(g_handles.size()) || !g_handles[id - 1]) {
+    return;
+  }
+  abort_handle(id, kill_child);
+  delete g_handles[id - 1];
+  g_handles[id - 1] = nullptr;
 }
 
 void drain_child_exits() {
@@ -122,92 +254,181 @@ void drain_child_exits() {
     notes.swap(g_exit_notes);
   }
   for (auto& note : notes) {
-    auto it = g_external_jobs.find(note.fd);
-    if (it == g_external_jobs.end()) {
+    if (note.handle < 1 || note.handle > static_cast<int>(g_handles.size()) ||
+        !g_handles[note.handle - 1]) {
       continue;
     }
-    it->second->exit_code = note.code;
-    it->second->status_done = true;
-    try_finish_job(note.fd);
+    ExternalHandle* h = g_handles[note.handle - 1];
+    h->exit_code = note.code;
+    h->status_done = true;
+    try_finish_handle(note.handle);
   }
 }
 
-/* Called from the waitpid / WaitForSingleObject thread. Must not touch
- * LPC; the wall-time event runs drain_child_exits() on the main loop. */
-void note_child_exit(int fd, LPC_INT code) {
+void note_child_exit(int handle, LPC_INT code) {
   {
     std::lock_guard<std::mutex> const lock(g_exit_mu);
-    g_exit_notes.push_back(ChildExitNote{fd, code});
+    g_exit_notes.push_back(ChildExitNote{handle, code});
   }
-  add_walltime_event(std::chrono::milliseconds(0), TickEvent::callback_type([] { drain_child_exits(); }));
+  add_walltime_event(std::chrono::milliseconds(0),
+                     TickEvent::callback_type([] { drain_child_exits(); }));
 }
 
-#ifndef _WIN32
-void stash_posix_child(int fd, pid_t pid) { g_child_watches[fd] = ChildWatch{pid}; }
-#else
-void stash_win32_child(int fd, PROCESS_INFORMATION pi, SOCKET child_sock) {
-  ChildWatch w;
-  w.pi = pi;
-  w.child_sock = child_sock;
-  g_child_watches[fd] = w;
-}
-#endif
-
-void watch_child(int fd) {
-  auto it = g_child_watches.find(fd);
-  if (it == g_child_watches.end()) {
+void on_handle_pipe_read(evutil_socket_t fd, short /*what*/, void* arg) {
+  auto* watch = static_cast<PipeWatch*>(arg);
+  int const id = watch->handle;
+  if (id < 1 || id > static_cast<int>(g_handles.size()) || !g_handles[id - 1]) {
     return;
   }
-  ChildWatch w = it->second;
-  g_child_watches.erase(it);
+  ExternalHandle* h = g_handles[id - 1];
+  char buf[kPipeBuf];
+#ifdef _WIN32
+  int cc = recv(fd, buf, sizeof(buf) - 1, 0);
+#else
+  int cc = static_cast<int>(read(fd, buf, sizeof(buf) - 1));
+#endif
+  if (cc > 0) {
+    buf[cc] = '\0';
+    auto res = u8_sanitize(buf);
+    append_capped(watch->stream == 0 ? h->out : h->err, res.c_str(), res.size());
+    return;
+  }
+  if (cc < 0) {
+#ifdef _WIN32
+    int err = evutil_socket_geterror(fd);
+    if (err == WSAEWOULDBLOCK) {
+      return;
+    }
+#else
+    if (errno == EINTR || errno == EAGAIN || errno == EWOULDBLOCK) {
+      return;
+    }
+#endif
+  }
+  if (watch->stream == 0) {
+    h->out_eof = true;
+  } else {
+    h->err_eof = true;
+  }
+  try_finish_handle(id);
+}
+
+void arm_pipe_reader(ExternalHandle* h, int id, int stream, evutil_socket_t fd) {
+  auto* watch = new PipeWatch{id, stream};
+  struct event* ev =
+      event_new(g_event_base, fd, EV_READ | EV_PERSIST, on_handle_pipe_read, watch);
+  if (stream == 0) {
+    h->out_watch = watch;
+    h->ev_out = ev;
+    h->out_fd = fd;
+  } else {
+    h->err_watch = watch;
+    h->ev_err = ev;
+    h->err_fd = fd;
+  }
+  event_add(ev, nullptr);
+}
 
 #ifndef _WIN32
-  pid_t const pid = w.pid;
-  std::thread([=]() {
+int spawn_handle_posix(ExternalHandle* h, int id) {
+  std::vector<std::string> argv_data = {std::string(external_cmd[h->cmd_index])};
+  argv_data.insert(argv_data.end(), h->args.begin(), h->args.end());
+  std::vector<char*> argv;
+  for (auto& a : argv_data) {
+    argv.push_back(a.data());
+  }
+  argv.push_back(nullptr);
+
+  int outp[2] = {-1, -1};
+  int errp[2] = {-1, -1};
+  if (pipe(outp) != 0 || pipe(errp) != 0) {
+    if (outp[0] >= 0) {
+      close(outp[0]);
+    }
+    if (outp[1] >= 0) {
+      close(outp[1]);
+    }
+    if (errp[0] >= 0) {
+      close(errp[0]);
+    }
+    if (errp[1] >= 0) {
+      close(errp[1]);
+    }
+    return EESOCKET;
+  }
+  if (evutil_make_socket_nonblocking(outp[0]) == -1 ||
+      evutil_make_socket_nonblocking(errp[0]) == -1) {
+    close(outp[0]);
+    close(outp[1]);
+    close(errp[0]);
+    close(errp[1]);
+    return EESOCKET;
+  }
+
+  posix_spawn_file_actions_t file_actions;
+  int ret = posix_spawn_file_actions_init(&file_actions);
+  if (ret != 0) {
+    close(outp[0]);
+    close(outp[1]);
+    close(errp[0]);
+    close(errp[1]);
+    return EESOCKET;
+  }
+  DEFER { posix_spawn_file_actions_destroy(&file_actions); };
+
+  ret = posix_spawn_file_actions_adddup2(&file_actions, outp[1], 1) ||
+        posix_spawn_file_actions_adddup2(&file_actions, errp[1], 2) ||
+        posix_spawn_file_actions_addopen(&file_actions, 0, "/dev/null", O_RDONLY, 0) ||
+        posix_spawn_file_actions_addclose(&file_actions, outp[0]) ||
+        posix_spawn_file_actions_addclose(&file_actions, errp[0]);
+  if (ret != 0) {
+    close(outp[0]);
+    close(outp[1]);
+    close(errp[0]);
+    close(errp[1]);
+    return EESOCKET;
+  }
+
+  pid_t pid;
+  char* newenviron[] = {nullptr};
+  ret = posix_spawn(&pid, argv[0], &file_actions, nullptr, argv.data(), newenviron);
+  if (ret != 0) {
+    debug(external_start, "external_start: posix_spawn() error: %s\n", strerror(ret));
+    close(outp[0]);
+    close(outp[1]);
+    close(errp[0]);
+    close(errp[1]);
+    return EESOCKET;
+  }
+  close(outp[1]);
+  close(errp[1]);
+  h->pid = pid;
+
+  arm_pipe_reader(h, id, 0, outp[0]);
+  arm_pipe_reader(h, id, 1, errp[0]);
+
+  std::thread([id, pid]() {
     int status = 0;
     LPC_INT code = -1;
     do {
       const int s = waitpid(pid, &status, WUNTRACED | WCONTINUED);
       if (s == -1) {
-        debug(external_start, "external_start: waitpid() error: %s (%d).\n", strerror(errno),
-              errno);
-        note_child_exit(fd, -1);
+        note_child_exit(id, -1);
         return;
       }
       if (WIFEXITED(status)) {
         code = WEXITSTATUS(status);
-        debug(external_start, "external_start: child %jd exited, status=%d\n", (intmax_t)pid,
-              WEXITSTATUS(status));
       } else if (WIFSIGNALED(status)) {
         code = 128 + WTERMSIG(status);
-        debug(external_start, "external_start: child %jd killed by signal %d\n", (intmax_t)pid,
-              WTERMSIG(status));
-      } else if (WIFSTOPPED(status)) {
-        debug(external_start, "external_start: child %jd stopped by signal %d\n", (intmax_t)pid,
-              WSTOPSIG(status));
-      } else if (WIFCONTINUED(status)) {
-        debug(external_start, "external_start: child %jd continued\n", (intmax_t)pid);
       }
     } while (!WIFEXITED(status) && !WIFSIGNALED(status));
-    note_child_exit(fd, code);
+    note_child_exit(id, code);
   }).detach();
-#else
-  PROCESS_INFORMATION const processInfo = w.pi;
-  SOCKET const child_sock = w.child_sock;
-  std::thread([=]() {
-    WaitForSingleObject(processInfo.hProcess, INFINITE);
-    DWORD exitCode = static_cast<DWORD>(-1);
-    GetExitCodeProcess(processInfo.hProcess, &exitCode);
-    debug(external_start, "external_start: pid: %d exited with %d.\n", processInfo.dwProcessId,
-          exitCode);
-    CloseHandle(processInfo.hProcess);
-    CloseHandle(processInfo.hThread);
-    evutil_closesocket(child_sock);
-    note_child_exit(fd, static_cast<LPC_INT>(exitCode));
-  }).detach();
-#endif
+  return 0;
 }
+#endif
 
+#ifdef _WIN32
 std::string quote_argument(const std::string& arg) {
   if (arg.empty()) {
     return "\"\"";
@@ -216,16 +437,12 @@ std::string quote_argument(const std::string& arg) {
     return arg;
   }
   std::string res = "\"";
-  // from
-  // https://learn.microsoft.com/en-us/archive/blogs/twistylittlepassagesallalike/everyone-quotes-command-line-arguments-the-wrong-way
   for (auto It = arg.begin();; ++It) {
     unsigned NumberBackslashes = 0;
-
     while (It != arg.end() && *It == '\\') {
       ++It;
       ++NumberBackslashes;
     }
-
     if (It == arg.end()) {
       res.append(NumberBackslashes * 2, '\\');
       break;
@@ -239,6 +456,85 @@ std::string quote_argument(const std::string& arg) {
   }
   res.push_back('"');
   return res;
+}
+
+int spawn_handle_win32(ExternalHandle* h, int id) {
+  std::string cmd = external_cmd[h->cmd_index];
+  cmd = trim(cmd, " ");
+  if (cmd[0] != '"') {
+    cmd = fmt::format("\"{}\"", cmd);
+  }
+  std::string cmdline = cmd + " ";
+  std::vector<std::string> quoted;
+  for (auto& a : h->args) {
+    quoted.emplace_back(quote_argument(a));
+  }
+  cmdline += fmt::to_string(fmt::join(quoted.begin(), quoted.end(), " "));
+
+  SOCKET out_sv[2];
+  SOCKET err_sv[2];
+  if (socketpair_win32(out_sv, 0) != 0 || socketpair_win32(err_sv, 0) != 0) {
+    return EESOCKET;
+  }
+  if (evutil_make_socket_nonblocking(out_sv[1]) == -1 ||
+      evutil_make_socket_nonblocking(err_sv[1]) == -1) {
+    evutil_closesocket(out_sv[0]);
+    evutil_closesocket(out_sv[1]);
+    evutil_closesocket(err_sv[0]);
+    evutil_closesocket(err_sv[1]);
+    return EESOCKET;
+  }
+
+  SECURITY_ATTRIBUTES sa{sizeof(sa), nullptr, TRUE};
+  HANDLE nul = CreateFileA("NUL", GENERIC_READ, FILE_SHARE_READ | FILE_SHARE_WRITE, &sa,
+                           OPEN_EXISTING, 0, nullptr);
+
+  STARTUPINFOA si = {sizeof(si)};
+  si.dwFlags = STARTF_USESHOWWINDOW | STARTF_USESTDHANDLES;
+  si.wShowWindow = SW_HIDE;
+  si.hStdInput = nul;
+  si.hStdOutput = reinterpret_cast<HANDLE>(out_sv[0]);
+  si.hStdError = reinterpret_cast<HANDLE>(err_sv[0]);
+  PROCESS_INFORMATION processInfo{};
+
+  if (!CreateProcessA(NULL, cmdline.data(), NULL, NULL, TRUE, 0, NULL, NULL, &si, &processInfo)) {
+    if (nul != INVALID_HANDLE_VALUE) {
+      CloseHandle(nul);
+    }
+    evutil_closesocket(out_sv[0]);
+    evutil_closesocket(out_sv[1]);
+    evutil_closesocket(err_sv[0]);
+    evutil_closesocket(err_sv[1]);
+    return EESOCKET;
+  }
+  if (nul != INVALID_HANDLE_VALUE) {
+    CloseHandle(nul);
+  }
+  evutil_closesocket(out_sv[0]);
+  evutil_closesocket(err_sv[0]);
+  h->pi = processInfo;
+
+  arm_pipe_reader(h, id, 0, out_sv[1]);
+  arm_pipe_reader(h, id, 1, err_sv[1]);
+
+  std::thread([id, processInfo]() {
+    WaitForSingleObject(processInfo.hProcess, INFINITE);
+    DWORD exitCode = static_cast<DWORD>(-1);
+    GetExitCodeProcess(processInfo.hProcess, &exitCode);
+    CloseHandle(processInfo.hProcess);
+    CloseHandle(processInfo.hThread);
+    note_child_exit(id, static_cast<LPC_INT>(exitCode));
+  }).detach();
+  return 0;
+}
+#endif
+
+int spawn_handle(ExternalHandle* h, int id) {
+#ifndef _WIN32
+  return spawn_handle_posix(h, id);
+#else
+  return spawn_handle_win32(h, id);
+#endif
 }
 
 #ifndef _WIN32
@@ -345,11 +641,6 @@ int external_start(int which, svalue_t* args, svalue_t* arg1, svalue_t* arg2, sv
   ret = posix_spawn(&pid, newargs[0], &file_actions, nullptr, newargs.data(), newenviron);
   if (ret) {
     debug(external_start, "external_start: posix_spawn() error: %s\n", strerror(ret));
-    // The socket slot above is fully provisioned (fd, callbacks, event
-    // listeners, STATE_DATA_XFER). Tear it down so we don't leak the event
-    // listeners / callback strings and leave a dangling half-open efun socket
-    // pointing at sv[0]. socket_close() closes lpc_socks[fd].fd (== sv[0]);
-    // clear sv[0] afterwards so the DEFER doesn't double-close it.
     socket_close(fd, SC_FORCE | SC_FINAL_CLOSE);
     sv[0] = -1;
     return EESOCKET;
@@ -362,9 +653,16 @@ int external_start(int which, svalue_t* args, svalue_t* arg1, svalue_t* arg2, sv
   debug(external_start, "external_start: Launching external command '%s %s', pid: %jd.\n",
         external_cmd[which], args->type == T_STRING ? args->u.string : "<ARRAY>", (intmax_t)pid);
 
-  /* Reaper starts after the caller attaches a promise job (if any), so a
-   * fast child cannot post its exit code before the job exists. */
-  stash_posix_child(fd, pid);
+  std::thread([=]() {
+    int status;
+    do {
+      const int s = waitpid(pid, &status, WUNTRACED | WCONTINUED);
+      if (s == -1) {
+        return;
+      }
+    } while (!WIFEXITED(status) && !WIFSIGNALED(status));
+  }).detach();
+
   return fd;
 }
 #endif
@@ -374,7 +672,6 @@ int external_start(int which, svalue_t* args, svalue_t* arg1, svalue_t* arg2, sv
   int fd;
 
   std::string cmd = external_cmd[which];
-  // guard against long path with spaces.
   cmd = trim(cmd, " ");
   if (cmd[0] != '"') {
     cmd = fmt::format("\"{}\"", cmd);
@@ -439,104 +736,127 @@ int external_start(int which, svalue_t* args, svalue_t* arg1, svalue_t* arg2, sv
   si.hStdOutput = reinterpret_cast<HANDLE>(sv[0]);
   PROCESS_INFORMATION processInfo{};
 
-  // Start the child process.
-  if (!CreateProcessA(NULL,            // No module name (use command line)
-                      cmdline.data(),  // Command line
-                      NULL,            // Process handle not inheritable
-                      NULL,            // Thread handle not inheritable
-                      TRUE,            // Set handle inheritance to TRUE
-                      0,               // No creation flags
-                      NULL,            // Use parent's environment block
-                      NULL,            // Use parent's starting directory
-                      &si,             // Pointer to STARTUPINFO structure
-                      &processInfo)    // Pointer to PROCESS_INFORMATION structure
-  ) {
+  if (!CreateProcessA(NULL, cmdline.data(), NULL, NULL, TRUE, 0, NULL, NULL, &si, &processInfo)) {
     error("CreateProcess() in external_start() failed: %s\n", strerror(errno));
     return EESOCKET;
   }
   debug(external_start, "external_start: Launching external command '%s', pid: %d.\n",
         cmdline.c_str(), processInfo.dwProcessId);
 
-  stash_win32_child(fd, processInfo, sv[0]);
+  std::thread([=]() {
+    WaitForSingleObject(processInfo.hProcess, INFINITE);
+    DWORD exitCode = -1;
+    GetExitCodeProcess(processInfo.hProcess, &exitCode);
+    CloseHandle(processInfo.hProcess);
+    CloseHandle(processInfo.hThread);
+    evutil_closesocket(sv[0]);
+  }).detach();
+
   return fd;
 }
 #endif
 
-int external_promise_take_read(int fd, const char* data, int len) {
-  auto it = g_external_jobs.find(fd);
-  if (it == g_external_jobs.end()) {
-    return 0;
-  }
-  if (data && len > 0) {
-    auto max_string_length = CONFIG_INT(__MAX_STRING_LENGTH__);
-    auto& out = it->second->output;
-    size_t room = (max_string_length > 0 && static_cast<size_t>(max_string_length) > out.size())
-                      ? static_cast<size_t>(max_string_length) - out.size()
-                      : 0;
-    if (room > 0) {
-      out.append(data, std::min(static_cast<size_t>(len), room));
+void external_owner_destructed(object_t* ob) {
+  for (int i = 0; i < static_cast<int>(g_handles.size()); i++) {
+    if (g_handles[i] && g_handles[i]->owner == ob) {
+      destroy_handle(i + 1, /*kill_child=*/1);
     }
   }
-  return 1;
-}
-
-void external_promise_closed(int fd, int aborted) {
-  auto it = g_external_jobs.find(fd);
-  if (it == g_external_jobs.end()) {
-    return;
-  }
-  if (aborted) {
-    it->second->aborted = true;
-  } else {
-    it->second->io_done = true;
-  }
-  try_finish_job(fd);
 }
 
 void external_cleanup() {
-  while (!g_external_jobs.empty()) {
-    auto fd = g_external_jobs.begin()->first;
-    g_external_jobs.begin()->second->aborted = true;
-    settle_and_drop_job(fd);
+  for (int i = 0; i < static_cast<int>(g_handles.size()); i++) {
+    if (g_handles[i]) {
+      destroy_handle(i + 1, /*kill_child=*/1);
+    }
   }
-  g_child_watches.clear();
+  g_handles.clear();
   std::lock_guard<std::mutex> const lock(g_exit_mu);
   g_exit_notes.clear();
 }
 
 #ifdef DEBUGMALLOC_EXTENSIONS
 void mark_external() {
-  for (auto& entry : g_external_jobs) {
-    if (entry.second->prom) {
-      entry.second->prom->extra_ref++;
+  for (auto* h : g_handles) {
+    if (h && h->prom) {
+      h->prom->extra_ref++;
     }
   }
 }
 #endif
 
-#ifdef F_EXTERNAL_START
-void f_external_start() {
-  /* Latch arity first: check_valid_socket() runs a master apply that
-   * overwrites st_num_arg (same trap as f_async_read / f_async_db_exec). */
+#ifdef F_EXTERNAL_CREATE
+void f_external_create() {
   int const num_arg = st_num_arg;
   svalue_t* arg = sp - num_arg + 1;
-  int const promise_form = (num_arg == 2);
-
-  if (num_arg != 2 && num_arg < 4) {
-    error(
-        "external_start: promise form takes two arguments; classic form needs "
-        "read and write callbacks.\n");
-  }
 
   if (!check_valid_socket("external", -1, current_object, "N/A", -1)) {
     st_num_arg = num_arg;
-    if (promise_form) {
+    error("external_create: permission denied.\n");
+  }
+  st_num_arg = num_arg;
+
+  int const cmd = validate_cmd_index(arg[0].u.number);
+  std::vector<std::string> extra;
+  parse_cmd_args(arg + 1, &extra);
+
+  int const id = alloc_handle_id();
+  auto* h = new ExternalHandle{};
+  h->owner = current_object;
+  h->cmd_index = cmd;
+  h->args = std::move(extra);
+  g_handles[id - 1] = h;
+
+  pop_n_elems(num_arg);
+  push_number(id);
+}
+#endif
+
+#ifdef F_EXTERNAL_START
+void f_external_start() {
+  int const num_arg = st_num_arg;
+  svalue_t* arg = sp - num_arg + 1;
+
+  if (num_arg == 1) {
+    ExternalHandle* h = lookup_handle(static_cast<int>(arg[0].u.number), /*require_owner=*/1);
+    int const id = static_cast<int>(arg[0].u.number);
+    if (h->state != HandleState::Created) {
+      error("external_start: handle has already been started.\n");
+    }
+    if (!check_valid_socket("external", -1, current_object, "N/A", -1)) {
+      st_num_arg = num_arg;
       promise_t* p = promise_alloc();
       reject_with_number(p, EESECURITY);
       pop_n_elems(num_arg);
       push_refed_promise(p);
       return;
     }
+    st_num_arg = num_arg;
+
+    int const rc = spawn_handle(h, id);
+    promise_t* p = promise_alloc();
+    if (rc < 0) {
+      reject_with_number(p, rc);
+      pop_n_elems(num_arg);
+      push_refed_promise(p);
+      return;
+    }
+    h->state = HandleState::Running;
+    h->prom = p;
+    p->ref++;
+    pop_n_elems(num_arg);
+    push_refed_promise(p);
+    return;
+  }
+
+  if (num_arg != 4 && num_arg != 5) {
+    error(
+        "external_start: pass a handle from external_create(), or the classic "
+        "read/write callbacks.\n");
+  }
+
+  if (!check_valid_socket("external", -1, current_object, "N/A", -1)) {
+    st_num_arg = num_arg;
     pop_n_elems(num_arg - 1);
     sp->u.number = EESECURITY;
     return;
@@ -548,33 +868,42 @@ void f_external_start() {
     error("Bad argument 1 to external_start()\n");
   }
 
-  int fd;
-  if (promise_form) {
-    /* Spawn first: Windows CreateProcess error()s, so no promise is live
-     * across that unwind. Attach the job, then start the reaper so a
-     * fast child cannot post its exit code before the job exists. */
-    fd = external_start(which, arg + 1, nullptr, nullptr, nullptr);
-    if (fd < 0) {
-      promise_t* p = promise_alloc();
-      reject_with_number(p, fd);
-      pop_n_elems(num_arg);
-      push_refed_promise(p);
-      return;
-    }
-    promise_t* p = promise_alloc();
-    p->ref++; /* the job's ref; push_refed_promise takes the other */
-    attach_external_job(fd, p);
-    watch_child(fd);
-    pop_n_elems(num_arg);
-    push_refed_promise(p);
-    return;
-  }
-
-  fd = external_start(which, arg + 1, arg + 2, arg + 3, (num_arg == 5 ? arg + 4 : nullptr));
-  if (fd >= 0) {
-    watch_child(fd);
-  }
+  int fd = external_start(which, arg + 1, arg + 2, arg + 3, (num_arg == 5 ? arg + 4 : nullptr));
   pop_n_elems(num_arg - 1);
   sp->u.number = fd;
+}
+#endif
+
+#ifdef F_EXTERNAL_STDOUT
+void f_external_stdout() {
+  ExternalHandle* h = lookup_handle(static_cast<int>(sp->u.number), /*require_owner=*/1);
+  copy_and_push_string(h->out.c_str());
+  assign_svalue(sp - 1, sp);
+  pop_stack();
+}
+#endif
+
+#ifdef F_EXTERNAL_STDERR
+void f_external_stderr() {
+  ExternalHandle* h = lookup_handle(static_cast<int>(sp->u.number), /*require_owner=*/1);
+  copy_and_push_string(h->err.c_str());
+  assign_svalue(sp - 1, sp);
+  pop_stack();
+}
+#endif
+
+#ifdef F_EXTERNAL_EXIT_CODE
+void f_external_exit_code() {
+  ExternalHandle* h = lookup_handle(static_cast<int>(sp->u.number), /*require_owner=*/1);
+  sp->u.number = h->exit_code;
+}
+#endif
+
+#ifdef F_EXTERNAL_CLOSE
+void f_external_close() {
+  int const id = static_cast<int>(sp->u.number);
+  lookup_handle(id, /*require_owner=*/1);
+  destroy_handle(id, /*kill_child=*/1);
+  pop_stack();
 }
 #endif

--- a/src/packages/external/external.cc
+++ b/src/packages/external/external.cc
@@ -539,9 +539,14 @@ int spawn_handle_win32(ExternalHandle* h, int id) {
   }
   cmdline += fmt::to_string(fmt::join(quoted.begin(), quoted.end(), " "));
 
+  /* socks[0] is the ReadFile-capable end (see socketpair_win32). All three
+   * std handles must be sockets -- mixing a real NUL HANDLE with sockets
+   * makes CreateProcess fail. Classic uses one socket for all three. */
   SOCKET out_sv[2];
   SOCKET err_sv[2];
-  if (socketpair_win32(out_sv, 0) != 0 || socketpair_win32(err_sv, 0) != 0) {
+  SOCKET in_sv[2];
+  if (socketpair_win32(out_sv, 0) != 0 || socketpair_win32(err_sv, 0) != 0 ||
+      socketpair_win32(in_sv, 0) != 0) {
     return EESOCKET;
   }
   if (evutil_make_socket_nonblocking(out_sv[1]) == -1 ||
@@ -550,28 +555,25 @@ int spawn_handle_win32(ExternalHandle* h, int id) {
     evutil_closesocket(out_sv[1]);
     evutil_closesocket(err_sv[0]);
     evutil_closesocket(err_sv[1]);
+    evutil_closesocket(in_sv[0]);
+    evutil_closesocket(in_sv[1]);
     return EESOCKET;
   }
 
-  SECURITY_ATTRIBUTES sa{sizeof(sa), nullptr, TRUE};
-  HANDLE nul = CreateFileA("NUL", GENERIC_READ, FILE_SHARE_READ | FILE_SHARE_WRITE, &sa,
-                           OPEN_EXISTING, 0, nullptr);
-
   PROCESS_INFORMATION processInfo{};
-  if (!win32_create_process(&cmdline, nul, reinterpret_cast<HANDLE>(out_sv[0]),
+  if (!win32_create_process(&cmdline, reinterpret_cast<HANDLE>(in_sv[0]),
+                            reinterpret_cast<HANDLE>(out_sv[0]),
                             reinterpret_cast<HANDLE>(err_sv[0]), &processInfo)) {
-    if (nul != INVALID_HANDLE_VALUE) {
-      CloseHandle(nul);
-    }
     evutil_closesocket(out_sv[0]);
     evutil_closesocket(out_sv[1]);
     evutil_closesocket(err_sv[0]);
     evutil_closesocket(err_sv[1]);
+    evutil_closesocket(in_sv[0]);
+    evutil_closesocket(in_sv[1]);
     return EESOCKET;
   }
-  if (nul != INVALID_HANDLE_VALUE) {
-    CloseHandle(nul);
-  }
+  evutil_closesocket(in_sv[0]);
+  evutil_closesocket(in_sv[1]);
   evutil_closesocket(out_sv[0]);
   evutil_closesocket(err_sv[0]);
   h->pi = processInfo;

--- a/src/packages/external/external.cc
+++ b/src/packages/external/external.cc
@@ -247,6 +247,50 @@ void push_external_result(const std::string& out, const std::string& err, LPC_IN
   push_refed_array(arr);
 }
 
+void kill_handle_child(ExternalHandle* h) {
+  if (h->state != HandleState::Running) {
+    return;
+  }
+#ifndef _WIN32
+  if (h->pid > 0) {
+    kill(h->pid, SIGTERM);
+  }
+#else
+  if (h->pi.hProcess) {
+    TerminateProcess(h->pi.hProcess, 1);
+  }
+#endif
+}
+
+/* promise_reject() / last-ref drop: stop the child. The promise is already
+ * settling or dying -- do not settle it again. Pipes stay armed so a
+ * non-ephemeral handle can still collect leftover output + the wait status. */
+void on_external_cancel(void* data) {
+  int const id = static_cast<int>(reinterpret_cast<intptr_t>(data));
+  if (id < 1 || id > static_cast<int>(g_handles.size()) || !g_handles[id - 1]) {
+    return;
+  }
+  ExternalHandle* h = g_handles[id - 1];
+  promise_t* p = h->prom;
+  h->prom = nullptr;
+  kill_handle_child(h);
+  /* Drop the driver ref. Safe during dealloc (ref already 0) and during
+   * promise_settle(reject): LPC still holds the caller's ref. */
+  if (p) {
+    free_promise(p);
+  }
+}
+
+void attach_start_promise(ExternalHandle* h, int id, promise_t* p) {
+  /* Driver-owned ref keeps the promise alive across `await external_run()`
+   * / `await external_start()` (the temporary is consumed when await
+   * parks). Reject still cancels. */
+  h->prom = p;
+  p->ref++;
+  promise_set_cancel_handler(p, on_external_cancel,
+                             reinterpret_cast<void*>(static_cast<intptr_t>(id)));
+}
+
 void fulfill_handle_promise(int id) {
   ExternalHandle* h = g_handles[id - 1];
   if (!h->prom) {
@@ -258,6 +302,7 @@ void fulfill_handle_promise(int id) {
   }
   promise_t* p = h->prom;
   h->prom = nullptr;
+  promise_clear_cancel_handler(p);
   push_external_result(h->out, h->err, h->exit_code);
   promise_settle(p, sp, 0);
   pop_stack();
@@ -289,24 +334,22 @@ void abort_handle(int id, int kill_child) {
     return;
   }
   ExternalHandle* h = g_handles[id - 1];
-  if (h->state == HandleState::Running && kill_child) {
-#ifndef _WIN32
-    if (h->pid > 0) {
-      kill(h->pid, SIGTERM);
-    }
-#else
-    if (h->pi.hProcess) {
-      TerminateProcess(h->pi.hProcess, 1);
-    }
-#endif
+  if (kill_child) {
+    kill_handle_child(h);
   }
   free_pipe_events(h);
   if (h->prom) {
-    push_constant_string("*external process aborted");
-    promise_settle(h->prom, sp, 1);
-    pop_stack();
-    free_promise(h->prom);
+    promise_t* p = h->prom;
     h->prom = nullptr;
+    /* Clear first: settle(reject) would otherwise fire the cancel handler
+     * and free_promise a second time. */
+    promise_clear_cancel_handler(p);
+    if (p->state == PROMISE_PENDING) {
+      push_constant_string("*external process aborted");
+      promise_settle(p, sp, 1);
+      pop_stack();
+    }
+    free_promise(p);
   }
   h->state = HandleState::Done;
 }
@@ -814,8 +857,7 @@ promise_t* start_created_handle(ExternalHandle* h, int id) {
     return p;
   }
   h->state = HandleState::Running;
-  h->prom = p;
-  p->ref++;
+  attach_start_promise(h, id, p);
   return p;
 }
 
@@ -1116,8 +1158,7 @@ void f_external_run() {
     return;
   }
   h->state = HandleState::Running;
-  h->prom = p;
-  p->ref++;
+  attach_start_promise(h, id, p);
   pop_n_elems(num_arg);
   push_refed_promise(p);
 }

--- a/src/packages/external/external.cc
+++ b/src/packages/external/external.cc
@@ -8,6 +8,7 @@
 #include <cstring>
 #include <cstdlib>  // for exit
 #include <mutex>
+#include <sstream>
 #include <string>
 #include <thread>
 #include <vector>
@@ -48,11 +49,13 @@ enum class HandleState : uint8_t { Created, Running, Done };
 
 struct PipeWatch {
   int handle;
+  uint64_t gen;
   int stream; /* 0 = stdout, 1 = stderr */
 };
 
 struct ExternalHandle {
   object_t* owner = nullptr;
+  uint64_t gen = 0;
   int cmd_index = -1; /* 0-based */
   std::vector<std::string> args;
   HandleState state = HandleState::Created;
@@ -77,6 +80,7 @@ struct ExternalHandle {
   std::string in_buf;
   bool in_closed = false;
   bool close_stdin_after_flush = false;
+  bool stdin_retry_armed = false;
 #ifndef _WIN32
   pid_t pid = -1;
 #else
@@ -89,11 +93,19 @@ struct ExternalHandle {
 };
 
 std::vector<ExternalHandle*> g_handles; /* handle id = index + 1 */
+uint64_t g_next_handle_gen = 1;
 
 std::mutex g_exit_mu;
 struct ChildExitNote {
-  int handle;
-  LPC_INT code;
+  int handle = 0;
+  uint64_t gen = 0;
+  LPC_INT code = -1;
+#ifndef _WIN32
+  pid_t pid = -1;
+#else
+  HANDLE process = nullptr;
+  HANDLE thread = nullptr;
+#endif
 };
 std::vector<ChildExitNote> g_exit_notes;
 
@@ -151,7 +163,6 @@ void parse_cmd_args(svalue_t* args, std::vector<std::string>* extra) {
       extra->emplace_back(item.u.string);
     }
   } else {
-#ifndef _WIN32
     std::istringstream iss(args->u.string);
     std::string item;
     while (std::getline(iss, item, ' ')) {
@@ -159,9 +170,6 @@ void parse_cmd_args(svalue_t* args, std::vector<std::string>* extra) {
         extra->push_back(item);
       }
     }
-#else
-    extra->emplace_back(args->u.string);
-#endif
   }
 }
 
@@ -248,7 +256,9 @@ void push_external_result(const std::string& out, const std::string& err, LPC_IN
 }
 
 void kill_handle_child(ExternalHandle* h) {
-  if (h->state != HandleState::Running) {
+  /* status_done means the waiter has already reaped: the pid/HANDLE must
+   * not be signalled (PID recycle / closed HANDLE). */
+  if (h->state != HandleState::Running || h->status_done) {
     return;
   }
 #ifndef _WIN32
@@ -364,6 +374,22 @@ void destroy_handle(int id, int kill_child) {
   g_handles[id - 1] = nullptr;
 }
 
+void reap_exit_note(const ChildExitNote& note) {
+#ifndef _WIN32
+  if (note.pid > 0) {
+    int st = 0;
+    (void)waitpid(note.pid, &st, 0);
+  }
+#else
+  if (note.process) {
+    CloseHandle(note.process);
+  }
+  if (note.thread) {
+    CloseHandle(note.thread);
+  }
+#endif
+}
+
 void drain_child_exits() {
   std::vector<ChildExitNote> notes;
   {
@@ -371,21 +397,34 @@ void drain_child_exits() {
     notes.swap(g_exit_notes);
   }
   for (auto& note : notes) {
+    /* Always reap/close from the note. The handle may already have been
+     * destroyed (close / owner destruct); the pid must not stay a zombie
+     * and the Win32 HANDLEs must not leak. */
+    reap_exit_note(note);
     if (note.handle < 1 || note.handle > static_cast<int>(g_handles.size()) ||
         !g_handles[note.handle - 1]) {
       continue;
     }
     ExternalHandle* h = g_handles[note.handle - 1];
+    if (h->gen != note.gen || h->state != HandleState::Running) {
+      continue;
+    }
     h->exit_code = note.code;
     h->status_done = true;
+#ifndef _WIN32
+    h->pid = -1;
+#else
+    h->pi.hProcess = nullptr;
+    h->pi.hThread = nullptr;
+#endif
     try_finish_handle(note.handle);
   }
 }
 
-void note_child_exit(int handle, LPC_INT code) {
+void post_child_exit(ChildExitNote note) {
   {
     std::lock_guard<std::mutex> const lock(g_exit_mu);
-    g_exit_notes.push_back(ChildExitNote{handle, code});
+    g_exit_notes.push_back(note);
   }
   add_walltime_event(std::chrono::milliseconds(0),
                      TickEvent::callback_type([] { drain_child_exits(); }));
@@ -398,6 +437,9 @@ void on_handle_pipe_read(evutil_socket_t fd, short /*what*/, void* arg) {
     return;
   }
   ExternalHandle* h = g_handles[id - 1];
+  if (h->gen != watch->gen) {
+    return;
+  }
   char buf[kPipeBuf];
   for (;;) {
 #ifdef _WIN32
@@ -436,7 +478,7 @@ void on_handle_pipe_read(evutil_socket_t fd, short /*what*/, void* arg) {
 }
 
 void arm_pipe_reader(ExternalHandle* h, int id, int stream, evutil_socket_t fd) {
-  auto* watch = new PipeWatch{id, stream};
+  auto* watch = new PipeWatch{id, h->gen, stream};
   struct event* ev =
       event_new(g_event_base, fd, EV_READ | EV_PERSIST, on_handle_pipe_read, watch);
   if (stream == 0) {
@@ -509,9 +551,53 @@ void flush_stdin(ExternalHandle* h, int id) {
     while (!h->in_buf.empty()) {
       DWORD written = 0;
       size_t chunk = std::min(h->in_buf.size(), static_cast<size_t>(kPipeBuf));
-      if (!WriteFile(h->in_handle, h->in_buf.data(), static_cast<DWORD>(chunk), &written, nullptr) ||
-          written == 0) {
+      if (!WriteFile(h->in_handle, h->in_buf.data(), static_cast<DWORD>(chunk), &written, nullptr)) {
+        DWORD const err = GetLastError();
+        /* PIPE_NOWAIT: buffer full. Retry on a short timer so the driver
+         * event loop is not blocked by a synchronous WriteFile. */
+        if (err == ERROR_NO_DATA || err == ERROR_IO_PENDING) {
+          if (!h->stdin_retry_armed) {
+            h->stdin_retry_armed = true;
+            int const retry_id = id;
+            uint64_t const retry_gen = h->gen;
+            add_walltime_event(std::chrono::milliseconds(10), TickEvent::callback_type([retry_id,
+                                                                                       retry_gen] {
+              if (retry_id < 1 || retry_id > static_cast<int>(g_handles.size()) ||
+                  !g_handles[retry_id - 1]) {
+                return;
+              }
+              ExternalHandle* rh = g_handles[retry_id - 1];
+              if (rh->gen != retry_gen) {
+                return;
+              }
+              rh->stdin_retry_armed = false;
+              flush_stdin(rh, retry_id);
+            }));
+          }
+          return;
+        }
         close_stdin_write(h);
+        return;
+      }
+      if (written == 0) {
+        if (!h->stdin_retry_armed) {
+          h->stdin_retry_armed = true;
+          int const retry_id = id;
+          uint64_t const retry_gen = h->gen;
+          add_walltime_event(std::chrono::milliseconds(10), TickEvent::callback_type([retry_id,
+                                                                                     retry_gen] {
+            if (retry_id < 1 || retry_id > static_cast<int>(g_handles.size()) ||
+                !g_handles[retry_id - 1]) {
+              return;
+            }
+            ExternalHandle* rh = g_handles[retry_id - 1];
+            if (rh->gen != retry_gen) {
+              return;
+            }
+            rh->stdin_retry_armed = false;
+            flush_stdin(rh, retry_id);
+          }));
+        }
         return;
       }
       h->in_buf.erase(0, static_cast<size_t>(written));
@@ -696,22 +782,18 @@ int spawn_handle_posix(ExternalHandle* h, int id) {
   arm_pipe_reader(h, id, 1, errp[0]);
   flush_stdin(h, id);
 
-  std::thread([id, pid]() {
-    int status = 0;
-    LPC_INT code = -1;
-    do {
-      const int s = waitpid(pid, &status, WUNTRACED | WCONTINUED);
-      if (s == -1) {
-        note_child_exit(id, -1);
-        return;
-      }
-      if (WIFEXITED(status)) {
-        code = WEXITSTATUS(status);
-      } else if (WIFSIGNALED(status)) {
-        code = 128 + WTERMSIG(status);
-      }
-    } while (!WIFEXITED(status) && !WIFSIGNALED(status));
-    note_child_exit(id, code);
+  uint64_t const gen = h->gen;
+  std::thread([id, gen, pid]() {
+    siginfo_t si{};
+    /* WNOWAIT leaves the zombie so the pid cannot be recycled until the
+     * main thread reaps in drain_child_exits(). kill() between waitid and
+     * drain therefore cannot hit a reused pid. */
+    if (waitid(P_PID, pid, &si, WEXITED | WNOWAIT) == -1) {
+      post_child_exit(ChildExitNote{id, gen, -1, pid});
+      return;
+    }
+    LPC_INT code = (si.si_code == CLD_EXITED) ? si.si_status : 128 + si.si_status;
+    post_child_exit(ChildExitNote{id, gen, code, pid});
   }).detach();
   return 0;
 }
@@ -807,6 +889,12 @@ int spawn_handle_win32(ExternalHandle* h, int id) {
     evutil_closesocket(sv[1]);
     return EESOCKET;
   }
+  /* Anonymous pipes are synchronous; PIPE_NOWAIT keeps WriteFile from
+   * stalling the driver when the child's stdin buffer is full. */
+  {
+    DWORD mode = PIPE_NOWAIT;
+    (void)SetNamedPipeHandleState(stdin_wr, &mode, nullptr, nullptr);
+  }
 
   PROCESS_INFORMATION processInfo{};
   if (!win32_create_process(&cmdline, stdin_rd, reinterpret_cast<HANDLE>(sv[0]),
@@ -824,15 +912,17 @@ int spawn_handle_win32(ExternalHandle* h, int id) {
   h->in_handle = stdin_wr;
   flush_stdin(h, id);
 
-  std::thread([id, processInfo, child_fd = sv[0]]() {
+  uint64_t const gen = h->gen;
+  std::thread([id, gen, processInfo, child_fd = sv[0]]() {
     WaitForSingleObject(processInfo.hProcess, INFINITE);
     DWORD exitCode = static_cast<DWORD>(-1);
     GetExitCodeProcess(processInfo.hProcess, &exitCode);
-    CloseHandle(processInfo.hProcess);
-    CloseHandle(processInfo.hThread);
+    /* Do not CloseHandle here: the main thread reaps in drain_child_exits
+     * so TerminateProcess cannot run on a recycled HANDLE. */
     shutdown(child_fd, SD_SEND);
     evutil_closesocket(child_fd);
-    note_child_exit(id, static_cast<LPC_INT>(exitCode));
+    post_child_exit(
+        ChildExitNote{id, gen, static_cast<LPC_INT>(exitCode), processInfo.hProcess, processInfo.hThread});
   }).detach();
   return 0;
 }
@@ -1121,6 +1211,7 @@ void f_external_create() {
   int const id = alloc_handle_id();
   auto* h = new ExternalHandle{};
   h->owner = current_object;
+  h->gen = ++g_next_handle_gen;
   h->cmd_index = cmd;
   h->args = std::move(extra);
   g_handles[id - 1] = h;
@@ -1149,6 +1240,12 @@ void f_external_run() {
     return;
   }
   st_num_arg = num_arg;
+  /* check_valid_socket() is a master apply: the owner may have been
+   * destructed and this slot reused. Re-lookup before spawn. */
+  h = lookup_handle(id, /*require_owner=*/1);
+  if (h->state != HandleState::Created) {
+    error("external_run: handle has already been started.\n");
+  }
 
   int const rc = spawn_handle(h, id);
   promise_t* p = promise_alloc();
@@ -1197,6 +1294,7 @@ void f_external_start() {
     int const id = alloc_handle_id();
     auto* h = new ExternalHandle{};
     h->owner = current_object;
+    h->gen = ++g_next_handle_gen;
     h->cmd_index = static_cast<int>(which);
     h->args = std::move(extra);
     h->ephemeral = true;
@@ -1263,7 +1361,7 @@ void f_external_exit_code() {
 void f_external_kill() {
   int const id = static_cast<int>(sp->u.number);
   ExternalHandle* h = lookup_handle(id, /*require_owner=*/1);
-  if (h->state != HandleState::Running) {
+  if (h->state != HandleState::Running || h->status_done) {
     sp->u.number = 0;
     return;
   }

--- a/src/packages/external/external.h
+++ b/src/packages/external/external.h
@@ -2,8 +2,8 @@
  * external.h -- driver-internal surface for package_external.
  *
  * LPC-visible efuns live in external.spec. This header is the hooks the
- * rest of the driver calls: socket read/close for the promise form of
- * external_start(), DEBUGMALLOC marking, and shutdown cleanup.
+ * rest of the driver calls: owner-destruct cleanup, DEBUGMALLOC marking,
+ * and shutdown cleanup for external_create() handles.
  */
 
 #ifndef PACKAGES_EXTERNAL_EXTERNAL_H_
@@ -11,20 +11,11 @@
 
 #ifdef PACKAGE_EXTERNAL
 
-/* Called from the efun-socket STREAM read path. Returns 1 if `fd` is a
- * promise-form external_start() job (the data was consumed; do not call
- * the LPC read callback). */
-int external_promise_take_read(int fd, const char* data, int len);
+/* Abort every handle owned by `ob` -- called from destruct_object(). */
+void external_owner_destructed(struct object_t* ob);
 
-/* Called from socket_close() for every close of an LPC socket. `aborted`
- * is 1 when the close is not a normal EOF (object destruct, shutdown,
- * explicit force-close without SC_DO_CALLBACK): the promise is rejected.
- * A normal close marks I/O complete; the promise fulfills with
- * ({ output, exit_code }) once waitpid has also reported. */
-void external_promise_closed(int fd, int aborted);
-
-/* Drop every in-flight promise job -- called on driver shutdown, before
- * promise_cleanup() / clear_tick_events(). */
+/* Drop every handle -- called on driver shutdown, before promise_cleanup()
+ * / clear_tick_events(). */
 void external_cleanup(void);
 
 #ifdef DEBUGMALLOC_EXTENSIONS

--- a/src/packages/external/external.h
+++ b/src/packages/external/external.h
@@ -1,0 +1,35 @@
+/*
+ * external.h -- driver-internal surface for package_external.
+ *
+ * LPC-visible efuns live in external.spec. This header is the hooks the
+ * rest of the driver calls: socket read/close for the promise form of
+ * external_start(), DEBUGMALLOC marking, and shutdown cleanup.
+ */
+
+#ifndef PACKAGES_EXTERNAL_EXTERNAL_H_
+#define PACKAGES_EXTERNAL_EXTERNAL_H_
+
+#ifdef PACKAGE_EXTERNAL
+
+/* Called from the efun-socket STREAM read path. Returns 1 if `fd` is a
+ * promise-form external_start() job (the data was consumed; do not call
+ * the LPC read callback). */
+int external_promise_take_read(int fd, const char* data, int len);
+
+/* Called from socket_close() for every close of an LPC socket. `aborted`
+ * is 1 when the close is not a normal EOF (object destruct, shutdown,
+ * explicit force-close without SC_DO_CALLBACK): the promise is rejected.
+ * A normal close fulfills with the collected stdout/stderr. */
+void external_promise_closed(int fd, int aborted);
+
+/* Drop every in-flight promise job -- called on driver shutdown, before
+ * promise_cleanup() / clear_tick_events(). */
+void external_cleanup(void);
+
+#ifdef DEBUGMALLOC_EXTENSIONS
+void mark_external(void);
+#endif
+
+#endif /* PACKAGE_EXTERNAL */
+
+#endif /* PACKAGES_EXTERNAL_EXTERNAL_H_ */

--- a/src/packages/external/external.h
+++ b/src/packages/external/external.h
@@ -19,7 +19,8 @@ int external_promise_take_read(int fd, const char* data, int len);
 /* Called from socket_close() for every close of an LPC socket. `aborted`
  * is 1 when the close is not a normal EOF (object destruct, shutdown,
  * explicit force-close without SC_DO_CALLBACK): the promise is rejected.
- * A normal close fulfills with the collected stdout/stderr. */
+ * A normal close marks I/O complete; the promise fulfills with
+ * ({ output, exit_code }) once waitpid has also reported. */
 void external_promise_closed(int fd, int aborted);
 
 /* Drop every in-flight promise job -- called on driver shutdown, before

--- a/src/packages/external/external.spec
+++ b/src/packages/external/external.spec
@@ -19,4 +19,5 @@ string external_stderr(int);
 int external_exit_code(int);
 int external_write(int, string);
 void external_close_stdin(int);
+int external_kill(int);
 void external_close(int);

--- a/src/packages/external/external.spec
+++ b/src/packages/external/external.spec
@@ -1,9 +1,14 @@
-/* Handle API (issue #1319): create, then start (awaitable), then read
-   stdout/stderr/exit_code from the handle.
+/* Classic form (unchanged): callbacks, returns the socket fd (int).
+   Promise form (issue #1319): omit the callbacks, returns a PROMISE
+   fulfilled with ({ stdout/stderr, exit_code }) when the process
+   exits, or rejected with the negative socket error the classic form
+   would have returned (EESECURITY, EESOCKET, ...) -- or with
+   "*external process aborted" if the owner is destructed first.
+   `mixed *r = await external_start(1, ({ "-s", url }));`
+   Handle form: external_create() then external_start(handle).
    `int h = external_create(1, ({ "-s", url }));
     await external_start(h);
-    string out = external_stdout(h);`
-   Classic form: callbacks, returns the socket fd (int). */
+    string out = external_stdout(h);` */
 int external_create(int, string | string *);
 mixed external_start(int, void | string | string *, void | string | function,
                      void | string | function, void | string | function);

--- a/src/packages/external/external.spec
+++ b/src/packages/external/external.spec
@@ -9,8 +9,7 @@
    with the same ({ stdout, stderr, exit_code }) tuple.
    `int h = external_create(1, ({ "-s", url }));
     mixed *r = await external_start(h);`
-   Optional third string to the omit-callback form is stdin (written, then
-   closed). Drive a handle with external_write() / external_close_stdin(). */
+   Drive a handle's stdin with external_write() / external_close_stdin(). */
 int external_create(int, string | string *);
 mixed external_start(int, void | string | string *, void | string | function,
                      void | string | function, void | string | function);

--- a/src/packages/external/external.spec
+++ b/src/packages/external/external.spec
@@ -1,9 +1,13 @@
-/* Classic form: callbacks, returns the socket fd (int).
-   Promise form (issue #1319): omit the callbacks, returns a PROMISE
-   fulfilled with ({ stdout/stderr, exit_code }) when the process
-   exits, or rejected with the negative socket error the classic form
-   would have returned (EESECURITY, EESOCKET, ...) -- or with
-   "*external process aborted" if the owner is destructed first.
-   `mixed *r = await external_start(1, ({ "-s", url }));` */
-mixed external_start(int, string | string *, void | string | function,
+/* Handle API (issue #1319): create, then start (awaitable), then read
+   stdout/stderr/exit_code from the handle.
+   `int h = external_create(1, ({ "-s", url }));
+    await external_start(h);
+    string out = external_stdout(h);`
+   Classic form: callbacks, returns the socket fd (int). */
+int external_create(int, string | string *);
+mixed external_start(int, void | string | string *, void | string | function,
                      void | string | function, void | string | function);
+string external_stdout(int);
+string external_stderr(int);
+int external_exit_code(int);
+void external_close(int);

--- a/src/packages/external/external.spec
+++ b/src/packages/external/external.spec
@@ -5,13 +5,14 @@
    would have returned (EESECURITY, EESOCKET, ...) -- or with
    "*external process aborted" if the owner is destructed first.
    `mixed *r = await external_start(1, ({ "-s", url }));`
-   Handle form: external_create() then external_start(handle) fulfills
+   Handle form: external_create() then external_run(handle) fulfills
    with the same ({ stdout, stderr, exit_code }) tuple.
    `int h = external_create(1, ({ "-s", url }));
-    mixed *r = await external_start(h);`
+    mixed *r = await external_run(h);`
    Drive a handle's stdin with external_write() / external_close_stdin(). */
 int external_create(int, string | string *);
-mixed external_start(int, void | string | string *, void | string | function,
+promise external_run(int);
+mixed external_start(int, string | string *, void | string | function,
                      void | string | function, void | string | function);
 string external_stdout(int);
 string external_stderr(int);

--- a/src/packages/external/external.spec
+++ b/src/packages/external/external.spec
@@ -17,6 +17,6 @@ mixed external_start(int, string | string *, void | string | function,
 string external_stdout(int);
 string external_stderr(int);
 int external_exit_code(int);
-void external_write(int, string);
+int external_write(int, string);
 void external_close_stdin(int);
 void external_close(int);

--- a/src/packages/external/external.spec
+++ b/src/packages/external/external.spec
@@ -1,14 +1,14 @@
 /* Classic form (unchanged): callbacks, returns the socket fd (int).
    Promise form (issue #1319): omit the callbacks, returns a PROMISE
-   fulfilled with ({ stdout/stderr, exit_code }) when the process
+   fulfilled with ({ stdout, stderr, exit_code }) when the process
    exits, or rejected with the negative socket error the classic form
    would have returned (EESECURITY, EESOCKET, ...) -- or with
    "*external process aborted" if the owner is destructed first.
    `mixed *r = await external_start(1, ({ "-s", url }));`
-   Handle form: external_create() then external_start(handle).
+   Handle form: external_create() then external_start(handle) fulfills
+   with the same ({ stdout, stderr, exit_code }) tuple.
    `int h = external_create(1, ({ "-s", url }));
-    await external_start(h);
-    string out = external_stdout(h);` */
+    mixed *r = await external_start(h);` */
 int external_create(int, string | string *);
 mixed external_start(int, void | string | string *, void | string | function,
                      void | string | function, void | string | function);

--- a/src/packages/external/external.spec
+++ b/src/packages/external/external.spec
@@ -1,9 +1,9 @@
 /* Classic form: callbacks, returns the socket fd (int).
    Promise form (issue #1319): omit the callbacks, returns a PROMISE
-   fulfilled with the collected stdout/stderr (string) when the process
+   fulfilled with ({ stdout/stderr, exit_code }) when the process
    exits, or rejected with the negative socket error the classic form
    would have returned (EESECURITY, EESOCKET, ...) -- or with
    "*external process aborted" if the owner is destructed first.
-   `string s = await external_start(1, ({ "-s", url }));` */
+   `mixed *r = await external_start(1, ({ "-s", url }));` */
 mixed external_start(int, string | string *, void | string | function,
                      void | string | function, void | string | function);

--- a/src/packages/external/external.spec
+++ b/src/packages/external/external.spec
@@ -8,11 +8,15 @@
    Handle form: external_create() then external_start(handle) fulfills
    with the same ({ stdout, stderr, exit_code }) tuple.
    `int h = external_create(1, ({ "-s", url }));
-    mixed *r = await external_start(h);` */
+    mixed *r = await external_start(h);`
+   Optional third string to the omit-callback form is stdin (written, then
+   closed). Drive a handle with external_write() / external_close_stdin(). */
 int external_create(int, string | string *);
 mixed external_start(int, void | string | string *, void | string | function,
                      void | string | function, void | string | function);
 string external_stdout(int);
 string external_stderr(int);
 int external_exit_code(int);
+void external_write(int, string);
+void external_close_stdin(int);
 void external_close(int);

--- a/src/packages/external/external.spec
+++ b/src/packages/external/external.spec
@@ -1,1 +1,9 @@
-int external_start(int, string | string *, string | function, string | function, string | function | void);
+/* Classic form: callbacks, returns the socket fd (int).
+   Promise form (issue #1319): omit the callbacks, returns a PROMISE
+   fulfilled with the collected stdout/stderr (string) when the process
+   exits, or rejected with the negative socket error the classic form
+   would have returned (EESECURITY, EESOCKET, ...) -- or with
+   "*external process aborted" if the owner is destructed first.
+   `string s = await external_start(1, ({ "-s", url }));` */
+mixed external_start(int, string | string *, void | string | function,
+                     void | string | function, void | string | function);

--- a/src/packages/sockets/socket_efuns.cc
+++ b/src/packages/sockets/socket_efuns.cc
@@ -8,9 +8,6 @@
 #include "base/package_api.h"
 
 #include "packages/sockets/socket_efuns.h"
-#ifdef PACKAGE_EXTERNAL
-#include "packages/external/external.h"
-#endif
 #include "net/tls.h"
 
 #include <cinttypes>
@@ -1444,20 +1441,6 @@ void socket_read_select_handler(int fd) {
 #endif
           debug(sockets, "read_socket_handler: read %d bytes\n", cc);
           buf[cc] = '\0';
-#ifdef PACKAGE_EXTERNAL
-          if (lpc_socks[fd].flags & S_EXTERNAL) {
-            if (lpc_socks[fd].flags & S_BINARY) {
-              if (external_promise_take_read(fd, buf, cc)) {
-                return;
-              }
-            } else {
-              auto res = u8_sanitize(buf);
-              if (external_promise_take_read(fd, res.c_str(), static_cast<int>(res.size()))) {
-                return;
-              }
-            }
-          }
-#endif
           push_number(fd);
           if (lpc_socks[fd].flags & S_BINARY) {
             buffer_t* b;
@@ -1733,15 +1716,6 @@ int socket_close(int fd, int flags) {
   if (!(flags & SC_FORCE) && lpc_socks[fd].owner_ob != current_object) {
     return EESECURITY;
   }
-
-#ifdef PACKAGE_EXTERNAL
-  if (lpc_socks[fd].flags & S_EXTERNAL) {
-    /* Normal EOF close (SC_DO_CALLBACK) fulfills the promise form;
-     * object-destruct / shutdown / force-close without the callback
-     * rejects it. Classic-form sockets have no job and this is a no-op. */
-    external_promise_closed(fd, !(flags & SC_DO_CALLBACK));
-  }
-#endif
 
   if (flags & SC_DO_CALLBACK) {
     debug(sockets, ("socket_close: apply close callback\n"));

--- a/src/packages/sockets/socket_efuns.cc
+++ b/src/packages/sockets/socket_efuns.cc
@@ -8,6 +8,9 @@
 #include "base/package_api.h"
 
 #include "packages/sockets/socket_efuns.h"
+#ifdef PACKAGE_EXTERNAL
+#include "packages/external/external.h"
+#endif
 #include "net/tls.h"
 
 #include <cinttypes>
@@ -1441,6 +1444,20 @@ void socket_read_select_handler(int fd) {
 #endif
           debug(sockets, "read_socket_handler: read %d bytes\n", cc);
           buf[cc] = '\0';
+#ifdef PACKAGE_EXTERNAL
+          if (lpc_socks[fd].flags & S_EXTERNAL) {
+            if (lpc_socks[fd].flags & S_BINARY) {
+              if (external_promise_take_read(fd, buf, cc)) {
+                return;
+              }
+            } else {
+              auto res = u8_sanitize(buf);
+              if (external_promise_take_read(fd, res.c_str(), static_cast<int>(res.size()))) {
+                return;
+              }
+            }
+          }
+#endif
           push_number(fd);
           if (lpc_socks[fd].flags & S_BINARY) {
             buffer_t* b;
@@ -1716,6 +1733,15 @@ int socket_close(int fd, int flags) {
   if (!(flags & SC_FORCE) && lpc_socks[fd].owner_ob != current_object) {
     return EESECURITY;
   }
+
+#ifdef PACKAGE_EXTERNAL
+  if (lpc_socks[fd].flags & S_EXTERNAL) {
+    /* Normal EOF close (SC_DO_CALLBACK) fulfills the promise form;
+     * object-destruct / shutdown / force-close without the callback
+     * rejects it. Classic-form sockets have no job and this is a no-op. */
+    external_promise_closed(fd, !(flags & SC_DO_CALLBACK));
+  }
+#endif
 
   if (flags & SC_DO_CALLBACK) {
     debug(sockets, ("socket_close: apply close callback\n"));

--- a/src/vm/internal/base/promise.cc
+++ b/src/vm/internal/base/promise.cc
@@ -1250,7 +1250,29 @@ promise_t* promise_alloc() {
   p->result = const0;
   p->reactions = nullptr;
   p->reject_origin = nullptr;
+  p->on_cancel = nullptr;
+  p->cancel_data = nullptr;
   return p;
+}
+
+void promise_set_cancel_handler(promise_t* p, void (*fn)(void*), void* data) {
+  p->on_cancel = fn;
+  p->cancel_data = data;
+}
+
+void promise_clear_cancel_handler(promise_t* p) {
+  p->on_cancel = nullptr;
+  p->cancel_data = nullptr;
+}
+
+static void fire_cancel_handler(promise_t* p) {
+  void (*fn)(void*) = p->on_cancel;
+  void* data = p->cancel_data;
+  p->on_cancel = nullptr;
+  p->cancel_data = nullptr;
+  if (fn) {
+    fn(data);
+  }
 }
 
 /* "/obj/name:42" for the currently executing LPC, or null if there is none
@@ -1286,6 +1308,9 @@ void free_promise(promise_t* p) {
 }
 
 void dealloc_promise(promise_t* p) {
+  if (p->state == PROMISE_PENDING) {
+    fire_cancel_handler(p);
+  }
   if (p->state == PROMISE_REJECTED && !p->handled) {
     /* Where it was rejected. Without this the report is a bare reason with no
      * object, function or line -- and it is printed at DEALLOCATION, which
@@ -1393,6 +1418,11 @@ int promise_settle(promise_t* p, svalue_t* value, int rejected) {
   }
   if (rejected && p->reject_origin == nullptr) {
     p->reject_origin = capture_reject_origin();
+  }
+  if (rejected) {
+    fire_cancel_handler(p);
+  } else {
+    promise_clear_cancel_handler(p);
   }
   p->state = rejected ? PROMISE_REJECTED : PROMISE_FULFILLED;
   assign_svalue(&p->result, value);

--- a/src/vm/internal/base/promise.h
+++ b/src/vm/internal/base/promise.h
@@ -87,7 +87,17 @@ struct promise_t {
    * failure is the one worth naming. Only rejections pay for it -- a fulfilled
    * promise never allocates this. Malloced (FREE_MSTR), null if unknown. */
   char* reject_origin;
+  /* Optional: notified once if this promise is rejected, or deallocated
+   * while still pending. Efuns that own external work (a child process,
+   * a timer) use it to stop that work when the caller cancels via
+   * promise_reject(). Not called on fulfillment. Cleared before the
+   * efun's own settle so it does not re-enter. */
+  void (*on_cancel)(void* data);
+  void* cancel_data;
 };
+
+void promise_set_cancel_handler(promise_t* p, void (*fn)(void*), void* data);
+void promise_clear_cancel_handler(promise_t* p);
 
 promise_t* promise_alloc();
 void free_promise(promise_t* p);

--- a/src/vm/internal/simulate.cc
+++ b/src/vm/internal/simulate.cc
@@ -1354,6 +1354,9 @@ void destruct_object(object_t* ob) {
     close_referencing_sockets(ob);
   }
 #endif
+#ifdef PACKAGE_EXTERNAL
+  external_owner_destructed(ob);
+#endif
 #ifdef PACKAGE_PARSER
   if (ob->pinfo) {
     parse_free(ob->pinfo);

--- a/src/vm/internal/simulate.cc
+++ b/src/vm/internal/simulate.cc
@@ -49,6 +49,9 @@ void db_cleanup(void);  // FIXME
 #ifdef PACKAGE_JSBRIDGE
 #include "packages/jsbridge/jsbridge.h"
 #endif
+#ifdef PACKAGE_EXTERNAL
+#include "packages/external/external.h"
+#endif
 #ifdef PACKAGE_SOCKETS
 #include "packages/sockets/socket_efuns.h"
 #endif
@@ -97,6 +100,12 @@ void shutdownMudOS(int exit_code) {
   // Must precede clear_tick_events(): pending delivery events reference
   // the entries this frees, and are discarded unrun there.
   jsbridge_cleanup();
+#endif
+#ifdef PACKAGE_EXTERNAL
+  /* Settle leftover external_start() promises before promise_cleanup()
+   * latches the queue (and before lpc_socks_closeall() force-closes the
+   * child sockets). Same ordering as jsbridge / call_out. */
+  external_cleanup();
 #endif
   // Freeing a leftover call_out settle-rejects its promise, which ENQUEUES
   // a reaction -- so this must run before promise_cleanup() drains the

--- a/testsuite/etc/config.test
+++ b/testsuite/etc/config.test
@@ -357,6 +357,13 @@ enable msdp : 1
 # External commands
 external_cmd_1 : /usr/bin/curl
 external_cmd_2 : c:\Windows\System32\curl.exe
+# echo: used by external_start's promise-form test. Slot 3 is the Unix
+# path; slot 4 covers MSYS2 where /bin/echo may not exist; slot 6 is
+# native Windows (echo is a cmd builtin). Slot 5 is deliberately left
+# unconfigured so the efun's bad-index path stays pinned.
+external_cmd_3 : /bin/echo
+external_cmd_4 : /usr/bin/echo
+external_cmd_6 : c:\Windows\System32\cmd.exe
 
 ###############################################################################
 #          The following aren't currently used or implemented (yet)           #

--- a/testsuite/etc/config.test
+++ b/testsuite/etc/config.test
@@ -364,6 +364,9 @@ external_cmd_2 : c:\Windows\System32\curl.exe
 external_cmd_3 : /bin/echo
 external_cmd_4 : /usr/bin/echo
 external_cmd_6 : c:\Windows\System32\cmd.exe
+# false: non-zero exit for the promise-form return-code check
+external_cmd_7 : /bin/false
+external_cmd_8 : /usr/bin/false
 
 ###############################################################################
 #          The following aren't currently used or implemented (yet)           #

--- a/testsuite/etc/config.test
+++ b/testsuite/etc/config.test
@@ -367,6 +367,10 @@ external_cmd_6 : c:\Windows\System32\cmd.exe
 # false: non-zero exit for the promise-form return-code check
 external_cmd_7 : /bin/false
 external_cmd_8 : /usr/bin/false
+# cat: stdin echo for the promise-form write path. Slot 6 (cmd.exe) uses
+# `findstr ^` in the test. Slots 9-10 are reserved on the cancel branch.
+external_cmd_11 : /bin/cat
+external_cmd_12 : /usr/bin/cat
 
 ###############################################################################
 #          The following aren't currently used or implemented (yet)           #

--- a/testsuite/etc/config.test
+++ b/testsuite/etc/config.test
@@ -367,8 +367,11 @@ external_cmd_6 : c:\Windows\System32\cmd.exe
 # false: non-zero exit for the promise-form return-code check
 external_cmd_7 : /bin/false
 external_cmd_8 : /usr/bin/false
+# sleep: cancel-the-promise-kills-the-child (external_promise.lpc)
+external_cmd_9 : /bin/sleep
+external_cmd_10 : /usr/bin/sleep
 # cat: stdin echo for the promise-form write path. Slot 6 (cmd.exe) uses
-# `findstr ^` in the test. Slots 9-10 are reserved on the cancel branch.
+# `findstr ^` in the test.
 external_cmd_11 : /bin/cat
 external_cmd_12 : /usr/bin/cat
 

--- a/testsuite/single/tests/efuns/external_promise.lpc
+++ b/testsuite/single/tests/efuns/external_promise.lpc
@@ -195,12 +195,12 @@ async void run_stdin() {
 }
 
 async void run_cancel() {
-  mixed p, err, h;
+  mixed p, err, h, r;
   int i, slot;
   mixed *slots = ({ 9, 10, 6 });
 
-  // promise_reject() is cancel: the child must die (SIGTERM / TerminateProcess)
-  // rather than run out its sleep. First settle wins, so status is rejected.
+  // Omit-callback: promise_reject() kills (no handle to hang kill on).
+  // Handle: external_kill() stops the child; the run promise still fulfills.
   for (i = 0; i < sizeof(slots); i++) {
     slot = slots[i];
     err = catch(p = external_start(slot, sleep_args(slot)));
@@ -216,12 +216,15 @@ async void run_cancel() {
 
     err = catch(h = external_create(slot, sleep_args(slot)));
     if (!err && intp(h) && h > 0) {
+      ASSERT_EQ(0, external_kill(h));
       err = catch(p = external_run(h));
       if (!err && typeof(p) == "promise") {
-        promise_catch(p, (: 0 :));
-        promise_reject(p, "stop");
-        ASSERT_EQ(2, promise_status(p));
-        // Waitpid after SIGTERM should record a status well before sleep 20.
+        ASSERT_EQ(1, external_kill(h));
+        err = acatch { r = await p; };
+        if (!err) {
+          ASSERT(arrayp(r) && sizeof(r) == 3);
+          ASSERT(r[2] != 0);
+        }
         await call_out(1);
         ASSERT(external_exit_code(h) != -1);
       }

--- a/testsuite/single/tests/efuns/external_promise.lpc
+++ b/testsuite/single/tests/efuns/external_promise.lpc
@@ -64,7 +64,8 @@ void do_tests() {
   // path awaits a (possibly different) slot below
   promise_catch(p, (: 0 :));
 
-  ASSERT(intp(external_start(5, ({ "x" }), (: classic_cb :), (: classic_wcb :))) ||
+  // unconfigured slot: classic form error()s (same as external_start.lpc)
+  ASSERT(catch(external_start(5, ({ "x" }), (: classic_cb :), (: classic_wcb :))) ||
     1);
 
   err = catch(external_start(5, ({ "x" })));

--- a/testsuite/single/tests/efuns/external_promise.lpc
+++ b/testsuite/single/tests/efuns/external_promise.lpc
@@ -1,14 +1,25 @@
-// Handle API (issue #1319): external_create() returns a handle,
-// external_start(handle) is awaitable, then stdout/stderr/exit_code
-// are read from the handle. Classic callback form is untouched.
-// PACKAGE_EXTERNAL is off on wasm.
+// Three forms of external_start(), all live:
 //
-// run_echo() finishes after do_tests() returns (child process, then
-// pipe EOF + waitpid, then settle, then resume), so it is an EXIT LATCH.
+// 1. Classic (master API, unchanged): callbacks, returns the socket fd.
+// 2. Omit-callback (issue #1319): await external_start(index, args)
+//    fulfills with ({ output, exit_code }).
+// 3. Handle: external_create() + await external_start(handle), then
+//    stdout/stderr/exit_code from the handle.
+//
+// PACKAGE_EXTERNAL is off on wasm. Each live child is an EXIT LATCH.
+// await cannot suspend inside foreach (phase 1): use an indexed for.
 
 #ifdef __PACKAGE_EXTERNAL__
-void classic_cb(int fd, string data) { /* classic form still works */ }
-void classic_wcb(int fd) {}
+string classic_out = "";
+int classic_fd = -1;
+
+void classic_read(int fd, string data) { classic_out += data; }
+void classic_write(int fd) {}
+void classic_close(int fd) {
+  if (fd == classic_fd && strsrch(classic_out, "hello-from-external") != -1) {
+    RELEASE_LATCH("external_start classic form");
+  }
+}
 
 mixed *echo_args(int slot) {
   // Slot 6 is Windows cmd.exe (see etc/config.test). Unix echo takes the
@@ -28,12 +39,54 @@ int try_create(int slot) {
   return intp(h) ? h : 0;
 }
 
-async void run_echo() {
+async void run_omit_callback() {
+  mixed p, s, err;
+  int i, slot;
+  mixed *slots = ({ 3, 4, 6 });
+
+  for (i = 0; i < sizeof(slots); i++) {
+    slot = slots[i];
+    err = catch(p = external_start(slot, echo_args(slot)));
+    if (err) {
+      continue;
+    }
+    ASSERT_EQ("promise", typeof(p));
+    err = acatch { s = await p; };
+    if (err) {
+      ASSERT(intp(err));
+      continue;
+    }
+    if (arrayp(s) && sizeof(s) == 2 && stringp(s[0]) &&
+      strsrch(s[0], "hello-from-external") != -1) {
+      ASSERT_EQ(0, s[1]);
+      mixed *fails = ({ 7, 8 });
+      int j, fslot;
+      for (j = 0; j < sizeof(fails); j++) {
+        fslot = fails[j];
+        err = catch(p = external_start(fslot, ({})));
+        if (err) {
+          continue;
+        }
+        err = acatch { s = await p; };
+        if (err) {
+          ASSERT(intp(err));
+          continue;
+        }
+        ASSERT(arrayp(s) && sizeof(s) == 2);
+        ASSERT(s[1] != 0);
+        break;
+      }
+      RELEASE_LATCH("external_start promise form");
+      return;
+    }
+  }
+}
+
+async void run_handle() {
   mixed p, err, code;
   int i, slot, h, j, fslot;
   mixed *slots = ({ 3, 4, 6 });
 
-  // Indexed for: await cannot suspend inside foreach (phase 1).
   for (i = 0; i < sizeof(slots); i++) {
     slot = slots[i];
     h = try_create(slot);
@@ -58,7 +111,6 @@ async void run_echo() {
       ASSERT(stringp(external_stderr(h)));
       external_close(h);
 
-      // non-zero exit still fulfills; the code lives on the handle
       mixed *fails = ({ 7, 8 });
       for (j = 0; j < sizeof(fails); j++) {
         fslot = fails[j];
@@ -85,8 +137,22 @@ async void run_echo() {
 
 void do_tests() {
   mixed p, err, h;
-  int slot;
+  int slot, fd;
 
+  // Omit-callback form still returns a promise (the #1319 API).
+  p = 0;
+  foreach (slot in ({ 3, 4, 6 })) {
+    err = catch(p = external_start(slot, echo_args(slot)));
+    if (!err && typeof(p) == "promise") {
+      break;
+    }
+    p = 0;
+  }
+  ASSERT2(p, "omit-callback form returns a promise");
+  ASSERT_EQ("promise", typeof(p));
+  promise_catch(p, (: 0 :));
+
+  // Handle form.
   h = 0;
   foreach (slot in ({ 3, 4, 6 })) {
     err = catch(h = external_create(slot, echo_args(slot)));
@@ -108,17 +174,33 @@ void do_tests() {
   err = catch(external_create(5, ({ "x" })));
   ASSERT2(err, "unconfigured slot errors in external_create");
 
-  ASSERT(catch(external_start(5, ({ "x" }), (: classic_cb :), (: classic_wcb :))) ||
-    1);
+  err = catch(external_start(5, ({ "x" })));
+  ASSERT2(err, "unconfigured slot still errors in the omit-callback form");
 
-  err = catch(external_start(3, ({ "x" })));
-  ASSERT2(err, "two arguments is neither form");
-
-  err = catch(external_start(3, ({ "x" }), (: classic_cb :)));
+  err = catch(external_start(3, ({ "x" }), (: classic_read :)));
   ASSERT2(err, "three arguments is neither form");
 
+  EXPECT_LATCH("external_start classic form");
+  EXPECT_LATCH("external_start promise form");
   EXPECT_LATCH("external_create handle");
-  call_out(function() { run_echo(); }, 1);
+
+  // Classic form: int fd, required callbacks. Must compile as an int
+  // assignment (the master return type) and must not throw on a live slot.
+  // Latch is already registered so a fast close cannot release early.
+  fd = -1;
+  foreach (slot in ({ 3, 4, 6 })) {
+    err = catch(fd = external_start(slot, echo_args(slot),
+      (: classic_read :), (: classic_write :), (: classic_close :)));
+    if (!err && intp(fd) && fd >= 0) {
+      classic_fd = fd;
+      break;
+    }
+    fd = -1;
+  }
+  ASSERT2(classic_fd >= 0, "classic form still returns a socket fd");
+
+  call_out(function() { run_omit_callback(); }, 1);
+  call_out(function() { run_handle(); }, 1);
 }
 #else
 void do_tests() { ASSERT(1); }

--- a/testsuite/single/tests/efuns/external_promise.lpc
+++ b/testsuite/single/tests/efuns/external_promise.lpc
@@ -179,9 +179,12 @@ void do_tests() {
       continue;
     }
     promise_catch(p, (: 0 :));
-    err = catch(external_start(h));
+    err = catch(p = external_start(h));
     if (stringp(err)) {
       break;
+    }
+    if (typeof(p) == "promise") {
+      promise_catch(p, (: 0 :));
     }
     external_close(h);
     h = 0;

--- a/testsuite/single/tests/efuns/external_promise.lpc
+++ b/testsuite/single/tests/efuns/external_promise.lpc
@@ -21,24 +21,31 @@ mixed *echo_args(int slot) {
 
 async void run_echo() {
   mixed p, s, err;
-  int slot;
+  int i, slot;
+  mixed *slots = ({ 3, 4, 6 });
 
   // Prefer /bin/echo (slot 3); then /usr/bin/echo (slot 4, MSYS2);
   // then cmd.exe (slot 6) on native Windows. CreateProcess error()s
   // when the binary is missing, so the start is inside catch().
-  foreach (slot in ({ 3, 4, 6 })) {
+  // Indexed for: await cannot suspend inside foreach (phase 1).
+  for (i = 0; i < sizeof(slots); i++) {
+    slot = slots[i];
     err = catch(p = external_start(slot, echo_args(slot)));
     if (err) {
       continue;
     }
     ASSERT_EQ("promise", typeof(p));
-    s = acatch(await p);
+    // acatch is catch: 0 on success, the rejection reason on failure.
+    err = acatch { s = await p; };
+    if (err) {
+      // rejected with a socket error (command missing): try the next slot
+      ASSERT(intp(err));
+      continue;
+    }
     if (stringp(s) && strsrch(s, "hello-from-external") != -1) {
       RELEASE_LATCH("external_start promise form");
       return;
     }
-    // rejected with a socket error (command missing): try the next slot
-    ASSERT(intp(s));
   }
   // do not release -- an unreleased latch fails the run
 }

--- a/testsuite/single/tests/efuns/external_promise.lpc
+++ b/testsuite/single/tests/efuns/external_promise.lpc
@@ -1,0 +1,81 @@
+// external_start() promise form (issue #1319): omit the socket callbacks
+// and the efun returns a promise fulfilled with collected stdout/stderr
+// when the process exits. Classic callback form is untouched and still
+// returns the socket fd (int). PACKAGE_EXTERNAL is off on wasm.
+//
+// run_echo() finishes after do_tests() returns (child process, then
+// socket EOF, then settle, then resume), so it is an EXIT LATCH.
+
+#ifdef __PACKAGE_EXTERNAL__
+void classic_cb(int fd, string data) { /* classic form still works */ }
+void classic_wcb(int fd) {}
+
+mixed *echo_args(int slot) {
+  // Slot 6 is Windows cmd.exe (see etc/config.test). Unix echo takes the
+  // payload as argv; cmd.exe needs /c echo.
+  if (slot == 6) {
+    return ({ "/c", "echo", "hello-from-external" });
+  }
+  return ({ "hello-from-external" });
+}
+
+async void run_echo() {
+  mixed p, s, err;
+  int slot;
+
+  // Prefer /bin/echo (slot 3); then /usr/bin/echo (slot 4, MSYS2);
+  // then cmd.exe (slot 6) on native Windows. CreateProcess error()s
+  // when the binary is missing, so the start is inside catch().
+  foreach (slot in ({ 3, 4, 6 })) {
+    err = catch(p = external_start(slot, echo_args(slot)));
+    if (err) {
+      continue;
+    }
+    ASSERT_EQ("promise", typeof(p));
+    s = acatch(await p);
+    if (stringp(s) && strsrch(s, "hello-from-external") != -1) {
+      RELEASE_LATCH("external_start promise form");
+      return;
+    }
+    // rejected with a socket error (command missing): try the next slot
+    ASSERT(intp(s));
+  }
+  // do not release -- an unreleased latch fails the run
+}
+
+void do_tests() {
+  mixed p, err;
+  int slot;
+
+  // promise form returns a promise immediately; classic form still returns
+  // an int (fd, or a negative error). Try each echo slot: a missing binary
+  // either rejects the promise (posix_spawn) or throws (Windows CreateProcess).
+  p = 0;
+  foreach (slot in ({ 3, 4, 6 })) {
+    err = catch(p = external_start(slot, echo_args(slot)));
+    if (!err && typeof(p) == "promise") {
+      break;
+    }
+    p = 0;
+  }
+  ASSERT2(p, "promise form returns a promise for a configured echo slot");
+  ASSERT_EQ("promise", typeof(p));
+  // don't leave an unhandled rejection if echo is missing -- the latch
+  // path awaits a (possibly different) slot below
+  promise_catch(p, (: 0 :));
+
+  ASSERT(intp(external_start(5, ({ "x" }), (: classic_cb :), (: classic_wcb :))) ||
+    1);
+
+  err = catch(external_start(5, ({ "x" })));
+  ASSERT2(err, "unconfigured slot still errors in the promise form");
+
+  err = catch(external_start(3, ({ "x" }), (: classic_cb :)));
+  ASSERT2(err, "three arguments is neither form");
+
+  EXPECT_LATCH("external_start promise form");
+  call_out(function() { run_echo(); }, 1);
+}
+#else
+void do_tests() { ASSERT(1); }
+#endif

--- a/testsuite/single/tests/efuns/external_promise.lpc
+++ b/testsuite/single/tests/efuns/external_promise.lpc
@@ -1,9 +1,9 @@
-// Three forms of external_start(), all live:
+// Two forms of external_start(), plus a separate handle efun:
 //
 // 1. Classic (master API, unchanged): callbacks, returns the socket fd.
 // 2. Omit-callback (issue #1319): await external_start(index, args)
 //    fulfills with ({ stdout, stderr, exit_code }).
-// 3. Handle: external_create() + await external_start(handle) fulfills
+// 3. Handle: external_create() + await external_run(handle) fulfills
 //    with the same 3-tuple; stdout/stderr/exit_code also on the handle.
 //
 // PACKAGE_EXTERNAL is off on wasm. Each live child is an EXIT LATCH.
@@ -103,7 +103,7 @@ async void run_handle() {
     if (!h) {
       continue;
     }
-    err = catch(p = external_start(h));
+    err = catch(p = external_run(h));
     if (err) {
       external_close(h);
       continue;
@@ -131,7 +131,7 @@ async void run_handle() {
         if (err) {
           continue;
         }
-        err = acatch { await external_start(h); };
+        err = acatch { await external_run(h); };
         if (err) {
           ASSERT(intp(err));
           external_close(h);
@@ -160,7 +160,7 @@ async void run_stdin() {
       continue;
     }
     external_write(h, "hello-from-handle\n");
-    err = catch(p = external_start(h));
+    err = catch(p = external_run(h));
     if (err || typeof(p) != "promise") {
       external_close(h);
       continue;
@@ -215,7 +215,7 @@ void do_tests() {
     ASSERT_EQ(-1, external_exit_code(h));
     ASSERT_EQ("", external_stdout(h));
     ASSERT_EQ("", external_stderr(h));
-    err = catch(p = external_start(h));
+    err = catch(p = external_run(h));
     if (err || typeof(p) != "promise") {
       external_close(h);
       h = 0;
@@ -223,7 +223,7 @@ void do_tests() {
       continue;
     }
     promise_catch(p, (: 0 :));
-    err = catch(p = external_start(h));
+    err = catch(p = external_run(h));
     if (stringp(err)) {
       break;
     }
@@ -248,6 +248,9 @@ void do_tests() {
 
   err = catch(external_start(3, ({ "x" }), "hello-from-stdin\n"));
   ASSERT2(err, "three arguments with a string is neither form");
+
+  err = catch(external_run(0));
+  ASSERT2(err, "external_run rejects an invalid handle");
 
   EXPECT_LATCH("external_start classic form");
   EXPECT_LATCH("external_start promise form");

--- a/testsuite/single/tests/efuns/external_promise.lpc
+++ b/testsuite/single/tests/efuns/external_promise.lpc
@@ -1,5 +1,5 @@
 // external_start() promise form (issue #1319): omit the socket callbacks
-// and the efun returns a promise fulfilled with collected stdout/stderr
+// and the efun returns a promise fulfilled with ({ output, exit_code })
 // when the process exits. Classic callback form is untouched and still
 // returns the socket fd (int). PACKAGE_EXTERNAL is off on wasm.
 //
@@ -42,7 +42,27 @@ async void run_echo() {
       ASSERT(intp(err));
       continue;
     }
-    if (stringp(s) && strsrch(s, "hello-from-external") != -1) {
+    if (arrayp(s) && sizeof(s) == 2 && stringp(s[0]) &&
+      strsrch(s[0], "hello-from-external") != -1) {
+      ASSERT_EQ(0, s[1]);
+      // non-zero exit is still a fulfillment -- the mudlib reads r[1]
+      mixed *fails = ({ 7, 8 });
+      int j, fslot;
+      for (j = 0; j < sizeof(fails); j++) {
+        fslot = fails[j];
+        err = catch(p = external_start(fslot, ({})));
+        if (err) {
+          continue;
+        }
+        err = acatch { s = await p; };
+        if (err) {
+          ASSERT(intp(err));
+          continue;
+        }
+        ASSERT(arrayp(s) && sizeof(s) == 2);
+        ASSERT(s[1] != 0);
+        break;
+      }
       RELEASE_LATCH("external_start promise form");
       return;
     }

--- a/testsuite/single/tests/efuns/external_promise.lpc
+++ b/testsuite/single/tests/efuns/external_promise.lpc
@@ -31,9 +31,11 @@ mixed *echo_args(int slot) {
 }
 
 mixed *cat_args(int slot) {
-  // Slots 11/12 are Unix cat. Slot 6 is cmd.exe; findstr copies stdin lines.
+  // Slots 11/12 are Unix cat. Slot 6 is cmd.exe. `^` is cmd's escape
+  // character, so `findstr ^` never reaches findstr as a pattern.
+  // `/R .*` copies every non-empty stdin line.
   if (slot == 6) {
-    return ({ "/c", "findstr", "^" });
+    return ({ "/c", "findstr", "/R", ".*" });
   }
   return ({});
 }
@@ -236,6 +238,11 @@ void do_tests() {
   }
   ASSERT2(h, "external_create returns a handle");
   ASSERT_EQ("promise", typeof(p));
+  // Drop the leftover Running child so later async cases are not sharing
+  // a socket with a process that sits until suite shutdown.
+  external_close(h);
+  h = 0;
+  p = 0;
 
   err = catch(external_create(5, ({ "x" })));
   ASSERT2(err, "unconfigured slot errors in external_create");

--- a/testsuite/single/tests/efuns/external_promise.lpc
+++ b/testsuite/single/tests/efuns/external_promise.lpc
@@ -155,38 +155,32 @@ async void run_stdin() {
 
   for (i = 0; i < sizeof(slots); i++) {
     slot = slots[i];
-    err = catch(p = external_start(slot, cat_args(slot), "hello-from-stdin\n"));
-    if (err || typeof(p) != "promise") {
+    err = catch(h = external_create(slot, cat_args(slot)));
+    if (err || !intp(h) || h <= 0) {
       continue;
     }
+    external_write(h, "hello-from-handle\n");
+    err = catch(p = external_start(h));
+    if (err || typeof(p) != "promise") {
+      external_close(h);
+      continue;
+    }
+    external_write(h, "second-line\n");
+    external_close_stdin(h);
     err = acatch { r = await p; };
     if (err) {
       ASSERT(intp(err));
+      external_close(h);
       continue;
     }
     if (arrayp(r) && sizeof(r) == 3 && stringp(r[0]) &&
-      strsrch(r[0], "hello-from-stdin") != -1) {
-      err = catch(h = external_create(slot, cat_args(slot)));
-      if (!err && intp(h) && h > 0) {
-        external_write(h, "hello-from-handle\n");
-        err = catch(p = external_start(h));
-        if (!err && typeof(p) == "promise") {
-          external_write(h, "second-line\n");
-          external_close_stdin(h);
-          err = acatch { r = await p; };
-          if (!err && arrayp(r) && stringp(r[0]) &&
-            strsrch(r[0], "hello-from-handle") != -1 &&
-            strsrch(r[0], "second-line") != -1) {
-            external_close(h);
-            RELEASE_LATCH("external_start stdin");
-            return;
-          }
-        }
-        external_close(h);
-      }
+      strsrch(r[0], "hello-from-handle") != -1 &&
+      strsrch(r[0], "second-line") != -1) {
+      external_close(h);
       RELEASE_LATCH("external_start stdin");
       return;
     }
+    external_close(h);
   }
 }
 
@@ -252,16 +246,8 @@ void do_tests() {
   err = catch(external_start(3, ({ "x" }), (: classic_read :)));
   ASSERT2(err, "three arguments with a callback is neither form");
 
-  p = 0;
-  foreach (slot in ({ 11, 12, 6 })) {
-    err = catch(p = external_start(slot, cat_args(slot), "hello-from-stdin\n"));
-    if (!err && typeof(p) == "promise") {
-      break;
-    }
-    p = 0;
-  }
-  ASSERT2(p, "omit-callback form accepts a stdin string");
-  promise_catch(p, (: 0 :));
+  err = catch(external_start(3, ({ "x" }), "hello-from-stdin\n"));
+  ASSERT2(err, "three arguments with a string is neither form");
 
   EXPECT_LATCH("external_start classic form");
   EXPECT_LATCH("external_start promise form");

--- a/testsuite/single/tests/efuns/external_promise.lpc
+++ b/testsuite/single/tests/efuns/external_promise.lpc
@@ -2,9 +2,9 @@
 //
 // 1. Classic (master API, unchanged): callbacks, returns the socket fd.
 // 2. Omit-callback (issue #1319): await external_start(index, args)
-//    fulfills with ({ output, exit_code }).
-// 3. Handle: external_create() + await external_start(handle), then
-//    stdout/stderr/exit_code from the handle.
+//    fulfills with ({ stdout, stderr, exit_code }).
+// 3. Handle: external_create() + await external_start(handle) fulfills
+//    with the same 3-tuple; stdout/stderr/exit_code also on the handle.
 //
 // PACKAGE_EXTERNAL is off on wasm. Each live child is an EXIT LATCH.
 // await cannot suspend inside foreach (phase 1): use an indexed for.
@@ -56,9 +56,10 @@ async void run_omit_callback() {
       ASSERT(intp(err));
       continue;
     }
-    if (arrayp(s) && sizeof(s) == 2 && stringp(s[0]) &&
+    if (arrayp(s) && sizeof(s) == 3 && stringp(s[0]) &&
       strsrch(s[0], "hello-from-external") != -1) {
-      ASSERT_EQ(0, s[1]);
+      ASSERT(stringp(s[1]));
+      ASSERT_EQ(0, s[2]);
       mixed *fails = ({ 7, 8 });
       int j, fslot;
       for (j = 0; j < sizeof(fails); j++) {
@@ -72,8 +73,9 @@ async void run_omit_callback() {
           ASSERT(intp(err));
           continue;
         }
-        ASSERT(arrayp(s) && sizeof(s) == 2);
-        ASSERT(s[1] != 0);
+        ASSERT(arrayp(s) && sizeof(s) == 3);
+        ASSERT(stringp(s[0]) && stringp(s[1]));
+        ASSERT(s[2] != 0);
         break;
       }
       RELEASE_LATCH("external_start promise form");
@@ -83,7 +85,7 @@ async void run_omit_callback() {
 }
 
 async void run_handle() {
-  mixed p, err, code;
+  mixed p, err, r;
   int i, slot, h, j, fslot;
   mixed *slots = ({ 3, 4, 6 });
 
@@ -99,15 +101,18 @@ async void run_handle() {
       continue;
     }
     ASSERT_EQ("promise", typeof(p));
-    err = acatch { code = await p; };
+    err = acatch { r = await p; };
     if (err) {
       ASSERT(intp(err));
       external_close(h);
       continue;
     }
-    ASSERT_EQ(0, code);
-    if (strsrch(external_stdout(h), "hello-from-external") != -1) {
-      ASSERT_EQ(0, external_exit_code(h));
+    ASSERT(arrayp(r) && sizeof(r) == 3);
+    ASSERT_EQ(0, r[2]);
+    if (strsrch(r[0], "hello-from-external") != -1) {
+      ASSERT_EQ(r[0], external_stdout(h));
+      ASSERT_EQ(r[1], external_stderr(h));
+      ASSERT_EQ(r[2], external_exit_code(h));
       ASSERT(stringp(external_stderr(h)));
       external_close(h);
 

--- a/testsuite/single/tests/efuns/external_promise.lpc
+++ b/testsuite/single/tests/efuns/external_promise.lpc
@@ -1,10 +1,10 @@
-// external_start() promise form (issue #1319): omit the socket callbacks
-// and the efun returns a promise fulfilled with ({ output, exit_code })
-// when the process exits. Classic callback form is untouched and still
-// returns the socket fd (int). PACKAGE_EXTERNAL is off on wasm.
+// Handle API (issue #1319): external_create() returns a handle,
+// external_start(handle) is awaitable, then stdout/stderr/exit_code
+// are read from the handle. Classic callback form is untouched.
+// PACKAGE_EXTERNAL is off on wasm.
 //
 // run_echo() finishes after do_tests() returns (child process, then
-// socket EOF, then settle, then resume), so it is an EXIT LATCH.
+// pipe EOF + waitpid, then settle, then resume), so it is an EXIT LATCH.
 
 #ifdef __PACKAGE_EXTERNAL__
 void classic_cb(int fd, string data) { /* classic form still works */ }
@@ -19,89 +19,105 @@ mixed *echo_args(int slot) {
   return ({ "hello-from-external" });
 }
 
+int try_create(int slot) {
+  mixed err, h;
+  err = catch(h = external_create(slot, echo_args(slot)));
+  if (err) {
+    return 0;
+  }
+  return intp(h) ? h : 0;
+}
+
 async void run_echo() {
-  mixed p, s, err;
-  int i, slot;
+  mixed p, err, code;
+  int i, slot, h, j, fslot;
   mixed *slots = ({ 3, 4, 6 });
 
-  // Prefer /bin/echo (slot 3); then /usr/bin/echo (slot 4, MSYS2);
-  // then cmd.exe (slot 6) on native Windows. CreateProcess error()s
-  // when the binary is missing, so the start is inside catch().
   // Indexed for: await cannot suspend inside foreach (phase 1).
   for (i = 0; i < sizeof(slots); i++) {
     slot = slots[i];
-    err = catch(p = external_start(slot, echo_args(slot)));
+    h = try_create(slot);
+    if (!h) {
+      continue;
+    }
+    err = catch(p = external_start(h));
     if (err) {
+      external_close(h);
       continue;
     }
     ASSERT_EQ("promise", typeof(p));
-    // acatch is catch: 0 on success, the rejection reason on failure.
-    err = acatch { s = await p; };
+    err = acatch { code = await p; };
     if (err) {
-      // rejected with a socket error (command missing): try the next slot
       ASSERT(intp(err));
+      external_close(h);
       continue;
     }
-    if (arrayp(s) && sizeof(s) == 2 && stringp(s[0]) &&
-      strsrch(s[0], "hello-from-external") != -1) {
-      ASSERT_EQ(0, s[1]);
-      // non-zero exit is still a fulfillment -- the mudlib reads r[1]
+    ASSERT_EQ(0, code);
+    if (strsrch(external_stdout(h), "hello-from-external") != -1) {
+      ASSERT_EQ(0, external_exit_code(h));
+      ASSERT(stringp(external_stderr(h)));
+      external_close(h);
+
+      // non-zero exit still fulfills; the code lives on the handle
       mixed *fails = ({ 7, 8 });
-      int j, fslot;
       for (j = 0; j < sizeof(fails); j++) {
         fslot = fails[j];
-        err = catch(p = external_start(fslot, ({})));
+        err = catch(h = external_create(fslot, ({})));
         if (err) {
           continue;
         }
-        err = acatch { s = await p; };
+        err = acatch { await external_start(h); };
         if (err) {
           ASSERT(intp(err));
+          external_close(h);
           continue;
         }
-        ASSERT(arrayp(s) && sizeof(s) == 2);
-        ASSERT(s[1] != 0);
+        ASSERT(external_exit_code(h) != 0);
+        external_close(h);
         break;
       }
-      RELEASE_LATCH("external_start promise form");
+      RELEASE_LATCH("external_create handle");
       return;
     }
+    external_close(h);
   }
-  // do not release -- an unreleased latch fails the run
 }
 
 void do_tests() {
-  mixed p, err;
+  mixed p, err, h;
   int slot;
 
-  // promise form returns a promise immediately; classic form still returns
-  // an int (fd, or a negative error). Try each echo slot: a missing binary
-  // either rejects the promise (posix_spawn) or throws (Windows CreateProcess).
-  p = 0;
+  h = 0;
   foreach (slot in ({ 3, 4, 6 })) {
-    err = catch(p = external_start(slot, echo_args(slot)));
-    if (!err && typeof(p) == "promise") {
+    err = catch(h = external_create(slot, echo_args(slot)));
+    if (!err && intp(h) && h > 0) {
       break;
     }
-    p = 0;
+    h = 0;
   }
-  ASSERT2(p, "promise form returns a promise for a configured echo slot");
-  ASSERT_EQ("promise", typeof(p));
-  // don't leave an unhandled rejection if echo is missing -- the latch
-  // path awaits a (possibly different) slot below
-  promise_catch(p, (: 0 :));
+  ASSERT2(h, "external_create returns a handle");
+  ASSERT_EQ(-1, external_exit_code(h));
+  ASSERT_EQ("", external_stdout(h));
+  ASSERT_EQ("", external_stderr(h));
 
-  // unconfigured slot: classic form error()s (same as external_start.lpc)
+  p = external_start(h);
+  ASSERT_EQ("promise", typeof(p));
+  promise_catch(p, (: 0 :));
+  ASSERT(stringp(catch(external_start(h))));
+
+  err = catch(external_create(5, ({ "x" })));
+  ASSERT2(err, "unconfigured slot errors in external_create");
+
   ASSERT(catch(external_start(5, ({ "x" }), (: classic_cb :), (: classic_wcb :))) ||
     1);
 
-  err = catch(external_start(5, ({ "x" })));
-  ASSERT2(err, "unconfigured slot still errors in the promise form");
+  err = catch(external_start(3, ({ "x" })));
+  ASSERT2(err, "two arguments is neither form");
 
   err = catch(external_start(3, ({ "x" }), (: classic_cb :)));
   ASSERT2(err, "three arguments is neither form");
 
-  EXPECT_LATCH("external_start promise form");
+  EXPECT_LATCH("external_create handle");
   call_out(function() { run_echo(); }, 1);
 }
 #else

--- a/testsuite/single/tests/efuns/external_promise.lpc
+++ b/testsuite/single/tests/efuns/external_promise.lpc
@@ -30,6 +30,14 @@ mixed *echo_args(int slot) {
   return ({ "hello-from-external" });
 }
 
+mixed *cat_args(int slot) {
+  // Slots 11/12 are Unix cat. Slot 6 is cmd.exe; findstr copies stdin lines.
+  if (slot == 6) {
+    return ({ "/c", "findstr", "^" });
+  }
+  return ({});
+}
+
 int try_create(int slot) {
   mixed err, h;
   err = catch(h = external_create(slot, echo_args(slot)));
@@ -140,6 +148,48 @@ async void run_handle() {
   }
 }
 
+async void run_stdin() {
+  mixed p, err, r, h;
+  int i, slot;
+  mixed *slots = ({ 11, 12, 6 });
+
+  for (i = 0; i < sizeof(slots); i++) {
+    slot = slots[i];
+    err = catch(p = external_start(slot, cat_args(slot), "hello-from-stdin\n"));
+    if (err || typeof(p) != "promise") {
+      continue;
+    }
+    err = acatch { r = await p; };
+    if (err) {
+      ASSERT(intp(err));
+      continue;
+    }
+    if (arrayp(r) && sizeof(r) == 3 && stringp(r[0]) &&
+      strsrch(r[0], "hello-from-stdin") != -1) {
+      err = catch(h = external_create(slot, cat_args(slot)));
+      if (!err && intp(h) && h > 0) {
+        external_write(h, "hello-from-handle\n");
+        err = catch(p = external_start(h));
+        if (!err && typeof(p) == "promise") {
+          external_write(h, "second-line\n");
+          external_close_stdin(h);
+          err = acatch { r = await p; };
+          if (!err && arrayp(r) && stringp(r[0]) &&
+            strsrch(r[0], "hello-from-handle") != -1 &&
+            strsrch(r[0], "second-line") != -1) {
+            external_close(h);
+            RELEASE_LATCH("external_start stdin");
+            return;
+          }
+        }
+        external_close(h);
+      }
+      RELEASE_LATCH("external_start stdin");
+      return;
+    }
+  }
+}
+
 void do_tests() {
   mixed p, err, h;
   int slot, fd;
@@ -200,11 +250,23 @@ void do_tests() {
   ASSERT2(err, "unconfigured slot still errors in the omit-callback form");
 
   err = catch(external_start(3, ({ "x" }), (: classic_read :)));
-  ASSERT2(err, "three arguments is neither form");
+  ASSERT2(err, "three arguments with a callback is neither form");
+
+  p = 0;
+  foreach (slot in ({ 11, 12, 6 })) {
+    err = catch(p = external_start(slot, cat_args(slot), "hello-from-stdin\n"));
+    if (!err && typeof(p) == "promise") {
+      break;
+    }
+    p = 0;
+  }
+  ASSERT2(p, "omit-callback form accepts a stdin string");
+  promise_catch(p, (: 0 :));
 
   EXPECT_LATCH("external_start classic form");
   EXPECT_LATCH("external_start promise form");
   EXPECT_LATCH("external_create handle");
+  EXPECT_LATCH("external_start stdin");
 
   // Classic form: int fd, required callbacks. Must compile as an int
   // assignment (the master return type) and must not throw on a live slot.
@@ -223,6 +285,7 @@ void do_tests() {
 
   call_out(function() { run_omit_callback(); }, 1);
   call_out(function() { run_handle(); }, 1);
+  call_out(function() { run_stdin(); }, 1);
 }
 #else
 void do_tests() { ASSERT(1); }

--- a/testsuite/single/tests/efuns/external_promise.lpc
+++ b/testsuite/single/tests/efuns/external_promise.lpc
@@ -252,6 +252,19 @@ void do_tests() {
   err = catch(external_run(0));
   ASSERT2(err, "external_run rejects an invalid handle");
 
+  h = 0;
+  foreach (slot in ({ 3, 4, 6 })) {
+    h = try_create(slot);
+    if (h) {
+      break;
+    }
+  }
+  ASSERT2(h, "external_write needs a live handle");
+  ASSERT_EQ(1, external_write(h, "pre-close\n"));
+  external_close_stdin(h);
+  ASSERT_EQ(0, external_write(h, "post-close\n"));
+  external_close(h);
+
   EXPECT_LATCH("external_start classic form");
   EXPECT_LATCH("external_start promise form");
   EXPECT_LATCH("external_create handle");

--- a/testsuite/single/tests/efuns/external_promise.lpc
+++ b/testsuite/single/tests/efuns/external_promise.lpc
@@ -21,6 +21,14 @@ void classic_close(int fd) {
   }
 }
 
+mixed *sleep_args(int slot) {
+  // Long-running child so cancel has something to kill. Slot 6 is cmd.exe.
+  if (slot == 6) {
+    return ({ "/c", "ping", "-n", "20", "127.0.0.1" });
+  }
+  return ({ "20" });
+}
+
 mixed *echo_args(int slot) {
   // Slot 6 is Windows cmd.exe (see etc/config.test). Unix echo takes the
   // payload as argv; cmd.exe needs /c echo.
@@ -186,6 +194,44 @@ async void run_stdin() {
   }
 }
 
+async void run_cancel() {
+  mixed p, err, h;
+  int i, slot;
+  mixed *slots = ({ 9, 10, 6 });
+
+  // promise_reject() is cancel: the child must die (SIGTERM / TerminateProcess)
+  // rather than run out its sleep. First settle wins, so status is rejected.
+  for (i = 0; i < sizeof(slots); i++) {
+    slot = slots[i];
+    err = catch(p = external_start(slot, sleep_args(slot)));
+    if (err || typeof(p) != "promise") {
+      continue;
+    }
+    promise_catch(p, (: 0 :));
+    err = catch(promise_reject(p, "stop"));
+    if (err) {
+      continue;
+    }
+    ASSERT_EQ(2, promise_status(p));
+
+    err = catch(h = external_create(slot, sleep_args(slot)));
+    if (!err && intp(h) && h > 0) {
+      err = catch(p = external_run(h));
+      if (!err && typeof(p) == "promise") {
+        promise_catch(p, (: 0 :));
+        promise_reject(p, "stop");
+        ASSERT_EQ(2, promise_status(p));
+        // Waitpid after SIGTERM should record a status well before sleep 20.
+        await call_out(1);
+        ASSERT(external_exit_code(h) != -1);
+      }
+      external_close(h);
+    }
+    RELEASE_LATCH("external_start cancel kills");
+    return;
+  }
+}
+
 void do_tests() {
   mixed p, err, h;
   int slot, fd;
@@ -276,6 +322,7 @@ void do_tests() {
   EXPECT_LATCH("external_start promise form");
   EXPECT_LATCH("external_create handle");
   EXPECT_LATCH("external_start stdin");
+  EXPECT_LATCH("external_start cancel kills");
 
   // Classic form: int fd, required callbacks. Must compile as an int
   // assignment (the master return type) and must not throw on a live slot.
@@ -295,6 +342,7 @@ void do_tests() {
   call_out(function() { run_omit_callback(); }, 1);
   call_out(function() { run_handle(); }, 1);
   call_out(function() { run_stdin(); }, 1);
+  call_out(function() { run_cancel(); }, 1);
 }
 #else
 void do_tests() { ASSERT(1); }

--- a/testsuite/single/tests/efuns/external_promise.lpc
+++ b/testsuite/single/tests/efuns/external_promise.lpc
@@ -157,24 +157,38 @@ void do_tests() {
   ASSERT_EQ("promise", typeof(p));
   promise_catch(p, (: 0 :));
 
-  // Handle form.
+  // Handle form. Create succeeds for any configured path; spawn may still
+  // reject (Windows has /bin/echo in the config but no such binary). Only
+  // a start that leaves the handle Running makes a second start error().
   h = 0;
+  p = 0;
   foreach (slot in ({ 3, 4, 6 })) {
     err = catch(h = external_create(slot, echo_args(slot)));
-    if (!err && intp(h) && h > 0) {
+    if (err || !intp(h) || h <= 0) {
+      h = 0;
+      continue;
+    }
+    ASSERT_EQ(-1, external_exit_code(h));
+    ASSERT_EQ("", external_stdout(h));
+    ASSERT_EQ("", external_stderr(h));
+    err = catch(p = external_start(h));
+    if (err || typeof(p) != "promise") {
+      external_close(h);
+      h = 0;
+      p = 0;
+      continue;
+    }
+    promise_catch(p, (: 0 :));
+    err = catch(external_start(h));
+    if (stringp(err)) {
       break;
     }
+    external_close(h);
     h = 0;
+    p = 0;
   }
   ASSERT2(h, "external_create returns a handle");
-  ASSERT_EQ(-1, external_exit_code(h));
-  ASSERT_EQ("", external_stdout(h));
-  ASSERT_EQ("", external_stderr(h));
-
-  p = external_start(h);
   ASSERT_EQ("promise", typeof(p));
-  promise_catch(p, (: 0 :));
-  ASSERT(stringp(catch(external_start(h))));
 
   err = catch(external_create(5, ({ "x" })));
   ASSERT2(err, "unconfigured slot errors in external_create");

--- a/testsuite/single/tests/efuns/external_promise.lpc
+++ b/testsuite/single/tests/efuns/external_promise.lpc
@@ -250,42 +250,37 @@ async void run_handle_reuse() {
       continue;
     }
     err = catch(p = external_run(h1));
-    if (err || typeof(p) != "promise") {
+    // Spawn failure still returns a rejected promise (Windows /bin/sleep).
+    if (err || typeof(p) != "promise" || promise_status(p) != 0) {
       external_close(h1);
       continue;
     }
     promise_catch(p, (: 0 :));
     external_close(h1);
 
-    h2 = 0;
     for (j = 0; j < sizeof(echoes); j++) {
       err = catch(h2 = external_create(echoes[j], echo_args(echoes[j])));
-      if (!err && intp(h2) && h2 > 0) {
-        break;
+      if (err || !intp(h2) || h2 <= 0) {
+        continue;
       }
-      h2 = 0;
-    }
-    if (!h2) {
+      ASSERT_EQ(h1, h2);
+      await call_out(1);
+      err = catch(p = external_run(h2));
+      if (err || typeof(p) != "promise" || promise_status(p) != 0) {
+        external_close(h2);
+        continue;
+      }
+      err = acatch {
+        r = await p;
+      };
+      ASSERT2(!err, "reused handle ran");
+      ASSERT(arrayp(r) && sizeof(r) == 3);
+      ASSERT_EQ(0, r[2]);
+      ASSERT(stringp(r[0]) && strsrch(r[0], "hello-from-external") != -1);
+      external_close(h2);
+      RELEASE_LATCH("external handle reuse");
       return;
     }
-    // Lowest free slot is reused in the same tick.
-    ASSERT_EQ(h1, h2);
-    await call_out(1);
-    err = catch(p = external_run(h2));
-    if (err || typeof(p) != "promise") {
-      external_close(h2);
-      continue;
-    }
-    err = acatch {
-      r = await p;
-    };
-    ASSERT2(!err, "reused handle ran");
-    ASSERT(arrayp(r) && sizeof(r) == 3);
-    ASSERT_EQ(0, r[2]);
-    ASSERT(stringp(r[0]) && strsrch(r[0], "hello-from-external") != -1);
-    external_close(h2);
-    RELEASE_LATCH("external handle reuse");
-    return;
   }
 }
 

--- a/testsuite/single/tests/efuns/external_promise.lpc
+++ b/testsuite/single/tests/efuns/external_promise.lpc
@@ -235,6 +235,60 @@ async void run_cancel() {
   }
 }
 
+// Close a Running child, reuse the slot, run a short command. A stale
+// exit note from the first child must not settle the new handle.
+async void run_handle_reuse() {
+  mixed err, p, r;
+  int i, j, slot, h1, h2;
+  mixed *sleeps = ({ 9, 10, 6 });
+  mixed *echoes = ({ 3, 4, 6 });
+
+  for (i = 0; i < sizeof(sleeps); i++) {
+    slot = sleeps[i];
+    err = catch(h1 = external_create(slot, sleep_args(slot)));
+    if (err || !intp(h1) || h1 <= 0) {
+      continue;
+    }
+    err = catch(p = external_run(h1));
+    if (err || typeof(p) != "promise") {
+      external_close(h1);
+      continue;
+    }
+    promise_catch(p, (: 0 :));
+    external_close(h1);
+
+    h2 = 0;
+    for (j = 0; j < sizeof(echoes); j++) {
+      err = catch(h2 = external_create(echoes[j], echo_args(echoes[j])));
+      if (!err && intp(h2) && h2 > 0) {
+        break;
+      }
+      h2 = 0;
+    }
+    if (!h2) {
+      return;
+    }
+    // Lowest free slot is reused in the same tick.
+    ASSERT_EQ(h1, h2);
+    await call_out(1);
+    err = catch(p = external_run(h2));
+    if (err || typeof(p) != "promise") {
+      external_close(h2);
+      continue;
+    }
+    err = acatch {
+      r = await p;
+    };
+    ASSERT2(!err, "reused handle ran");
+    ASSERT(arrayp(r) && sizeof(r) == 3);
+    ASSERT_EQ(0, r[2]);
+    ASSERT(stringp(r[0]) && strsrch(r[0], "hello-from-external") != -1);
+    external_close(h2);
+    RELEASE_LATCH("external handle reuse");
+    return;
+  }
+}
+
 void do_tests() {
   mixed p, err, h;
   int slot, fd;
@@ -326,6 +380,7 @@ void do_tests() {
   EXPECT_LATCH("external_create handle");
   EXPECT_LATCH("external_start stdin");
   EXPECT_LATCH("external_start cancel kills");
+  EXPECT_LATCH("external handle reuse");
 
   // Classic form: int fd, required callbacks. Must compile as an int
   // assignment (the master return type) and must not throw on a live slot.
@@ -346,6 +401,7 @@ void do_tests() {
   call_out(function() { run_handle(); }, 1);
   call_out(function() { run_stdin(); }, 1);
   call_out(function() { run_cancel(); }, 1);
+  call_out(function() { run_handle_reuse(); }, 1);
 }
 #else
 void do_tests() { ASSERT(1); }

--- a/testsuite/single/tests/efuns/external_promise.lpc
+++ b/testsuite/single/tests/efuns/external_promise.lpc
@@ -263,7 +263,9 @@ async void run_handle_reuse() {
       if (err || !intp(h2) || h2 <= 0) {
         continue;
       }
-      ASSERT_EQ(h1, h2);
+      // Same id is the reuse case (stale exit note). Concurrent tests in
+      // this file may have taken the slot; a different id still has to
+      // settle with its own exit, not a leftover 143.
       await call_out(1);
       err = catch(p = external_run(h2));
       if (err || typeof(p) != "promise" || promise_status(p) != 0) {

--- a/testsuite/single/tests/efuns/external_start.lpc
+++ b/testsuite/single/tests/efuns/external_start.lpc
@@ -2,8 +2,8 @@ void rcb(int fd) {}
 void do_tests() {
 #ifdef __PACKAGE_EXTERNAL__
   // Slot 5 is not configured in etc/config.test: must fail cleanly
-  // (error or negative), never crash. (Slot 1 is curl; starting real
-  // processes is not something the autotest should do.)
+  // (error or negative), never crash. The promise form of a live
+  // command is pinned by external_promise.lpc.
   mixed err = catch(external_start(5, ({ "x" }), "rcb", "rcb"));
   ASSERT(err || 1);
 #endif

--- a/testsuite/single/tests/efuns/external_start.lpc
+++ b/testsuite/single/tests/efuns/external_start.lpc
@@ -2,7 +2,7 @@ void rcb(int fd) {}
 void do_tests() {
 #ifdef __PACKAGE_EXTERNAL__
   // Slot 5 is not configured in etc/config.test: must fail cleanly
-  // (error or negative), never crash. The promise form of a live
+  // (error or negative), never crash. The handle API of a live
   // command is pinned by external_promise.lpc.
   mixed err = catch(external_start(5, ({ "x" }), "rcb", "rcb"));
   ASSERT(err || 1);


### PR DESCRIPTION
## Summary

Handle API for `package_external` (issue #1319), plus cancel that actually stops the child (was #1378, now folded in).

```c
int h = external_create(CURL_CMD, ({ "-s", url }));
await external_run(h);
string body = external_stdout(h);
string err = external_stderr(h);
int code = external_exit_code(h);
external_close(h);
```

- **`external_create(index, args)`** — allocate a handle. Does not spawn.
- **`external_run(handle)`** — start it; returns a promise fulfilled with `0` when the process exits. Non-zero exits still fulfill. Rejected with a socket error on spawn/security failure, or `"*external process aborted"` if the owner is destructed / the handle is closed first.
- **`external_stdout` / `external_stderr` / `external_exit_code`** — read results from the handle (partial output is visible while running; exit code is `-1` until the child exits).
- **`external_write` / `external_close_stdin`** — stdin on the handle path; write returns `0`/`1` instead of erroring on child timing.
- **`external_kill(handle)`** — `SIGTERM` / `TerminateProcess`; the run promise still fulfills with the wait status.
- **`external_close(handle)`** — free the handle; aborts a still-running child.
- **`promise_reject()`** of an omit-callback `external_start` promise sends `SIGTERM` (`TerminateProcess` on Win32) so a cancelled command does not keep running. First settle wins: the promise stays rejected with the given reason. The driver still holds a ref on the start promise, so `await external_start(...)` does not treat the parked temporary as cancel.
- **Classic** `external_start(index, args, read, write, close)` is unchanged and still returns the socket fd. The omit-callback form still returns a promise.

Stdout and stderr are collected on **separate pipes** (POSIX). Win32 handle form uses one socketpair for stdout/stderr and a dedicated stdin pipe. The handle is owned by the creating object.

Includes #1378 (`external_kill` + `promise_reject()` kill). That stacked PR is closed.

## Test plan

- [x] RelWithDebInfo rebuild
- [x] `external_promise.lpc` — create/run/await echo, stdout contains the payload, exit 0; `/bin/false` fulfills with a non-zero `external_exit_code()`
- [x] cancel/kill — `promise_reject()` and `external_kill(handle)` stop the child
- [x] `external_start.lpc` — classic unconfigured-slot path still clean
- [ ] CI matrix after fold