### PR TITLE
compiler: normalize master-supplied include directories

### DIFF
--- a/src/compiler/internal/lexer_utils.cc
+++ b/src/compiler/internal/lexer_utils.cc
@@ -2214,7 +2214,12 @@ void init_include_path() {
           current_file, elem);
       return;
     }
-    path.emplace_back(elem);
+    /* Store what set_inc_list() stores: a root-relative directory with no
+     * leading slash. The mudlib may legitimately spell an absolute directory
+     * ("/std/object/include"), but keeping that slash here made every name
+     * built from it come back out of add_slash() doubled ("//std/..."), which
+     * include_list() then handed to LPC as a path stat() cannot open. */
+    path.emplace_back(check);
   }
   inc_path = std::move(path);
 }
@@ -2246,7 +2251,12 @@ std::pair<int, std::string> inc_open(std::string_view name, bool check_local) {
   for (const auto& path : inc_path) {
     buf.clear();
     buf.append(path);
-    buf += '/';
+    /* A mudlib that spells its include dirs with a trailing slash
+     * ("/std/object/include/") is not an error; joining blindly just made
+     * "/std/object/include//header.h". */
+    if (!buf.empty() && buf.back() != '/') {
+      buf += '/';
+    }
     buf.append(name);
     const char* tmp = check_valid_path(buf.c_str(), master_ob, "include", 0);
     if (tmp) {

--- a/testsuite/clone/mgip5.lpc
+++ b/testsuite/clone/mgip5.lpc
@@ -1,0 +1,5 @@
+/* Include path supplied by master::get_include_path() with a trailing
+ * slash -- the join must not double the separator. */
+#include <m_gip_test.h>
+
+void create() {}

--- a/testsuite/single/master.lpc
+++ b/testsuite/single/master.lpc
@@ -521,6 +521,11 @@ mixed get_include_path(string file) {
     case "/clone/mgip4.c":
     case "/clone/mgip4.lpc":
       return ({});          // should yield error message
+    case "/clone/mgip5":
+    case "/clone/mgip5.c":
+    case "/clone/mgip5.lpc":
+      // Trailing slash: a legal way to spell a directory.
+      return ({ "/include/m_gip1/", "/include" });
     default:
       return ({ ":DEFAULT:" }); ;
   }

--- a/testsuite/single/tests/compiler/get_include_path.lpc
+++ b/testsuite/single/tests/compiler/get_include_path.lpc
@@ -12,4 +12,7 @@ void do_tests() {
 
   ob = load_object("/clone/mgip4");
   ASSERT_EQ(3, ob->doit());
+
+  ob = load_object("/clone/mgip5");
+  ASSERT_EQ(1, ob->doit());
 }

--- a/testsuite/single/tests/efuns/include_list.lpc
+++ b/testsuite/single/tests/efuns/include_list.lpc
@@ -22,4 +22,25 @@ void do_tests() {
   ASSERT_EQ(({ "/include/globals.h", "/include/tests.h",
     "/clone/include_list_a.h", "/clone/include_list_nest.h",
     "/clone/include_list_b.h" }), l);
+
+  // Every reported name is a path that can actually be opened: exactly one
+  // leading slash and no doubled separators, however the mudlib spelled the
+  // directory it came from. A master-supplied include path used to be stored
+  // with its leading slash (unlike a configured one), and the search-path
+  // join added a separator unconditionally, so a header found through
+  // master::get_include_path() came back as "//include/m_gip1/m_gip_test.h"
+  // -- or "//include/m_gip1//m_gip_test.h" when the directory was spelled
+  // with a trailing slash. stat() opens neither.
+  ob = load_object("/clone/mgip1");
+  l = include_list(ob);
+  ASSERT(member_array("/include/m_gip1/m_gip_test.h", l) != -1);
+
+  ob = load_object("/clone/mgip5");
+  l = include_list(ob);
+  ASSERT(member_array("/include/m_gip1/m_gip_test.h", l) != -1);
+
+  foreach (string f in l) {
+    ASSERT_EQ('/', f[0]);
+    ASSERT(strsrch(f, "//") == -1);
+  }
 }


### PR DESCRIPTION
### The problem

`master::get_include_path()` is [documented](docs/apply/master/get_include_path.md) to return "the absolute path to the desired include directories", and the apply's own example returns `({ "/Domain/" + t[2] + "/include", ":DEFAULT:" })` — with a leading slash.

`init_include_path()` validates such an element with the leading slash skipped:

```cpp
const char* check = (elem[0] == '/') ? &elem[1] : elem;
if (!legal_path(check)) { ... }
path.emplace_back(elem);   // ...then stores the slash anyway
```

but stores `elem` verbatim. `set_inc_list()`, handling the `include directories` config option, does the opposite — it strips the leading slash and stores the directory root-relative. So the two sources of include directories disagree about what an `inc_path` entry looks like, and `add_slash()` (which prepends unconditionally) is only correct for one of them.

The result: a header found through a master-supplied directory is recorded with a doubled leading slash.

### Why it matters now

Nothing noticed while those names only surfaced in tracebacks, where a `//` is cosmetic. `include_list()` (#1356, #1375) now hands them to LPC, and there they are load-bearing — the efun's stated purpose is that "mudlibs that rebuild only changed objects can walk `include_list(ob)` to see which headers would force `ob` to recompile". Observed on a mudlib doing exactly that:

```lpc
include_list(find_object("/std/object/cooldown.lpc"));
// ({ "/include/global.h", ..., "//std/object/include//cooldown.h" })

stat("//std/object/include//cooldown.h");   // 0
stat("/std/object/include/cooldown.h");     // ({ 383, 1741925521, 0, 1773355649 })
```

The consumer cannot stat the header it was just told about, so a selective-recompile pass treats every such file as permanently stale.

The second `//` is a separate contributor: the mudlib spelled the directory `/std/object/include/`, and `inc_open()` appends its separator unconditionally.

### The change

- `init_include_path()` stores `check` — the same root-relative form `set_inc_list()` already stores. This is the actual fix, and it makes the two entry points agree.
- `inc_open()` skips the separator when the directory already ends in one. A trailing slash is a legal way to spell a directory and is not covered by the apply's documentation either way; this is defensive rather than a contract violation, and it also covers a configured `include directories : /` (which normalizes to an empty entry).

Neither changes any path that was already well-formed: paths are only ever built from the collapsed form, and `add_slash()` stays as-is.

### Tests

`tests/efuns/include_list.lpc` now covers both spellings — the existing `/clone/mgip1` fixture for the leading slash, and a new `/clone/mgip5` for the trailing one — plus a general shape assertion (one leading slash, no doubled separator) over every reported name.

Verified the test earns its place: with the `lexer_utils.cc` change reverted, it fails on exactly those checks and nothing else moves.

```
][ RUN      ] /single/tests/efuns/include_list.lpc
]*/single/tests/efuns/include_list.lpc:36, Check failed.
]*/single/tests/efuns/include_list.lpc:40, Check failed.
]*/single/tests/efuns/include_list.lpc:44, Check failed.  (x3)
][  FAILED  ] /single/tests/efuns/include_list.lpc
][==========] 12005 checks from 724 file(s) ran.
][  FAILED  ] 1 file(s), 5 failed check(s)
```

With the fix: `ctest -L testsuite` passes, `ctest -LE testsuite` passes 439/439, and `testsuite/format.sh --check` reports 950 unchanged.

Note that `tests/compiler/get_include_path.lpc` passes either way — the doubled path still *opens*, since POSIX collapses `//`. Only the reported name was wrong, which is why this went unseen until an efun exposed it. That test gains the `mgip5` case anyway, to pin the trailing-slash spelling as supported.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xo97GF7nG5nTVpLCkWU756