### PR TITLE
compiler: keep total_lines across compile_file() (#1385)

### DIFF
--- a/src/compiler/internal/compiler.cc
+++ b/src/compiler/internal/compiler.cc
@@ -2933,7 +2933,10 @@ program_t* compile_file(std::string_view source, const char* name, vm_context_t*
   int saved_current_line = current_line;
   int saved_current_line_base = current_line_base;
   int saved_current_line_saved = current_line_saved;
-  int saved_total_lines = total_lines;
+  // total_lines is a process-wide compile statistic for
+  // query_load_average()'s "comp lines/s", not per-file state. Nested
+  // compile_file() (inherit) and this DEFER must leave it accumulated;
+  // restoring it here zeroed every load after the Flex migration (#1385).
   const char* saved_current_file = current_file;
   int saved_current_file_id = current_file_id;
   int saved_pragmas = pragmas;
@@ -3039,7 +3042,6 @@ program_t* compile_file(std::string_view source, const char* name, vm_context_t*
       current_line = saved_current_line;
       current_line_base = saved_current_line_base;
       current_line_saved = saved_current_line_saved;
-      total_lines = saved_total_lines;
       current_file = saved_current_file;
       current_file_id = saved_current_file_id;
       pragmas = saved_pragmas;

--- a/src/tests/test_compiler.cc
+++ b/src/tests/test_compiler.cc
@@ -2816,6 +2816,24 @@ TEST(CompileEntry, CompileFileFdSuccess) {
   deallocate_program(prog);
 }
 
+// compile_file() used to restore total_lines to its pre-call value on the
+// way out, so load_object()'s update_compile_av(total_lines) always saw 0
+// (issue #1385). Ordinary source newlines go through lpc_lex_newline();
+// the statistic must survive the compile's DEFER.
+TEST(CompileEntry, TotalLinesAccumulatesOrdinarySource) {
+  ensure_compile_env();
+  int const before = total_lines;
+  program_t* prog = compile_file(
+      "int a;\n"
+      "int b;\n"
+      "int c;\n"
+      "int f() { return 1; }\n",
+      "/total_lines_probe");
+  ASSERT_NE(prog, nullptr);
+  EXPECT_GE(total_lines - before, 4);
+  deallocate_program(prog);
+}
+
 TEST(CompileEntry, CompileFileFdBadFdThenViewStillWorks) {
   ensure_compile_env();
   // A failing fd load must not poison the next compile (the fd flag is


### PR DESCRIPTION
## Summary

`query_load_average()` has reported `0.00 comp lines/s` since the Flex migration because `compile_file()` restored `total_lines` to its pre-call value on every exit. `load_object()` then fed that zero to `update_compile_av()`.

`total_lines` is a process-wide compile statistic, not per-file lexer state. Leave it accumulated (including through nested inherit compiles). Ordinary source newlines already go through `lpc_lex_newline()`.

Fixes #1385.

## Test plan

- [x] GTest `CompileEntry.TotalLinesAccumulatesOrdinarySource`
- [x] Debug + RelWithDebInfo compile
- [x] `ctest -R CompileEntry.TotalLines` (Debug + Rel)