### PR TITLE
fix: Coverity CID 1686645, 1686624, 1686623, 1686622

### DIFF
--- a/src/compiler/internal/icode.cc
+++ b/src/compiler/internal/icode.cc
@@ -416,7 +416,9 @@ void i_generate_node(parse_node_t* expr) {
           ins_byte(dest->l.number);
           break;
         }
-        if (dest && dest->kind == NODE_PARAMETER_LVALUE) {
+        /* dest was already used above; a null check here is REVERSE_INULL
+         * (Coverity CID 1686623). A well-formed assign always has a dest. */
+        if (dest->kind == NODE_PARAMETER_LVALUE) {
           i_generate_node(expr->l.expr);
           end_pushes();
           ins_byte(expr->v.number == F_ASSIGN ? F_ASSIGN_LOCAL : F_VOID_ASSIGN_LOCAL);

--- a/src/packages/external/external.cc
+++ b/src/packages/external/external.cc
@@ -698,9 +698,8 @@ int open_spawn_pipe(int p[2]) {
   if (pipe(p) != 0) {
     return -1;
   }
-  fcntl(p[0], F_SETFD, FD_CLOEXEC);
-  fcntl(p[1], F_SETFD, FD_CLOEXEC);
-  if (evutil_make_socket_nonblocking(p[0]) == -1) {
+  if (evutil_make_socket_closeonexec(p[0]) == -1 || evutil_make_socket_closeonexec(p[1]) == -1 ||
+      evutil_make_socket_nonblocking(p[0]) == -1) {
     close_pipe_pair(p);
     return -1;
   }
@@ -713,9 +712,8 @@ int open_stdin_pipe(int p[2]) {
   if (pipe(p) != 0) {
     return -1;
   }
-  fcntl(p[0], F_SETFD, FD_CLOEXEC);
-  fcntl(p[1], F_SETFD, FD_CLOEXEC);
-  if (evutil_make_socket_nonblocking(p[1]) == -1) {
+  if (evutil_make_socket_closeonexec(p[0]) == -1 || evutil_make_socket_closeonexec(p[1]) == -1 ||
+      evutil_make_socket_nonblocking(p[1]) == -1) {
     close_pipe_pair(p);
     return -1;
   }

--- a/src/vm/internal/base/promise.cc
+++ b/src/vm/internal/base/promise.cc
@@ -218,8 +218,18 @@ constexpr const char* kDestructedRejection = PROMISE_REASON_DESTRUCTED;
 /* What a cancelled body's next await raises, and what its promise settles
  * with as PROMISE_CANCELLED if nothing catches it. Matched by CONTENT for
  * the raise itself -- a plain string is forgeable by throw() -- but
- * promise_status() is the authoritative test from outside. */
-constexpr const char* kCancelledRejection = PROMISE_REASON_CANCELLED;
+ * promise_status() is the authoritative test from outside.
+ *
+ * Unique storage, not a pointer alias of the string literal: settle-time
+ * from_cancel is pointer identity against this object (a mudlib throw() of
+ * the same text must not stamp PROMISE_CANCELLED). Coverity CID 1686645
+ * flagged `== PROMISE_REASON_CANCELLED` as BAD_COMPARE because the old
+ * constexpr alias inlined to a literal. */
+static const char kCancelledRejection[] = PROMISE_REASON_CANCELLED;
+
+static bool is_driver_cancelled_reason(const svalue_t* v) {
+  return v->type == T_STRING && v->u.string == kCancelledRejection;
+}
 
 /* Cancelled is a negative settlement: await / then / combinators treat it
  * like a rejection, but promise_status() reports PROMISE_CANCELLED. */
@@ -945,8 +955,7 @@ bool run_coroutine_body(char* entry_pc, promise_t* p, control_stack_t* async_fra
 #endif
       /* Settle-time cancel: only the driver's constant pointer, never a
        * pre-stamped flag that would outlive a declined cancel. */
-      (void)promise_settle(p, &err, 1,
-                           err.type == T_STRING && err.u.string == kCancelledRejection);
+      (void)promise_settle(p, &err, 1, is_driver_cancelled_reason(&err));
       free_svalue(&err, "run_coroutine_body");
       too_deep_error = 0;
       if (max_eval_error) {


### PR DESCRIPTION
## Summary

Fixes the Coverity findings from the latest scan.

**CID 1686645 (BAD_COMPARE)** in `run_coroutine_body`: `err.u.string == kCancelledRejection` inlined to a compare against the string literal `"*async function cancelled"`. Settle-time `from_cancel` is **pointer identity** on purpose — a mudlib `throw()` of the same text must not stamp `PROMISE_CANCELLED`. Give the constant unique storage and compare through `is_driver_cancelled_reason()`.

**CID 1686624 / 1686622 (CHECKED_RETURN)** in `open_spawn_pipe` / `open_stdin_pipe`: `fcntl(..., F_SETFD, FD_CLOEXEC)` was unchecked. Use `evutil_make_socket_closeonexec()` (already used for nonblocking on the same fds) and fail the setup if CLOEXEC does not stick.

**CID 1686623 (REVERSE_INULL)** in `i_generate_node`: `IS_NODE(dest, ...)` already dereferences `dest`; the later `dest && dest->kind == NODE_PARAMETER_LVALUE` implied dest could be null. Drop the dead null check.

## Test plan

- [x] Debug + RelWithDebInfo compile
- [x] Full GTest (`ctest -LE testsuite`): Rel 440/440, Debug 441/441
- [x] Full LPC suite (`driver etc/config.test -ftest`): Debug 12212 checks from 725 files, `Checks succeeded.` Rel ran the same suite immediately before (same command, `set -e`)