### PR TITLE
docs: promise_reject default reason and indirect self-resolve (#1387, #1388)

### DIFF
--- a/docs/efun/promises/promise_reject.md
+++ b/docs/efun/promises/promise_reject.md
@@ -11,11 +11,19 @@ title: promises / promise_reject
     void promise_reject(promise p, mixed reason);
 
 ### DESCRIPTION
-    Rejects the pending promise `p` with `reason` (0 if omitted). Rejection
+    Rejects the pending promise `p` with `reason`. Omitting `reason` does
+    not reject with `0` — the driver substitutes `PROMISE_REASON_NO_REASON`
+    (`"*promise rejected"`), so that a bare reject is never falsy: `acatch`
+    signals failure by yielding the reason and success by yielding `0`, so
+    a falsy reason would read as success. An explicitly falsy reason
+    (`promise_reject(p, 0)`) is still the caller's choice, and still
+    ambiguous — `promise_status()` is the unambiguous test. Rejection
     handlers attached with promise_then(3)/promise_catch(3) run from the
     microtask drain — never synchronously from this call, but still within
     the same gametick. An `await` suspended on `p` raises `reason` as an
     error at the await point (catchable with `acatch`).
+
+    It is an error to reject a promise with itself (`promise_reject(p, p)`).
 
     It is an error to settle a promise that is already settled — including
     one whose fate is already committed to a pending adoption (see

--- a/docs/efun/promises/promise_resolve.md
+++ b/docs/efun/promises/promise_resolve.md
@@ -19,7 +19,12 @@ title: promises / promise_resolve
     If `value` is itself a promise, `p` adopts its eventual state instead
     of fulfilling immediately (flattening): `p` stays pending until `value`
     settles, then settles the same way. Resolving a promise with itself is
-    an error.
+    an error when the cycle is a direct `promise_resolve(p, p)` — that
+    call errors before anything is allocated. When the cycle arrives
+    indirectly — a `promise_then()` handler returning the very promise its
+    result settles, or an `async` body returning its own promise — there
+    is no call to fail, and `p` rejects with `PROMISE_REASON_SELF_RESOLVED`
+    (`"*promise resolved with itself"`) instead.
 
     It is an error to settle a promise that is already settled — including
     one whose fate is already committed to a pending adoption: after

--- a/testsuite/single/tests/efuns/promise_reject_default.lpc
+++ b/testsuite/single/tests/efuns/promise_reject_default.lpc
@@ -22,6 +22,8 @@
 // files happened to hold latches that deferred the recap past the drain.
 // The shutdown(-1) guard never fired either, for the same reason.
 
+nosave promise src, chained;
+
 async void probe() {
   mixed p = promise_create();
   mixed err;
@@ -31,7 +33,22 @@ async void probe() {
   ASSERT2(err, "a bare promise_reject() must reject with a TRUTHY reason, "
     "or acatch() cannot tell it from success");
   ASSERT_EQ("string", typeof(err));
+  // The substituted reason is PROMISE_REASON_NO_REASON (issue #1387).
+  ASSERT_EQ("*promise rejected", err);
   RELEASE_LATCH("bare reject is truthy");
+}
+
+// Indirect self-resolve: a then-handler returning the chained promise
+// itself. promise_resolve(p, p) errors; this path rejects instead (#1388).
+async void probe_self() {
+  mixed err;
+
+  src = promise_create();
+  chained = promise_then(src, (: chained :));
+  promise_resolve(src, 1);
+  err = acatch(await chained);
+  ASSERT_EQ("*promise resolved with itself", err);
+  RELEASE_LATCH("indirect self-resolve rejects");
 }
 
 void do_tests() {
@@ -43,5 +60,7 @@ void do_tests() {
   ASSERT_EQ("explicit reason", promise_result(p2));
 
   EXPECT_LATCH("bare reject is truthy");
+  EXPECT_LATCH("indirect self-resolve rejects");
   probe();
+  probe_self();
 }


### PR DESCRIPTION
## Summary

- `promise_reject(p)` does not reject with `0`. The driver substitutes `PROMISE_REASON_NO_REASON` (`"*promise rejected"`) so a bare reject is never falsy under `acatch`. Document that, and that `promise_reject(p, p)` errors.
- `promise_resolve(p, p)` errors. An indirect cycle (a `promise_then()` handler or `async` body returning its own promise) rejects with `PROMISE_REASON_SELF_RESOLVED` (`"*promise resolved with itself"`) instead.

Fixes #1387. Fixes #1388.

## Test plan

- [x] Pin `*promise rejected` and the indirect self-resolve reject string in `promise_reject_default.lpc`
- [x] `driver etc/config.test -ftest:single/tests/efuns/promise_reject_default.lpc` (Debug + Rel)