### PR TITLE
compiler: persist DECL_NOSAVE when a global shadows inherit (#1381)

### DIFF
--- a/docs/lpc/constructs/shadowing.md
+++ b/docs/lpc/constructs/shadowing.md
@@ -340,30 +340,17 @@ int a = 222;            // warning: Redeclaration of global variable 'a'.
 Your object now has **two** variables called `a`. Your code sees yours; the
 inherited object's code sees its own. So far so tolerable.
 
-Then you call `save_object()`, and the save file gets two lines with the same
-key — the inherited one first, yours second:
+Then you call `save_object()`. The compiler marks the shadowing declaration
+`nosave` so the save file has one line for that name — the inherited one:
 
 ```
 a 111
-a 222
 ```
 
-On `restore_object()`, both lines are matched by name, and name matching finds
-the *first* one — so both values land in the inherited variable, and the second
-line wins. The inherited `a` ends up holding *your* saved value, and your own
-`a` is never restored at all: it comes back **undefined**, not zero.
-
-That distinction matters when you go looking for the bug. An undefined int
-prints as `0` and compares equal to `0`, so nothing looks wrong until you test
-it properly:
-
-```c
-// after restore_object()
-a                  // 0     -- looks fine
-undefinedp(a)      // 1     -- it was never actually restored
-```
-
-Nothing errors. Nothing warns. The data is just quietly wrong from then on.
+`restore_object()` writes that value back into the inherited slot. Your own
+`a` is not saved and is not cleared: it keeps whatever it held at restore
+time. The two variables are still two slots; only the inherited one is
+persistent.
 
 If you inherit something and want a variable of your own, give it a different
 name. If you want the inherited one, use it — it's already there.
@@ -386,8 +373,8 @@ scarier.
 
 * Don't name a `function` variable or parameter after any existing function.
   It will not be callable.
-* Don't redeclare a variable your inherited object already declares. It breaks
-  `save_object` / `restore_object` silently.
+* Don't redeclare a variable your inherited object already declares. The
+  compiler will persist only the inherited one.
 * Do use `nomask` on things nobody should override. It turns a subtle bug into
   a compile error, which is a trade you want.
 * Do turn on `#pragma warnings` in objects that inherit from more than one

--- a/src/compiler/internal/compiler.cc
+++ b/src/compiler/internal/compiler.cc
@@ -1991,7 +1991,11 @@ int define_new_variable(const char* name, int type) {
   np = reinterpret_cast<const char**>(allocate_in_mem_block(A_VAR_NAME, sizeof(char*)));
   *np = name;
   tp = reinterpret_cast<lpc_type_t*>(allocate_in_mem_block(A_VAR_TYPE, sizeof(lpc_type_t)));
-  *tp = type;
+  // define_variable() may add DECL_NOSAVE when this name already exists
+  // (inherited or earlier in this file) so save_object() emits one key.
+  // That flag used to live only in A_VAR_TEMP and never reached
+  // prog->variable_types (#1381).
+  *tp = VAR_TEMP(n)->type;
   symbol_record(OP_SYMBOL_VAR, current_file, current_line, name);
   return n;
 }

--- a/testsuite/clone/save_shadow_child.lpc
+++ b/testsuite/clone/save_shadow_child.lpc
@@ -1,0 +1,12 @@
+// Fixture for /single/tests/efuns/save_object_shadow.lpc: shadows inherited
+// `a`. The compiler marks this declaration nosave so save_object() emits
+// one key (issue #1381).
+inherit "/clone/save_shadow_parent";
+int a = 222;
+int query_child_a() { return a; }
+void set_child_a(int v) { a = v; }
+int child_a_undef() { return undefinedp(a); }
+string do_save() { return save_object(0); }
+void save_to(string f) { save_object(f, 1); }
+void do_restore(string f) { restore_object(f); }
+void do_restore_str(string s) { restore_object(s); }

--- a/testsuite/clone/save_shadow_parent.lpc
+++ b/testsuite/clone/save_shadow_parent.lpc
@@ -1,0 +1,6 @@
+// Fixture for /single/tests/efuns/save_object_shadow.lpc: an inherited
+// global that the child redeclares under the same name.
+int a = 111;
+int query_parent_a() { return a; }
+void set_parent_a(int v) { a = v; }
+int parent_a_undef() { return undefinedp(a); }

--- a/testsuite/single/tests/efuns/save_object_shadow.lpc
+++ b/testsuite/single/tests/efuns/save_object_shadow.lpc
@@ -1,0 +1,39 @@
+// A global that shadows an inherited one used to be saved under the same
+// key as the inherited slot. restore_object() applied both lines to the
+// inherited variable and left the child's undefined (issue #1381).
+// The compiler marks the shadowing declaration nosave so only one key
+// is emitted.
+
+void do_tests() {
+  object ob, fresh;
+  string saved, expected;
+
+  ob = clone_object("/clone/save_shadow_child");
+  ASSERT(objectp(ob));
+  ASSERT_EQ(222, ob->query_child_a());
+  ASSERT_EQ(111, ob->query_parent_a());
+
+  saved = ob->do_save();
+  expected = "#/clone/save_shadow_child.lpc\na 111\n";
+  ASSERT_EQ(expected, saved);
+  // The child's value must not appear as a second `a` line.
+  ASSERT_EQ(-1, strsrch(saved, "a 222"));
+
+  ob->set_child_a(888);
+  ob->set_parent_a(999);
+  ob->save_to("/sf_shadow");
+
+  fresh = clone_object("/clone/save_shadow_child");
+  fresh->set_child_a(888);
+  fresh->set_parent_a(777);
+  fresh->do_restore("/sf_shadow");
+  // Inherited slot is restored; child's nosave slot is left as-is.
+  ASSERT_EQ(999, fresh->query_parent_a());
+  ASSERT_EQ(888, fresh->query_child_a());
+  ASSERT_EQ(0, fresh->parent_a_undef());
+  ASSERT_EQ(0, fresh->child_a_undef());
+
+  destruct(ob);
+  destruct(fresh);
+  rm("/sf_shadow.o");
+}


### PR DESCRIPTION
## Summary

`define_variable()` already marks a shadowing global `nosave` so `save_object()` emits one key. `define_new_variable()` then wrote the unmodified type into `A_VAR_TYPE`, so `prog->variable_types` never saw the flag. Restore applied both `a` lines to the inherited slot and left the child's undefined.

Store `VAR_TEMP(n)->type` (the effective type) into `A_VAR_TYPE`. Update the shadowing docs to match.

Fixes #1381.

## Test plan

- [x] Clone fixtures + `save_object_shadow.lpc` (one key, restore leaves child defined)
- [x] Debug + RelWithDebInfo compile
- [x] `driver etc/config.test -ftest:single/tests/efuns/save_object_shadow.lpc` (Debug + Rel)