### PR TITLE
external: promise_reject() kills the child process

### DIFF
--- a/docs/concepts/general/async.md
+++ b/docs/concepts/general/async.md
@@ -386,7 +386,8 @@ rejected with the failure value (e.g. `async_read`'s negative int) —
 `({ stdout, stderr, exit_code })` when the process exits (a non-zero
 exit still fulfills), or rejected with a socket error /
 `"*external process aborted"`. The child is started with
-`posix_spawn()` (Win32: `CreateProcess`). The classic
+`posix_spawn()` (Win32: `CreateProcess`). `promise_reject` of that
+promise, or of `external_run(handle)`'s promise, kills the child. The classic
 `external_start(index, args, read, write, close)` form is unchanged and
 still returns the socket fd.
 

--- a/docs/concepts/general/async.md
+++ b/docs/concepts/general/async.md
@@ -168,7 +168,9 @@ differs from JS: there, settling an already-settled promise is a silent
 no-op, which is what lets `Promise.race` be written in userland. Here it is
 an **error**, so the unguarded version throws on whichever of the two paths
 finishes second — the common case, not a rare one. Note also that the
-underlying work is not stopped by either shape; only your wait ends.
+underlying work is not stopped by either shape; only your wait ends
+(exception: `promise_reject` of an `external_start` / `external_run`
+promise kills the child; `external_kill(handle)` is the handle form).
 
 `return value` fulfills the promise (a returned promise is adopted). An
 uncaught error inside the body rejects it — an async body behaves as if
@@ -387,7 +389,8 @@ rejected with the failure value (e.g. `async_read`'s negative int) —
 exit still fulfills), or rejected with a socket error /
 `"*external process aborted"`. The child is started with
 `posix_spawn()` (Win32: `CreateProcess`). `promise_reject` of that
-promise, or of `external_run(handle)`'s promise, kills the child. The classic
+promise kills the child. A handle is stopped with `external_kill(h)`
+(keep the result) or `external_close(h)` (discard). The classic
 `external_start(index, args, read, write, close)` form is unchanged and
 still returns the socket fd.
 

--- a/docs/efun/external/external_close.md
+++ b/docs/efun/external/external_close.md
@@ -20,4 +20,4 @@ title: external / external_close
 
 ### SEE ALSO
 
-    external_create(3), external_run(3)
+    external_create(3), external_run(3), external_kill(3)

--- a/docs/efun/external/external_create.md
+++ b/docs/efun/external/external_create.md
@@ -37,7 +37,8 @@ title: external / external_create
 
 ### SEE ALSO
 
-    external_run(3), external_start(3), external_write(3),
+    external_run(3), external_kill(3), external_start(3),
+    external_write(3),
     external_close_stdin(3),
     external_stdout(3), external_stderr(3),
     external_exit_code(3), external_close(3)

--- a/docs/efun/external/external_kill.md
+++ b/docs/efun/external/external_kill.md
@@ -1,0 +1,43 @@
+---
+title: external / external_kill
+---
+# external_kill
+
+### NAME
+
+    external_kill() - stop an external command, keep the handle
+
+### SYNOPSIS
+
+    int external_kill(int handle);
+
+### DESCRIPTION
+
+    Send `SIGTERM` to a running child (`TerminateProcess` with status
+    `143` on Win32, the same as `128 + SIGTERM`). Returns `1` if a
+    signal was sent, `0` if the handle is not running (Created or
+    already exited). Errors only if the handle is invalid or not owned
+    by this object.
+
+    The run promise is not rejected. It fulfills when the child
+    actually exits, with `({ stdout, stderr, exit_code })` — typically
+    `r[2] == 143`. Partial output stays on the handle.
+
+        int h = external_create(SLEEP_CMD, ({ "20" }));
+        mixed p = external_run(h);
+        call_out((: external_kill, h :), 10);
+        mixed *r = await p;
+        external_close(h);
+
+    `external_close(h)` also kills a running child, but frees the
+    handle and rejects the run promise with `"*external process
+    aborted"`. Use `external_kill` when you still want the result.
+
+    The omit-callback form has no handle: `promise_reject(p, reason)`
+    of that start promise kills the child. `with_timeout()` rejects a
+    gate and does **not** kill the child.
+
+### SEE ALSO
+
+    external_run(3), external_close(3), external_start(3),
+    promise_reject(3)

--- a/docs/efun/external/external_run.md
+++ b/docs/efun/external/external_run.md
@@ -37,6 +37,12 @@ title: external / external_run
     A handle can be run only once. Use `external_start(index, args)`
     when there is no handle.
 
+    Cancelling the run promise with `promise_reject(p)` (first settle
+    wins) kills the child (`SIGTERM` / `TerminateProcess`).
+    `external_close(h)` and destructing the owner do the same. A
+    non-zero exit from the kill (`128 + SIGTERM` on POSIX) is not
+    reported on a cancelled promise -- the promise is already rejected.
+
 ### SEE ALSO
 
     external_create(3), external_start(3), external_write(3),

--- a/docs/efun/external/external_run.md
+++ b/docs/efun/external/external_run.md
@@ -37,14 +37,18 @@ title: external / external_run
     A handle can be run only once. Use `external_start(index, args)`
     when there is no handle.
 
-    Cancelling the run promise with `promise_reject(p)` (first settle
-    wins) kills the child (`SIGTERM` / `TerminateProcess`).
-    `external_close(h)` and destructing the owner do the same. A
-    non-zero exit from the kill (`128 + SIGTERM` on POSIX) is not
-    reported on a cancelled promise -- the promise is already rejected.
+### CANCELLING
+
+    `external_kill(h)` stops the child and keeps the handle: the run
+    promise still fulfills with `({ stdout, stderr, 143 })`.
+    `external_close(h)` stops the child, frees the handle, and rejects
+    the run promise with `"*external process aborted"`. Destructing
+    the owner does the same as `external_close`.
+    `promise_reject(p)` of the run promise also kills the child; the
+    promise stays rejected with the given reason.
 
 ### SEE ALSO
 
-    external_create(3), external_start(3), external_write(3),
-    external_close_stdin(3), external_stdout(3), external_stderr(3),
-    external_exit_code(3), external_close(3)
+    external_create(3), external_start(3), external_kill(3),
+    external_write(3), external_close_stdin(3), external_stdout(3),
+    external_stderr(3), external_exit_code(3), external_close(3)

--- a/docs/efun/external/external_start.md
+++ b/docs/efun/external/external_start.md
@@ -55,6 +55,12 @@ title: external / external_start
     A handle from `external_create()` is started with `external_run()`,
     not this efun. See [external_run](/efun/external/external_run).
 
+    Cancelling the start promise with `promise_reject(p)` (first settle
+    wins) kills the child (`SIGTERM` / `TerminateProcess`).
+    `external_close(h)` and destructing the owner do the same. A
+    non-zero exit from the kill (`128 + SIGTERM` on POSIX) is not
+    reported on a cancelled promise -- the promise is already rejected.
+
 ### RUNTIME CONFIGURATION
 
     You can configure your runtime configuration to know about various external

--- a/docs/efun/external/external_start.md
+++ b/docs/efun/external/external_start.md
@@ -55,11 +55,16 @@ title: external / external_start
     A handle from `external_create()` is started with `external_run()`,
     not this efun. See [external_run](/efun/external/external_run).
 
-    Cancelling the start promise with `promise_reject(p)` (first settle
-    wins) kills the child (`SIGTERM` / `TerminateProcess`).
-    `external_close(h)` and destructing the owner do the same. A
-    non-zero exit from the kill (`128 + SIGTERM` on POSIX) is not
-    reported on a cancelled promise -- the promise is already rejected.
+### CANCELLING
+
+    This form has no handle. `promise_reject(p, reason)` of the start
+    promise kills the child; `p` stays rejected with `reason`. That is
+    the one driver promise where rejecting also stops the work.
+    `with_timeout()` rejects a gate and does **not** kill the child.
+
+    For a handle, use `external_kill(h)` (stop, keep the result) or
+    `external_close(h)` (stop, discard). See
+    [external_kill](/efun/external/external_kill).
 
 ### RUNTIME CONFIGURATION
 
@@ -150,7 +155,8 @@ void close_call_back(int fd) {
 
 ### SEE ALSO
 
-    external_create(3), external_run(3), external_write(3),
+    external_create(3), external_run(3), external_kill(3),
+    external_write(3),
     external_close_stdin(3),
     external_stdout(3), external_stderr(3),
     external_exit_code(3), external_close(3), socket_write(3),

--- a/docs/efun/promises/promise_reject.md
+++ b/docs/efun/promises/promise_reject.md
@@ -38,7 +38,9 @@ title: promises / promise_reject
     a pre-settled async_read(3) promise discards the file contents, and a
     pre-resolved one turns a read failure into an apparent success. Settle a
     promise you did not create only when you mean to stop caring about its
-    result.
+    result. Exception: rejecting an `external_start` / `external_run`
+    promise also kills the child process. To stop a handle and still
+    read the result, use `external_kill(handle)` instead.
 
     A rejected promise whose rejection is never observed (no handler
     attached, result never read) is reported to the debug log when it is

--- a/docs/sidebars.generated.json
+++ b/docs/sidebars.generated.json
@@ -799,6 +799,12 @@
           },
           {
             "type": "doc",
+            "id": "efun/external/external_kill",
+            "key": "efun/external/external_kill",
+            "label": "external_kill"
+          },
+          {
+            "type": "doc",
             "id": "efun/external/external_run",
             "key": "efun/external/external_run",
             "label": "external_run"

--- a/src/packages/external/external.cc
+++ b/src/packages/external/external.cc
@@ -257,7 +257,8 @@ void kill_handle_child(ExternalHandle* h) {
   }
 #else
   if (h->pi.hProcess) {
-    TerminateProcess(h->pi.hProcess, 1);
+    /* 143 == 128 + SIGTERM so Win32 reports the same wait status as POSIX. */
+    TerminateProcess(h->pi.hProcess, 143);
   }
 #endif
 }
@@ -1255,6 +1256,19 @@ void f_external_stderr() {
 void f_external_exit_code() {
   ExternalHandle* h = lookup_handle(static_cast<int>(sp->u.number), /*require_owner=*/1);
   sp->u.number = h->exit_code;
+}
+#endif
+
+#ifdef F_EXTERNAL_KILL
+void f_external_kill() {
+  int const id = static_cast<int>(sp->u.number);
+  ExternalHandle* h = lookup_handle(id, /*require_owner=*/1);
+  if (h->state != HandleState::Running) {
+    sp->u.number = 0;
+    return;
+  }
+  kill_handle_child(h);
+  sp->u.number = 1;
 }
 #endif
 

--- a/src/packages/external/external.cc
+++ b/src/packages/external/external.cc
@@ -247,6 +247,50 @@ void push_external_result(const std::string& out, const std::string& err, LPC_IN
   push_refed_array(arr);
 }
 
+void kill_handle_child(ExternalHandle* h) {
+  if (h->state != HandleState::Running) {
+    return;
+  }
+#ifndef _WIN32
+  if (h->pid > 0) {
+    kill(h->pid, SIGTERM);
+  }
+#else
+  if (h->pi.hProcess) {
+    TerminateProcess(h->pi.hProcess, 1);
+  }
+#endif
+}
+
+/* promise_reject() / last-ref drop: stop the child. The promise is already
+ * settling or dying -- do not settle it again. Pipes stay armed so a
+ * non-ephemeral handle can still collect leftover output + the wait status. */
+void on_external_cancel(void* data) {
+  int const id = static_cast<int>(reinterpret_cast<intptr_t>(data));
+  if (id < 1 || id > static_cast<int>(g_handles.size()) || !g_handles[id - 1]) {
+    return;
+  }
+  ExternalHandle* h = g_handles[id - 1];
+  promise_t* p = h->prom;
+  h->prom = nullptr;
+  kill_handle_child(h);
+  /* Drop the driver ref. Safe during dealloc (ref already 0) and during
+   * promise_settle(reject): LPC still holds the caller's ref. */
+  if (p) {
+    free_promise(p);
+  }
+}
+
+void attach_start_promise(ExternalHandle* h, int id, promise_t* p) {
+  /* Driver-owned ref keeps the promise alive across `await external_run()`
+   * / `await external_start()` (the temporary is consumed when await
+   * parks). Reject still cancels. */
+  h->prom = p;
+  p->ref++;
+  promise_set_cancel_handler(p, on_external_cancel,
+                             reinterpret_cast<void*>(static_cast<intptr_t>(id)));
+}
+
 void fulfill_handle_promise(int id) {
   ExternalHandle* h = g_handles[id - 1];
   if (!h->prom) {
@@ -258,6 +302,7 @@ void fulfill_handle_promise(int id) {
   }
   promise_t* p = h->prom;
   h->prom = nullptr;
+  promise_clear_cancel_handler(p);
   push_external_result(h->out, h->err, h->exit_code);
   promise_settle(p, sp, 0);
   pop_stack();
@@ -289,24 +334,22 @@ void abort_handle(int id, int kill_child) {
     return;
   }
   ExternalHandle* h = g_handles[id - 1];
-  if (h->state == HandleState::Running && kill_child) {
-#ifndef _WIN32
-    if (h->pid > 0) {
-      kill(h->pid, SIGTERM);
-    }
-#else
-    if (h->pi.hProcess) {
-      TerminateProcess(h->pi.hProcess, 1);
-    }
-#endif
+  if (kill_child) {
+    kill_handle_child(h);
   }
   free_pipe_events(h);
   if (h->prom) {
-    push_constant_string("*external process aborted");
-    promise_settle(h->prom, sp, 1);
-    pop_stack();
-    free_promise(h->prom);
+    promise_t* p = h->prom;
     h->prom = nullptr;
+    /* Clear first: settle(reject) would otherwise fire the cancel handler
+     * and free_promise a second time. */
+    promise_clear_cancel_handler(p);
+    if (p->state == PROMISE_PENDING) {
+      push_constant_string("*external process aborted");
+      promise_settle(p, sp, 1);
+      pop_stack();
+    }
+    free_promise(p);
   }
   h->state = HandleState::Done;
 }
@@ -814,8 +857,7 @@ promise_t* start_created_handle(ExternalHandle* h, int id) {
     return p;
   }
   h->state = HandleState::Running;
-  h->prom = p;
-  p->ref++;
+  attach_start_promise(h, id, p);
   return p;
 }
 
@@ -1116,8 +1158,7 @@ void f_external_run() {
     return;
   }
   h->state = HandleState::Running;
-  h->prom = p;
-  p->ref++;
+  attach_start_promise(h, id, p);
   pop_n_elems(num_arg);
   push_refed_promise(p);
 }

--- a/src/packages/external/external.spec
+++ b/src/packages/external/external.spec
@@ -19,4 +19,5 @@ string external_stderr(int);
 int external_exit_code(int);
 int external_write(int, string);
 void external_close_stdin(int);
+int external_kill(int);
 void external_close(int);

--- a/src/vm/internal/base/promise.cc
+++ b/src/vm/internal/base/promise.cc
@@ -1250,7 +1250,29 @@ promise_t* promise_alloc() {
   p->result = const0;
   p->reactions = nullptr;
   p->reject_origin = nullptr;
+  p->on_cancel = nullptr;
+  p->cancel_data = nullptr;
   return p;
+}
+
+void promise_set_cancel_handler(promise_t* p, void (*fn)(void*), void* data) {
+  p->on_cancel = fn;
+  p->cancel_data = data;
+}
+
+void promise_clear_cancel_handler(promise_t* p) {
+  p->on_cancel = nullptr;
+  p->cancel_data = nullptr;
+}
+
+static void fire_cancel_handler(promise_t* p) {
+  void (*fn)(void*) = p->on_cancel;
+  void* data = p->cancel_data;
+  p->on_cancel = nullptr;
+  p->cancel_data = nullptr;
+  if (fn) {
+    fn(data);
+  }
 }
 
 /* "/obj/name:42" for the currently executing LPC, or null if there is none
@@ -1286,6 +1308,9 @@ void free_promise(promise_t* p) {
 }
 
 void dealloc_promise(promise_t* p) {
+  if (p->state == PROMISE_PENDING) {
+    fire_cancel_handler(p);
+  }
   if (p->state == PROMISE_REJECTED && !p->handled) {
     /* Where it was rejected. Without this the report is a bare reason with no
      * object, function or line -- and it is printed at DEALLOCATION, which
@@ -1393,6 +1418,11 @@ int promise_settle(promise_t* p, svalue_t* value, int rejected) {
   }
   if (rejected && p->reject_origin == nullptr) {
     p->reject_origin = capture_reject_origin();
+  }
+  if (rejected) {
+    fire_cancel_handler(p);
+  } else {
+    promise_clear_cancel_handler(p);
   }
   p->state = rejected ? PROMISE_REJECTED : PROMISE_FULFILLED;
   assign_svalue(&p->result, value);

--- a/src/vm/internal/base/promise.h
+++ b/src/vm/internal/base/promise.h
@@ -87,7 +87,17 @@ struct promise_t {
    * failure is the one worth naming. Only rejections pay for it -- a fulfilled
    * promise never allocates this. Malloced (FREE_MSTR), null if unknown. */
   char* reject_origin;
+  /* Optional: notified once if this promise is rejected, or deallocated
+   * while still pending. Efuns that own external work (a child process,
+   * a timer) use it to stop that work when the caller cancels via
+   * promise_reject(). Not called on fulfillment. Cleared before the
+   * efun's own settle so it does not re-enter. */
+  void (*on_cancel)(void* data);
+  void* cancel_data;
 };
+
+void promise_set_cancel_handler(promise_t* p, void (*fn)(void*), void* data);
+void promise_clear_cancel_handler(promise_t* p);
 
 promise_t* promise_alloc();
 void free_promise(promise_t* p);

--- a/testsuite/etc/config.test
+++ b/testsuite/etc/config.test
@@ -367,8 +367,11 @@ external_cmd_6 : c:\Windows\System32\cmd.exe
 # false: non-zero exit for the promise-form return-code check
 external_cmd_7 : /bin/false
 external_cmd_8 : /usr/bin/false
+# sleep: cancel-the-promise-kills-the-child (external_promise.lpc)
+external_cmd_9 : /bin/sleep
+external_cmd_10 : /usr/bin/sleep
 # cat: stdin echo for the promise-form write path. Slot 6 (cmd.exe) uses
-# `findstr ^` in the test. Slots 9-10 are reserved on the cancel branch.
+# `findstr ^` in the test.
 external_cmd_11 : /bin/cat
 external_cmd_12 : /usr/bin/cat
 

--- a/testsuite/single/tests/efuns/external_promise.lpc
+++ b/testsuite/single/tests/efuns/external_promise.lpc
@@ -195,12 +195,12 @@ async void run_stdin() {
 }
 
 async void run_cancel() {
-  mixed p, err, h;
+  mixed p, err, h, r;
   int i, slot;
   mixed *slots = ({ 9, 10, 6 });
 
-  // promise_reject() is cancel: the child must die (SIGTERM / TerminateProcess)
-  // rather than run out its sleep. First settle wins, so status is rejected.
+  // Omit-callback: promise_reject() kills (no handle to hang kill on).
+  // Handle: external_kill() stops the child; the run promise still fulfills.
   for (i = 0; i < sizeof(slots); i++) {
     slot = slots[i];
     err = catch(p = external_start(slot, sleep_args(slot)));
@@ -216,12 +216,15 @@ async void run_cancel() {
 
     err = catch(h = external_create(slot, sleep_args(slot)));
     if (!err && intp(h) && h > 0) {
+      ASSERT_EQ(0, external_kill(h));
       err = catch(p = external_run(h));
       if (!err && typeof(p) == "promise") {
-        promise_catch(p, (: 0 :));
-        promise_reject(p, "stop");
-        ASSERT_EQ(2, promise_status(p));
-        // Waitpid after SIGTERM should record a status well before sleep 20.
+        ASSERT_EQ(1, external_kill(h));
+        err = acatch { r = await p; };
+        if (!err) {
+          ASSERT(arrayp(r) && sizeof(r) == 3);
+          ASSERT(r[2] != 0);
+        }
         await call_out(1);
         ASSERT(external_exit_code(h) != -1);
       }

--- a/testsuite/single/tests/efuns/external_promise.lpc
+++ b/testsuite/single/tests/efuns/external_promise.lpc
@@ -21,6 +21,14 @@ void classic_close(int fd) {
   }
 }
 
+mixed *sleep_args(int slot) {
+  // Long-running child so cancel has something to kill. Slot 6 is cmd.exe.
+  if (slot == 6) {
+    return ({ "/c", "ping", "-n", "20", "127.0.0.1" });
+  }
+  return ({ "20" });
+}
+
 mixed *echo_args(int slot) {
   // Slot 6 is Windows cmd.exe (see etc/config.test). Unix echo takes the
   // payload as argv; cmd.exe needs /c echo.
@@ -186,6 +194,44 @@ async void run_stdin() {
   }
 }
 
+async void run_cancel() {
+  mixed p, err, h;
+  int i, slot;
+  mixed *slots = ({ 9, 10, 6 });
+
+  // promise_reject() is cancel: the child must die (SIGTERM / TerminateProcess)
+  // rather than run out its sleep. First settle wins, so status is rejected.
+  for (i = 0; i < sizeof(slots); i++) {
+    slot = slots[i];
+    err = catch(p = external_start(slot, sleep_args(slot)));
+    if (err || typeof(p) != "promise") {
+      continue;
+    }
+    promise_catch(p, (: 0 :));
+    err = catch(promise_reject(p, "stop"));
+    if (err) {
+      continue;
+    }
+    ASSERT_EQ(2, promise_status(p));
+
+    err = catch(h = external_create(slot, sleep_args(slot)));
+    if (!err && intp(h) && h > 0) {
+      err = catch(p = external_run(h));
+      if (!err && typeof(p) == "promise") {
+        promise_catch(p, (: 0 :));
+        promise_reject(p, "stop");
+        ASSERT_EQ(2, promise_status(p));
+        // Waitpid after SIGTERM should record a status well before sleep 20.
+        await call_out(1);
+        ASSERT(external_exit_code(h) != -1);
+      }
+      external_close(h);
+    }
+    RELEASE_LATCH("external_start cancel kills");
+    return;
+  }
+}
+
 void do_tests() {
   mixed p, err, h;
   int slot, fd;
@@ -276,6 +322,7 @@ void do_tests() {
   EXPECT_LATCH("external_start promise form");
   EXPECT_LATCH("external_create handle");
   EXPECT_LATCH("external_start stdin");
+  EXPECT_LATCH("external_start cancel kills");
 
   // Classic form: int fd, required callbacks. Must compile as an int
   // assignment (the master return type) and must not throw on a live slot.
@@ -295,6 +342,7 @@ void do_tests() {
   call_out(function() { run_omit_callback(); }, 1);
   call_out(function() { run_handle(); }, 1);
   call_out(function() { run_stdin(); }, 1);
+  call_out(function() { run_cancel(); }, 1);
 }
 #else
 void do_tests() { ASSERT(1); }


### PR DESCRIPTION
Stacked on #1377. `promise_reject()` of an `external_start` promise sends `SIGTERM` (Win32: `TerminateProcess`) so a cancelled command does not keep running.

The driver still holds a ref on the start promise, so `await external_start(...)` does not treat the parked temporary as cancel. `external_close()` and owner destruct already killed the child; this adds the same for an explicit reject.

First settle wins: the promise stays rejected with the given reason.